### PR TITLE
Add Bible verse search helper

### DIFF
--- a/lib/services/bible_database_service.dart
+++ b/lib/services/bible_database_service.dart
@@ -14,6 +14,13 @@ class DatabaseService {
 
   final Map<String, Database> _databases = {};
 
+  String _escapeLikePattern(String input) {
+    return input.replaceAllMapped(
+      RegExp(r'([%_\\])'),
+      (match) => '\\${match[1]}',
+    );
+  }
+
   Future<Database> _getDatabase(String bibleId) async {
     if (_databases.containsKey(bibleId)) {
       return _databases[bibleId]!;
@@ -56,6 +63,28 @@ class DatabaseService {
       where: 'book = ? AND chapter = ?',
       whereArgs: [bookId, chapter],
     );
+    return List.generate(maps.length, (i) => Verse.fromMap(maps[i]));
+  }
+
+  Future<List<Verse>> searchVerses(
+    String bibleId,
+    String query, {
+    int? limit,
+  }) async {
+    if (query.trim().isEmpty) {
+      return [];
+    }
+
+    final db = await _getDatabase(bibleId);
+    final safeQuery = _escapeLikePattern(query.toLowerCase());
+    final List<Map<String, dynamic>> maps = await db.query(
+      'bible_verses',
+      where: "LOWER(text) LIKE ? ESCAPE '\\\\'",
+      whereArgs: ['%$safeQuery%'],
+      orderBy: 'book, chapter, verse',
+      limit: limit,
+    );
+
     return List.generate(maps.length, (i) => Verse.fromMap(maps[i]));
   }
 

--- a/lib/services/bible_service.dart
+++ b/lib/services/bible_service.dart
@@ -16,4 +16,8 @@ class BibleService {
   Future<List<Bible>> getBibleVersions() async {
     return _databaseService.getBibleVersions();
   }
+
+  Future<List<Verse>> searchVerses(String query, {int? limit}) {
+    return _databaseService.searchVerses(_defaultBibleId, query, limit: limit);
+  }
 }


### PR DESCRIPTION
## Summary
- add a LIKE-pattern escaping helper to the shared Bible database service
- implement a reusable `searchVerses` query with optional limits
- expose verse search through the higher-level BibleService API

## Testing
- not run (environment lacks Flutter/Dart SDK)


------
https://chatgpt.com/codex/tasks/task_e_68decafbd33083209f3b22899a53a4f6