### PR TITLE
Add translation-aware Bible service helpers

### DIFF
--- a/lib/services/bible_database_service.dart
+++ b/lib/services/bible_database_service.dart
@@ -66,7 +66,27 @@ class DatabaseService {
     return List.generate(maps.length, (i) => Verse.fromMap(maps[i]));
   }
 
-master
+  Future<Verse?> getVerse(
+    String bibleId,
+    int bookId,
+    int chapter,
+    int verseNumber,
+  ) async {
+    final db = await _getDatabase(bibleId);
+    final maps = await db.query(
+      'bible_verses',
+      where: 'book = ? AND chapter = ? AND verse = ?',
+      whereArgs: [bookId, chapter, verseNumber],
+      limit: 1,
+    );
+
+    if (maps.isEmpty) {
+      return null;
+    }
+
+    return Verse.fromMap(maps.first);
+  }
+
   Future<List<Verse>> searchVerses(
     String bibleId,
     String query, {

--- a/lib/services/bible_service.dart
+++ b/lib/services/bible_service.dart
@@ -5,8 +5,8 @@ class BibleService {
   final DatabaseService _databaseService = DatabaseService();
   static const String _defaultBibleId = 'kjv';
 
-  Future<String> _resolveBibleId(String translationId) async {
-    final normalized = translationId.trim().toLowerCase();
+  Future<String> _resolveBibleId([String? translationId]) async {
+    final normalized = (translationId ?? '').trim().toLowerCase();
     if (normalized.isEmpty) {
       return _defaultBibleId;
     }
@@ -32,20 +32,71 @@ class BibleService {
     return _defaultBibleId;
   }
 
-  Future<List<Book>> loadBooks() async {
-    return _databaseService.getBooks(_defaultBibleId);
+  Future<List<Book>> loadBooks({String? translationId}) async {
+    final bibleId = await _resolveBibleId(translationId);
+    return _databaseService.getBooks(bibleId);
   }
 
-  Future<List<Verse>> getVerses(int bookId, int chapter) async {
-    return _databaseService.getVerses(_defaultBibleId, bookId, chapter);
+  Future<List<Verse>> getVerses(
+    int bookId,
+    int chapter, {
+    String? translationId,
+  }) async {
+    final bibleId = await _resolveBibleId(translationId);
+    return _databaseService.getVerses(bibleId, bookId, chapter);
+  }
+
+  Future<Verse?> getVerse(
+    int bookId,
+    int chapter,
+    int verseNumber, {
+    String? translationId,
+  }) async {
+    final bibleId = await _resolveBibleId(translationId);
+    return _databaseService.getVerse(bibleId, bookId, chapter, verseNumber);
   }
 
   Future<List<Bible>> getBibleVersions() async {
     return _databaseService.getBibleVersions();
   }
 
-  Future<List<Verse>> searchVerses(String query, {int? limit}) {
-    return _databaseService.searchVerses(_defaultBibleId, query, limit: limit);
+  Future<Bible?> findBible(String translationId) async {
+    final normalized = translationId.trim().toLowerCase();
+    if (normalized.isEmpty) {
+      return null;
+    }
+
+    final availableBibles = await _databaseService.getBibleVersions();
+    for (final bible in availableBibles) {
+      final idLower = bible.id.toLowerCase();
+      if (idLower == normalized) {
+        return bible;
+      }
+
+      final nameLower = bible.name.toLowerCase();
+      if (nameLower == normalized) {
+        return bible;
+      }
+
+      final sanitizedName = nameLower.replaceAll(RegExp(r'\s+'), '_');
+      if (sanitizedName == normalized) {
+        return bible;
+      }
+    }
+
+    return null;
   }
-master
+
+  Future<bool> hasTranslation(String translationId) async {
+    return await findBible(translationId) != null;
+  }
+
+  Future<List<Verse>> searchVerses(
+    String query, {
+    String? translationId,
+    int? limit,
+  }) async {
+    final bibleId = await _resolveBibleId(translationId);
+    return _databaseService.searchVerses(bibleId, query, limit: limit);
+  }
 }


### PR DESCRIPTION
## Summary
- allow Bible service lookups to resolve different translation identifiers while defaulting to KJV when needed
- expose helpers for checking translation availability and fetching specific verses
- back database access with a focused query for retrieving a single verse

## Testing
- not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ded4c7c414832097f4e34c47a8c73f