### PR TITLE
feat: support bible translation imports

### DIFF
--- a/lib/src/data/bible/bible_repository_impl.dart
+++ b/lib/src/data/bible/bible_repository_impl.dart
@@ -1,3 +1,5 @@
+import 'package:drift/drift.dart';
+
 import '../../domain/bible/entities.dart';
 import '../../domain/bible/repositories.dart';
 import '../../infrastructure/db/app_database.dart';
@@ -101,5 +103,93 @@ class BibleRepositoryImpl implements BibleRepository {
           ),
         )
         .toList();
+  }
+
+  @override
+  Future<BibleTranslation?> findTranslationById(String id) async {
+    await _ensureSeeded();
+    final query = _db.select(_db.translations)
+      ..where((tbl) => tbl.id.equals(id))
+      ..limit(1);
+    final row = await query.getSingleOrNull();
+    if (row == null) {
+      return null;
+    }
+    return BibleTranslation(
+      id: row.id,
+      name: row.name,
+      language: row.language,
+      languageName: row.languageName,
+      version: row.version,
+      source: row.source,
+      copyright: row.copyright,
+      installedAt: DateTime.fromMillisecondsSinceEpoch(row.installedAt),
+    );
+  }
+
+  @override
+  Future<void> saveImportedTranslation(
+    BibleTranslation translation,
+    List<BibleVerse> verses, {
+    bool replaceExisting = false,
+  }) async {
+    await _ensureSeeded();
+
+    await _db.transaction(() async {
+      if (replaceExisting) {
+        await (_db.delete(_db.verses)
+              ..where((tbl) => tbl.translationId.equals(translation.id)))
+            .go();
+        await (_db.delete(_db.translations)
+              ..where((tbl) => tbl.id.equals(translation.id)))
+            .go();
+        await _db.dropSearchIndex(translation.id);
+      }
+
+      await _db.into(_db.translations).insert(
+            TranslationsCompanion.insert(
+              id: translation.id,
+              name: translation.name,
+              language: translation.language,
+              languageName: translation.languageName,
+              version: translation.version,
+              copyright: translation.copyright,
+              source: Value(translation.source),
+              installedAt:
+                  translation.installedAt.millisecondsSinceEpoch,
+            ),
+            mode: InsertMode.insertOrReplace,
+          );
+
+      if (verses.isEmpty) {
+        return;
+      }
+
+      const chunkSize = 500;
+      for (var start = 0; start < verses.length; start += chunkSize) {
+        final chunk = verses.skip(start).take(chunkSize).map(
+              (verse) => VersesCompanion.insert(
+                translationId: translation.id,
+                bookId: verse.bookId,
+                chapter: verse.chapter,
+                verse: verse.verse,
+                text: verse.text,
+              ),
+            );
+        await _db.batch((batch) {
+          batch.insertAll(
+            _db.verses,
+            chunk.toList(),
+            mode: InsertMode.insertOrReplace,
+          );
+        });
+      }
+    });
+  }
+
+  @override
+  Future<void> buildSearchIndex(String translationId) async {
+    await _ensureSeeded();
+    await _db.rebuildFtsFor(translationId);
   }
 }

--- a/lib/src/domain/bible/import/exceptions.dart
+++ b/lib/src/domain/bible/import/exceptions.dart
@@ -1,0 +1,58 @@
+import '../entities.dart';
+import 'manifest_schema.dart';
+
+class BibleImportException implements Exception {
+  BibleImportException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'BibleImportException: $message';
+}
+
+class MissingManifestException extends BibleImportException {
+  MissingManifestException()
+      : super('manifest.json was not found in the package.');
+}
+
+class InvalidManifestException extends BibleImportException {
+  InvalidManifestException(List<String> issues)
+      : _issues = List.unmodifiable(issues),
+        super('Invalid manifest: ${issues.join('; ')}');
+
+  final List<String> _issues;
+
+  List<String> get issues => _issues;
+}
+
+class MissingPackageFileException extends BibleImportException {
+  MissingPackageFileException(this.fileName)
+      : super('Package file `$fileName` was not found.');
+
+  final String fileName;
+}
+
+class ChecksumMismatchException extends BibleImportException {
+  ChecksumMismatchException({required this.expected, required this.actual})
+      : super(
+            'Package checksum mismatch. Expected $expected but computed $actual.');
+
+  final String expected;
+  final String actual;
+}
+
+class UnsupportedBiblePackageFormatException extends BibleImportException {
+  UnsupportedBiblePackageFormatException(String format)
+      : super('Unsupported package file format `$format`.');
+}
+
+class DuplicateTranslationException extends BibleImportException {
+  DuplicateTranslationException({
+    required this.existing,
+    required this.manifest,
+  }) : super(
+            'Translation `${manifest.id}` already exists and requires guidance for conflict resolution.');
+
+  final BibleTranslation existing;
+  final BiblePackageManifest manifest;
+}

--- a/lib/src/domain/bible/import/import_bible_package_usecase.dart
+++ b/lib/src/domain/bible/import/import_bible_package_usecase.dart
@@ -1,0 +1,329 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart' as crypto;
+import 'package:flutter_archive/flutter_archive.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+import '../entities.dart';
+import '../repositories.dart';
+import 'exceptions.dart';
+import 'import_models.dart';
+import 'manifest_schema.dart';
+import 'verse_record_validator.dart';
+
+class ImportBiblePackageUseCase {
+  ImportBiblePackageUseCase(this._repository);
+
+  final BibleRepository _repository;
+
+  Future<BibleTranslation> call({
+    required File packageFile,
+    ImportConflictResolution conflictResolution = ImportConflictResolution.prompt,
+    void Function(ImportProgress progress)? onProgress,
+  }) async {
+    _emit(
+      onProgress,
+      ImportProgress(
+        stage: ImportStage.preparing,
+        message: 'Preparing ${p.basename(packageFile.path)} for import',
+      ),
+    );
+
+    if (!await packageFile.exists()) {
+      throw BibleImportException('Package file not found at ${packageFile.path}.');
+    }
+
+    final tempDir = await Directory.systemTemp.createTemp('bible_package_');
+    try {
+      _emit(
+        onProgress,
+        ImportProgress(stage: ImportStage.extracting, message: 'Extracting package...'),
+      );
+      await ZipFile.extractToDirectory(
+        zipFile: packageFile,
+        destinationDir: tempDir,
+        allowWrite: true,
+      );
+
+      final manifestFile = File(p.join(tempDir.path, 'manifest.json'));
+      if (!await manifestFile.exists()) {
+        throw MissingManifestException();
+      }
+
+      _emit(
+        onProgress,
+        ImportProgress(stage: ImportStage.readingManifest, message: 'Reading manifest...'),
+      );
+      final manifestMap = _decodeJson(await manifestFile.readAsString());
+
+      _emit(
+        onProgress,
+        ImportProgress(stage: ImportStage.validatingManifest, message: 'Validating manifest...'),
+      );
+      final manifest = BiblePackageManifest.fromJson(manifestMap);
+
+      final existing = await _repository.findTranslationById(manifest.id);
+      if (existing != null) {
+        switch (conflictResolution) {
+          case ImportConflictResolution.prompt:
+            throw DuplicateTranslationException(existing: existing, manifest: manifest);
+          case ImportConflictResolution.skip:
+            return existing;
+          case ImportConflictResolution.replace:
+            break;
+        }
+      }
+
+      final payloadFile = _resolvePayloadFile(tempDir, manifest);
+
+      _emit(
+        onProgress,
+        ImportProgress(stage: ImportStage.verifyingChecksum, message: 'Verifying checksum...'),
+      );
+      final checksum = await _computeChecksum(payloadFile);
+      if (checksum.toLowerCase() != manifest.checksum.toLowerCase()) {
+        throw ChecksumMismatchException(expected: manifest.checksum, actual: checksum);
+      }
+
+      _emit(
+        onProgress,
+        ImportProgress(stage: ImportStage.parsingContent, message: 'Parsing verses...'),
+      );
+      final verses = await _parsePayload(
+        manifest: manifest,
+        file: payloadFile,
+        onProgress: onProgress,
+      );
+
+      final translation = BibleTranslation(
+        id: manifest.id,
+        name: manifest.name,
+        language: manifest.language,
+        languageName: _deriveLanguageName(manifest.language),
+        version: manifest.version,
+        source: manifest.source ?? 'imported',
+        copyright: manifest.source ?? '',
+        installedAt: DateTime.now(),
+      );
+
+      _emit(
+        onProgress,
+        ImportProgress(stage: ImportStage.writingMetadata, message: 'Registering translation metadata...'),
+      );
+      _emit(
+        onProgress,
+        ImportProgress(stage: ImportStage.writingVerses, message: 'Writing ${verses.length} verses...'),
+      );
+      await _repository.saveImportedTranslation(
+        translation,
+        verses,
+        replaceExisting: existing != null &&
+            conflictResolution == ImportConflictResolution.replace,
+      );
+
+      _emit(
+        onProgress,
+        ImportProgress(stage: ImportStage.buildingSearchIndex, message: 'Building search index...'),
+      );
+      await _repository.buildSearchIndex(translation.id);
+
+      _emit(
+        onProgress,
+        ImportProgress(stage: ImportStage.completed, message: 'Import completed.'),
+      );
+
+      return translation;
+    } on BibleImportException {
+      rethrow;
+    } catch (error) {
+      throw BibleImportException('Failed to import package: $error');
+    } finally {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    }
+  }
+
+  Map<String, dynamic> _decodeJson(String source) {
+    final dynamic decoded = jsonDecode(source);
+    if (decoded is Map<String, dynamic>) {
+      return decoded;
+    }
+    throw InvalidManifestException(['Manifest root must be a JSON object.']);
+  }
+
+  File _resolvePayloadFile(Directory directory, BiblePackageManifest manifest) {
+    final candidates = [
+      ...manifest.files,
+      if (manifest.fileFormat == BiblePackageFileFormat.jsonl) 'verses.jsonl',
+      if (manifest.fileFormat == BiblePackageFileFormat.sqlite) 'verses.sqlite',
+    ];
+
+    for (final candidate in candidates) {
+      if (candidate.trim().isEmpty) {
+        continue;
+      }
+      final file = File(p.join(directory.path, candidate));
+      if (file.existsSync()) {
+        return file;
+      }
+    }
+
+    final fallback = candidates.isNotEmpty
+        ? candidates.first
+        : manifest.fileFormat == BiblePackageFileFormat.jsonl
+            ? 'verses.jsonl'
+            : 'verses.sqlite';
+    throw MissingPackageFileException(fallback);
+  }
+
+  Future<String> _computeChecksum(File file) async {
+    final sink = crypto.AccumulatorSink<crypto.Digest>();
+    final input = crypto.sha256.startChunkedConversion(sink);
+    final stream = file.openRead();
+    await for (final chunk in stream) {
+      input.add(chunk);
+    }
+    input.close();
+    return sink.events.single.toString();
+  }
+
+  Future<List<BibleVerse>> _parsePayload({
+    required BiblePackageManifest manifest,
+    required File file,
+    void Function(ImportProgress progress)? onProgress,
+  }) async {
+    switch (manifest.fileFormat) {
+      case BiblePackageFileFormat.jsonl:
+        return _parseJsonLines(manifest, file, onProgress);
+      case BiblePackageFileFormat.sqlite:
+        return _parseSqlite(manifest, file, onProgress);
+    }
+  }
+
+  Future<List<BibleVerse>> _parseJsonLines(
+    BiblePackageManifest manifest,
+    File file,
+    void Function(ImportProgress progress)? onProgress,
+  ) async {
+    final verses = <BibleVerse>[];
+    var processed = 0;
+    final lines = file
+        .openRead()
+        .transform(utf8.decoder)
+        .transform(const LineSplitter());
+
+    await for (final line in lines) {
+      if (line.trim().isEmpty) {
+        continue;
+      }
+      Map<String, dynamic> record;
+      try {
+        record = jsonDecode(line) as Map<String, dynamic>;
+      } catch (error) {
+        throw BibleImportException('Failed to decode verse JSON: $error');
+      }
+      final issues = VerseRecordValidator.validate(record);
+      if (issues.isNotEmpty) {
+        throw BibleImportException(
+          'Invalid verse record at index $processed: ${issues.join('; ')}',
+        );
+      }
+      verses.add(
+        BibleVerse(
+          translationId: manifest.id,
+          bookId: record['bookId'] as int,
+          chapter: record['chapter'] as int,
+          verse: record['verse'] as int,
+          text: record['text'] as String,
+        ),
+      );
+      processed++;
+      if (processed % 1000 == 0) {
+        _emit(
+          onProgress,
+          ImportProgress(
+            stage: ImportStage.parsingContent,
+            message: 'Parsed $processed verses...',
+          ),
+        );
+      }
+    }
+
+    return verses;
+  }
+
+  Future<List<BibleVerse>> _parseSqlite(
+    BiblePackageManifest manifest,
+    File file,
+    void Function(ImportProgress progress)? onProgress,
+  ) async {
+    final database = sqlite.sqlite3.open(file.path);
+    try {
+      final result = database.select(
+        'SELECT book_id, chapter, verse, text FROM verses ORDER BY book_id, chapter, verse',
+      );
+      final verses = <BibleVerse>[];
+      var processed = 0;
+      for (final row in result) {
+        final bookId = (row['book_id'] ?? row['bookId']) as int?;
+        final chapter = row['chapter'] as int?;
+        final verse = row['verse'] as int?;
+        final text = row['text'] as String?;
+        if (bookId == null || chapter == null || verse == null || text == null) {
+          throw BibleImportException(
+            'SQLite package must provide book_id, chapter, verse and text columns.',
+          );
+        }
+        verses.add(
+          BibleVerse(
+            translationId: manifest.id,
+            bookId: bookId,
+            chapter: chapter,
+            verse: verse,
+            text: text,
+          ),
+        );
+        processed++;
+        if (processed % 1000 == 0) {
+          _emit(
+            onProgress,
+            ImportProgress(
+              stage: ImportStage.parsingContent,
+              message: 'Parsed $processed verses...',
+            ),
+          );
+        }
+      }
+      return verses;
+    } on sqlite.SqliteException catch (error) {
+      throw BibleImportException('Failed to read SQLite payload: ${error.message}');
+    } finally {
+      database.dispose();
+    }
+  }
+
+  void _emit(
+    void Function(ImportProgress progress)? onProgress,
+    ImportProgress progress,
+  ) {
+    if (onProgress != null) {
+      onProgress(progress);
+    }
+  }
+
+  String _deriveLanguageName(String language) {
+    if (language.trim().isEmpty) {
+      return language;
+    }
+    final segments = language.split(RegExp(r'[-_]'));
+    return segments
+        .where((segment) => segment.isNotEmpty)
+        .map(
+          (segment) => segment[0].toUpperCase() + segment.substring(1).toLowerCase(),
+        )
+        .join(' ');
+  }
+}

--- a/lib/src/domain/bible/import/import_models.dart
+++ b/lib/src/domain/bible/import/import_models.dart
@@ -1,0 +1,30 @@
+enum ImportStage {
+  preparing,
+  extracting,
+  readingManifest,
+  validatingManifest,
+  verifyingChecksum,
+  parsingContent,
+  writingMetadata,
+  writingVerses,
+  buildingSearchIndex,
+  completed,
+}
+
+enum ImportConflictResolution {
+  prompt,
+  replace,
+  skip,
+}
+
+class ImportProgress {
+  ImportProgress({
+    required this.stage,
+    this.progress,
+    this.message,
+  });
+
+  final ImportStage stage;
+  final double? progress;
+  final String? message;
+}

--- a/lib/src/domain/bible/import/manifest_schema.dart
+++ b/lib/src/domain/bible/import/manifest_schema.dart
@@ -1,0 +1,192 @@
+import 'exceptions.dart';
+
+/// Schema definition for Bible package manifests as specified in the
+/// blueprint (see §5.1).
+class BiblePackageManifest {
+  BiblePackageManifest({
+    required this.id,
+    required this.language,
+    required this.name,
+    required this.version,
+    required this.fileFormat,
+    required this.checksum,
+    this.source,
+    List<String>? files,
+  }) : files = List.unmodifiable(files ?? const []);
+
+  final String id;
+  final String language;
+  final String name;
+  final String version;
+  final BiblePackageFileFormat fileFormat;
+  final String checksum;
+  final String? source;
+  final List<String> files;
+
+  static const Map<String, dynamic> schema = {
+    r'$schema': 'http://json-schema.org/draft-07/schema#',
+    'title': 'BiblePackageManifest',
+    'type': 'object',
+    'required': ['id', 'language', 'name', 'version', 'fileFormat', 'checksum'],
+    'properties': {
+      'id': {
+        'type': 'string',
+        'pattern': r'^[a-z0-9_-]+$',
+      },
+      'language': {
+        'type': 'string',
+      },
+      'name': {
+        'type': 'string',
+      },
+      'version': {
+        'type': 'string',
+      },
+      'source': {
+        'type': 'string',
+      },
+      'fileFormat': {
+        'type': 'string',
+        'enum': ['jsonl', 'sqlite'],
+      },
+      'checksum': {
+        'type': 'string',
+      },
+      'files': {
+        'type': 'array',
+        'items': {
+          'type': 'string',
+        },
+      },
+    },
+  };
+
+  static BiblePackageManifest fromJson(Map<String, dynamic> json) {
+    final errors = BiblePackageManifestValidator.validate(json);
+    if (errors.isNotEmpty) {
+      throw InvalidManifestException(errors);
+    }
+    return BiblePackageManifest(
+      id: json['id'] as String,
+      language: json['language'] as String,
+      name: json['name'] as String,
+      version: json['version'] as String,
+      fileFormat: BiblePackageFileFormatX.fromJson(json['fileFormat'] as String),
+      checksum: json['checksum'] as String,
+      source: json['source'] as String?,
+      files: (json['files'] as List<dynamic>?)
+              ?.map((value) => value as String)
+              .toList() ??
+          const [],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'language': language,
+      'name': name,
+      'version': version,
+      'fileFormat': fileFormat.toJson(),
+      'checksum': checksum,
+      if (source != null) 'source': source,
+      if (files.isNotEmpty) 'files': files,
+    };
+  }
+}
+
+/// Supported payload types declared by the manifest.
+enum BiblePackageFileFormat { jsonl, sqlite }
+
+extension BiblePackageFileFormatX on BiblePackageFileFormat {
+  String toJson() {
+    switch (this) {
+      case BiblePackageFileFormat.jsonl:
+        return 'jsonl';
+      case BiblePackageFileFormat.sqlite:
+        return 'sqlite';
+    }
+  }
+
+  static BiblePackageFileFormat fromJson(String value) {
+    switch (value) {
+      case 'jsonl':
+        return BiblePackageFileFormat.jsonl;
+      case 'sqlite':
+        return BiblePackageFileFormat.sqlite;
+      default:
+        throw UnsupportedBiblePackageFormatException(value);
+    }
+  }
+}
+
+class BiblePackageManifestValidator {
+  static final RegExp _idPattern = RegExp(r'^[a-z0-9_-]+$');
+
+  static List<String> validate(Map<String, dynamic> json) {
+    final errors = <String>[];
+
+    void ensureRequired(String key) {
+      if (!json.containsKey(key) || json[key] == null) {
+        errors.add('Missing required property `$key`.');
+      }
+    }
+
+    for (final key
+        in ['id', 'language', 'name', 'version', 'fileFormat', 'checksum']) {
+      ensureRequired(key);
+    }
+
+    if (json['id'] is! String || (json['id'] as String).trim().isEmpty) {
+      errors.add('`id` must be a non-empty string.');
+    } else {
+      final id = (json['id'] as String).trim();
+      if (!_idPattern.hasMatch(id)) {
+        errors.add('`id` must match the pattern ^[a-z0-9_-]+$.');
+      }
+    }
+
+    if (json['language'] != null && json['language'] is! String) {
+      errors.add('`language` must be a string.');
+    }
+    if (json['name'] != null && json['name'] is! String) {
+      errors.add('`name` must be a string.');
+    }
+    if (json['version'] != null && json['version'] is! String) {
+      errors.add('`version` must be a string.');
+    }
+    if (json['source'] != null && json['source'] is! String) {
+      errors.add('`source` must be a string when provided.');
+    }
+    if (json['checksum'] != null && json['checksum'] is! String) {
+      errors.add('`checksum` must be a string.');
+    }
+
+    if (json['fileFormat'] != null) {
+      if (json['fileFormat'] is! String) {
+        errors.add('`fileFormat` must be a string.');
+      } else {
+        final value = json['fileFormat'] as String;
+        if (!['jsonl', 'sqlite'].contains(value)) {
+          errors.add('`fileFormat` must be one of: jsonl, sqlite.');
+        }
+      }
+    }
+
+    if (json['files'] != null) {
+      if (json['files'] is! List) {
+        errors.add('`files` must be an array of strings when provided.');
+      } else {
+        final files = json['files'] as List;
+        for (var i = 0; i < files.length; i++) {
+          final item = files[i];
+          if (item is! String) {
+            errors.add('`files[$i]` must be a string.');
+          }
+        }
+      }
+    }
+
+    return errors;
+  }
+}

--- a/lib/src/domain/bible/import/verse_record_validator.dart
+++ b/lib/src/domain/bible/import/verse_record_validator.dart
@@ -1,0 +1,32 @@
+class VerseRecordValidator {
+  static List<String> validate(Map<String, dynamic> json) {
+    final errors = <String>[];
+
+    if (json['bookId'] == null || json['bookId'] is! int) {
+      errors.add('`bookId` must be an integer between 1 and 66.');
+    } else {
+      final value = json['bookId'] as int;
+      if (value < 1 || value > 66) {
+        errors.add('`bookId` must be between 1 and 66.');
+      }
+    }
+
+    if (json['chapter'] == null || json['chapter'] is! int) {
+      errors.add('`chapter` must be a positive integer.');
+    } else if ((json['chapter'] as int) < 1) {
+      errors.add('`chapter` must be greater than 0.');
+    }
+
+    if (json['verse'] == null || json['verse'] is! int) {
+      errors.add('`verse` must be a positive integer.');
+    } else if ((json['verse'] as int) < 1) {
+      errors.add('`verse` must be greater than 0.');
+    }
+
+    if (json['text'] == null || json['text'] is! String) {
+      errors.add('`text` must be a string.');
+    }
+
+    return errors;
+  }
+}

--- a/lib/src/domain/bible/repositories.dart
+++ b/lib/src/domain/bible/repositories.dart
@@ -13,4 +13,11 @@ abstract class BibleRepository {
     String query, {
     int? limit,
   });
+  Future<BibleTranslation?> findTranslationById(String id);
+  Future<void> saveImportedTranslation(
+    BibleTranslation translation,
+    List<BibleVerse> verses, {
+    bool replaceExisting,
+  });
+  Future<void> buildSearchIndex(String translationId);
 }

--- a/lib/src/infrastructure/db/app_database.dart
+++ b/lib/src/infrastructure/db/app_database.dart
@@ -310,4 +310,38 @@ class AppDatabase extends _$AppDatabase {
     ).map((row) => row.read<int>('count')).getSingleOrNull();
     return (count ?? 0) > 0;
   }
+
+  String ftsTableNameFor(String translationId) {
+    final sanitized = translationId.replaceAll(RegExp(r'[^a-zA-Z0-9_]'), '_');
+    return 'verses_${sanitized}_fts';
+  }
+
+  Future<void> dropSearchIndex(String translationId) async {
+    final tableName = ftsTableNameFor(translationId);
+    await customStatement('DROP TABLE IF EXISTS $tableName');
+  }
+
+  Future<void> rebuildFtsFor(String translationId) async {
+    final tableName = ftsTableNameFor(translationId);
+    await dropSearchIndex(translationId);
+    await customStatement(
+      'CREATE VIRTUAL TABLE $tableName USING fts5(text, book_id UNINDEXED, chapter UNINDEXED, verse UNINDEXED, tokenize="unicode61 remove_diacritics 2")',
+    );
+    await customStatement(
+      'INSERT INTO $tableName(rowid, text, book_id, chapter, verse) SELECT rowid, text, book_id, chapter, verse FROM verses WHERE translation_id = ?',
+      [translationId],
+    );
+  }
+
+  Future<bool> hasSearchIndex(String translationId) async {
+    final tableName = ftsTableNameFor(translationId);
+    final rows = await customSelect(
+      'SELECT name FROM sqlite_master WHERE type = ? AND name = ?',
+      variables: [
+        const Variable<String>('table'),
+        Variable<String>(tableName),
+      ],
+    ).get();
+    return rows.isNotEmpty;
+  }
 }

--- a/lib/src/infrastructure/db/daos/bible_dao.dart
+++ b/lib/src/infrastructure/db/daos/bible_dao.dart
@@ -37,14 +37,72 @@ class BibleDao {
     String query, {
     int? limit,
   }) {
-    final q = _db.select(_db.verses)
+    return _searchWithFts(translationId, query, limit: limit);
+  }
+
+  Future<List<Verse>> _searchWithFts(
+    String translationId,
+    String query, {
+    int? limit,
+  }) async {
+    final hasIndex = await _db.hasSearchIndex(translationId);
+    if (hasIndex) {
+      final tableName = _db.ftsTableNameFor(translationId);
+      final matchQuery = _prepareFtsQuery(query);
+      final buffer = StringBuffer()
+        ..writeln('SELECT v.translation_id, v.book_id, v.chapter, v.verse, v.text')
+        ..writeln('FROM $tableName f')
+        ..writeln('JOIN verses v ON v.rowid = f.rowid')
+        ..writeln('WHERE v.translation_id = ? AND f MATCH ?')
+        ..writeln('ORDER BY v.book_id ASC, v.chapter ASC, v.verse ASC');
+      if (limit != null) {
+        buffer.writeln('LIMIT ?');
+      }
+      final rows = await _db
+          .customSelect(
+            buffer.toString(),
+            variables: [
+              Variable<String>(translationId),
+              Variable<String>(matchQuery),
+              if (limit != null) Variable<int>(limit),
+            ],
+            readsFrom: {_db.verses},
+          )
+          .get();
+      return rows
+          .map(
+            (row) => Verse(
+              translationId: row.read<String>('translation_id'),
+              bookId: row.read<int>('book_id'),
+              chapter: row.read<int>('chapter'),
+              verse: row.read<int>('verse'),
+              text: row.read<String>('text'),
+            ),
+          )
+          .toList();
+    }
+
+    final likeQuery = _db.select(_db.verses)
       ..where((tbl) => tbl.translationId.equals(translationId) &
           tbl.text.lower().like('%${query.toLowerCase()}%'))
-      ..orderBy([(tbl) => OrderingTerm.asc(tbl.bookId), (tbl) => OrderingTerm.asc(tbl.chapter), (tbl) => OrderingTerm.asc(tbl.verse)]);
+      ..orderBy([
+        (tbl) => OrderingTerm.asc(tbl.bookId),
+        (tbl) => OrderingTerm.asc(tbl.chapter),
+        (tbl) => OrderingTerm.asc(tbl.verse),
+      ]);
     if (limit != null) {
-      q.limit(limit);
+      likeQuery.limit(limit);
     }
-    return q.get();
+    return likeQuery.get();
+  }
+
+  String _prepareFtsQuery(String query) {
+    final trimmed = query.trim();
+    if (trimmed.isEmpty) {
+      return trimmed;
+    }
+    final escaped = trimmed.replaceAll('"', '""');
+    return '"$escaped"';
   }
 
   Future<List<BookAggregate>> getBooks(String translationId) async {

--- a/lib/src/presentation/providers.dart
+++ b/lib/src/presentation/providers.dart
@@ -13,6 +13,7 @@ import '../domain/accounts/usecases.dart';
 import '../domain/bible/entities.dart';
 import '../domain/bible/repositories.dart';
 import '../domain/bible/usecases.dart';
+import '../domain/bible/import/import_bible_package_usecase.dart';
 import '../domain/chat/repositories.dart';
 import '../domain/chat/usecases.dart';
 import '../domain/lessons/repositories.dart';
@@ -28,6 +29,7 @@ import '../infrastructure/db/daos/bible_dao.dart';
 import '../infrastructure/db/daos/chat_dao.dart';
 import '../infrastructure/db/daos/lesson_dao.dart';
 import '../infrastructure/db/daos/sync_dao.dart';
+import 'settings/bible_import_controller.dart';
 
 final appDatabaseProvider = Provider<AppDatabase>((ref) {
   final db = AppDatabase();
@@ -89,6 +91,10 @@ final getChapterUseCaseProvider = Provider((ref) {
 
 final searchBibleUseCaseProvider = Provider((ref) {
   return SearchBibleUseCase(ref.watch(bibleRepositoryProvider));
+});
+
+final importBiblePackageUseCaseProvider = Provider((ref) {
+  return ImportBiblePackageUseCase(ref.watch(bibleRepositoryProvider));
 });
 
 final watchLessonsUseCaseProvider = Provider((ref) {
@@ -222,6 +228,12 @@ final verseSearchProvider =
 final verseOfTheDayProvider = FutureProvider((ref) async {
   const service = VerseOfTheDayService();
   return service.fetch();
+});
+
+final bibleImportControllerProvider =
+    StateNotifierProvider<BibleImportController, BibleImportState>((ref) {
+  final useCase = ref.watch(importBiblePackageUseCaseProvider);
+  return BibleImportController(useCase);
 });
 
 class ChapterRequest {

--- a/lib/src/presentation/settings/bible_import_controller.dart
+++ b/lib/src/presentation/settings/bible_import_controller.dart
@@ -1,0 +1,77 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/bible/entities.dart';
+import '../../domain/bible/import/exceptions.dart';
+import '../../domain/bible/import/import_bible_package_usecase.dart';
+import '../../domain/bible/import/import_models.dart';
+
+class BibleImportState {
+  const BibleImportState({
+    this.isImporting = false,
+    this.progress,
+    this.imported,
+    this.error,
+    this.conflict,
+    this.packageFile,
+  });
+
+  final bool isImporting;
+  final ImportProgress? progress;
+  final BibleTranslation? imported;
+  final String? error;
+  final DuplicateTranslationException? conflict;
+  final File? packageFile;
+
+  bool get hasOutcome => imported != null || error != null;
+}
+
+class BibleImportController extends StateNotifier<BibleImportState> {
+  BibleImportController(this._useCase) : super(const BibleImportState());
+
+  final ImportBiblePackageUseCase _useCase;
+
+  Future<void> importPackage(
+    File file, {
+    ImportConflictResolution conflictResolution = ImportConflictResolution.prompt,
+  }) async {
+    state = BibleImportState(
+      isImporting: true,
+      progress: ImportProgress(stage: ImportStage.preparing, message: 'Preparing import...'),
+      packageFile: file,
+    );
+    try {
+      final translation = await _useCase(
+        packageFile: file,
+        conflictResolution: conflictResolution,
+        onProgress: (progress) {
+          state = BibleImportState(
+            isImporting: true,
+            progress: progress,
+            packageFile: file,
+          );
+        },
+      );
+      state = BibleImportState(imported: translation);
+    } on DuplicateTranslationException catch (conflict) {
+      state = BibleImportState(conflict: conflict, packageFile: file);
+    } on BibleImportException catch (error) {
+      state = BibleImportState(error: error.message, packageFile: file);
+    } catch (error) {
+      state = BibleImportState(error: error.toString(), packageFile: file);
+    }
+  }
+
+  Future<void> resolveConflict(ImportConflictResolution resolution) async {
+    final file = state.packageFile;
+    if (file == null) {
+      return;
+    }
+    await importPackage(file, conflictResolution: resolution);
+  }
+
+  void clearOutcome() {
+    state = const BibleImportState();
+  }
+}

--- a/lib/src/presentation/settings/settings_screen.dart
+++ b/lib/src/presentation/settings/settings_screen.dart
@@ -1,8 +1,14 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:share_plus/share_plus.dart';
 
+import '../../domain/bible/import/exceptions.dart';
+import '../../domain/bible/import/import_models.dart';
 import '../providers.dart';
+import 'bible_import_controller.dart';
 import 'about_screen.dart';
 import 'privacy_policy_screen.dart';
 
@@ -13,6 +19,47 @@ class SettingsScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final themeModeAsync = ref.watch(themeModeControllerProvider);
     final translationsAsync = ref.watch(translationsProvider);
+    final importState = ref.watch(bibleImportControllerProvider);
+
+    ref.listen<BibleImportState>(bibleImportControllerProvider,
+        (previous, next) {
+      if (previous?.conflict != next.conflict && next.conflict != null) {
+        Future.microtask(() async {
+          final resolution = await _showConflictDialog(context, next.conflict!);
+          final controller =
+              ref.read(bibleImportControllerProvider.notifier);
+          if (resolution == ImportConflictResolution.replace) {
+            await controller.resolveConflict(ImportConflictResolution.replace);
+          } else {
+            controller.clearOutcome();
+          }
+        });
+      } else if (previous?.imported != next.imported &&
+          next.imported != null) {
+        Future.microtask(() {
+          if (!context.mounted) return;
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                'Imported ${next.imported!.name} (${next.imported!.language.toUpperCase()})',
+              ),
+            ),
+          );
+          ref.invalidate(translationsProvider);
+          ref.invalidate(booksProvider);
+          ref.invalidate(verseSearchProvider);
+          ref.read(bibleImportControllerProvider.notifier).clearOutcome();
+        });
+      } else if (previous?.error != next.error && next.error != null) {
+        Future.microtask(() {
+          if (!context.mounted) return;
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(next.error!)),
+          );
+          ref.read(bibleImportControllerProvider.notifier).clearOutcome();
+        });
+      }
+    });
 
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
@@ -53,6 +100,38 @@ class SettingsScreen extends ConsumerWidget {
             padding: EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
             child: Text('Bible Translations'),
           ),
+          ListTile(
+            leading: const Icon(Icons.download_outlined),
+            title: const Text('Import translation package'),
+            subtitle: const Text('Install a translation from a .zip package'),
+            enabled: !importState.isImporting,
+            onTap: importState.isImporting
+                ? null
+                : () => _pickAndImport(context, ref),
+            trailing: importState.isImporting
+                ? const SizedBox(
+                    height: 20,
+                    width: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : null,
+          ),
+          if (importState.isImporting && importState.progress != null)
+            Padding(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(importState.progress!.message ??
+                      importState.progress!.stage.name),
+                  const SizedBox(height: 8),
+                  LinearProgressIndicator(
+                    value: importState.progress!.progress,
+                  ),
+                ],
+              ),
+            ),
           translationsAsync.when(
             data: (translations) => Column(
               children: [
@@ -143,6 +222,53 @@ class SettingsScreen extends ConsumerWidget {
           ),
         ],
       ),
+    );
+  }
+
+  Future<void> _pickAndImport(BuildContext context, WidgetRef ref) async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: const ['zip'],
+    );
+    if (result == null || result.files.isEmpty) {
+      return;
+    }
+    final path = result.files.single.path;
+    if (path == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Selected file is not accessible.')),
+      );
+      return;
+    }
+    final file = File(path);
+    await ref.read(bibleImportControllerProvider.notifier).importPackage(file);
+  }
+
+  Future<ImportConflictResolution?> _showConflictDialog(
+    BuildContext context,
+    DuplicateTranslationException conflict,
+  ) {
+    return showDialog<ImportConflictResolution>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Translation already installed'),
+          content: Text(
+            'The translation ${conflict.manifest.name} (${conflict.manifest.id}) is already installed. Replace the existing version?',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(ImportConflictResolution.skip),
+              child: const Text('Keep existing'),
+            ),
+            FilledButton(
+              onPressed: () =>
+                  Navigator.of(context).pop(ImportConflictResolution.replace),
+              child: const Text('Replace'),
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,9 @@ dependencies:
   path_provider: ^2.0.11
   flutter_riverpod: ^2.5.1
   uuid: ^4.5.1
+  flutter_archive: ^6.0.3
+  file_picker: ^8.1.2
+  crypto: ^3.0.3
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add manifest validation utilities and an import use case for Bible translation packages
- extend the repository and database to write imported verses, rebuild FTS indexes, and expose import progress
- update settings UI to pick ZIP packages, surface progress/conflicts, and refresh cached translation data after import

## Testing
- Not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df6d865d808320bbf1d9ace2286f5e