### PR TITLE
Add parallel chapter annotations and reading progress integration

### DIFF
--- a/lib/src/data/bible/annotation_repository_impl.dart
+++ b/lib/src/data/bible/annotation_repository_impl.dart
@@ -1,0 +1,321 @@
+import 'package:uuid/uuid.dart';
+
+import '../../domain/annotations/entities.dart';
+import '../../domain/annotations/repositories.dart';
+import '../../infrastructure/db/app_database.dart';
+import '../../infrastructure/db/daos/annotation_dao.dart';
+
+class AnnotationRepositoryImpl implements AnnotationRepository {
+  AnnotationRepositoryImpl(this._db, this._dao);
+
+  final AppDatabase _db;
+  final AnnotationDao _dao;
+  final Uuid _uuid = const Uuid();
+
+  Future<void> _ensureSeeded() => _db.ensureSeeded();
+
+  @override
+  Stream<List<Bookmark>> watchBookmarksForChapter(
+    String translationId,
+    int bookId,
+    int chapter,
+  ) async* {
+    await _ensureSeeded();
+    yield* _dao.watchBookmarksForChapter(translationId, bookId, chapter).map(
+      (rows) => rows.map(_mapBookmark).toList(),
+    );
+  }
+
+  @override
+  Future<Bookmark?> findBookmark(
+    String translationId,
+    int bookId,
+    int chapter,
+    int verse,
+  ) async {
+    await _ensureSeeded();
+    final row = await _dao.findBookmark(translationId, bookId, chapter, verse);
+    return row == null ? null : _mapBookmark(row);
+  }
+
+  @override
+  Future<Bookmark> createBookmark(VerseLocation location) async {
+    await _ensureSeeded();
+    final id = _uuid.v4();
+    final now = DateTime.now();
+    await _dao.insertBookmark(
+      BookmarksCompanion.insert(
+        id: id,
+        translationId: location.translationId,
+        bookId: location.bookId,
+        chapter: location.chapter,
+        verse: location.verse,
+        createdAt: now.millisecondsSinceEpoch,
+      ),
+    );
+    return Bookmark(id: id, location: location, createdAt: now);
+  }
+
+  @override
+  Future<void> deleteBookmark(String id) {
+    return _dao.deleteBookmark(id);
+  }
+
+  @override
+  Stream<List<Highlight>> watchHighlightsForChapter(
+    String translationId,
+    int bookId,
+    int chapter,
+  ) async* {
+    await _ensureSeeded();
+    yield* _dao.watchHighlightsForChapter(translationId, bookId, chapter).map(
+      (rows) => rows.map(_mapHighlight).toList(),
+    );
+  }
+
+  @override
+  Future<Highlight?> findHighlight(
+    String translationId,
+    int bookId,
+    int chapter,
+    int verse,
+  ) async {
+    await _ensureSeeded();
+    final row = await _dao.findHighlight(translationId, bookId, chapter, verse);
+    return row == null ? null : _mapHighlight(row);
+  }
+
+  @override
+  Future<Highlight> saveHighlight(Highlight highlight) async {
+    await _ensureSeeded();
+    final id = highlight.id.isEmpty ? _uuid.v4() : highlight.id;
+    final now = DateTime.now();
+    await _dao.upsertHighlight(
+      HighlightsCompanion.insert(
+        id: id,
+        translationId: highlight.location.translationId,
+        bookId: highlight.location.bookId,
+        chapter: highlight.location.chapter,
+        verse: highlight.location.verse,
+        colour: highlight.colour,
+        createdAt: now.millisecondsSinceEpoch,
+      ),
+    );
+    return Highlight(
+      id: id,
+      location: highlight.location,
+      colour: highlight.colour,
+      createdAt: now,
+    );
+  }
+
+  @override
+  Future<void> deleteHighlight(String id) {
+    return _dao.deleteHighlight(id);
+  }
+
+  @override
+  Stream<List<Note>> watchNotesForChapter(
+    String translationId,
+    int bookId,
+    int chapter,
+  ) async* {
+    await _ensureSeeded();
+    yield* _dao.watchNotesForChapter(translationId, bookId, chapter).asyncMap(
+      (rows) async {
+        final notes = <Note>[];
+        for (final row in rows) {
+          final historyRows = await _dao.getRevisions(row.id);
+          notes.add(_mapNote(row, historyRows));
+        }
+        return notes;
+      },
+    );
+  }
+
+  @override
+  Future<Note?> findNote(
+    String translationId,
+    int bookId,
+    int chapter,
+    int verse,
+  ) async {
+    await _ensureSeeded();
+    final row = await _dao.findNote(translationId, bookId, chapter, verse);
+    if (row == null) {
+      return null;
+    }
+    final historyRows = await _dao.getRevisions(row.id);
+    return _mapNote(row, historyRows);
+  }
+
+  @override
+  Future<Note> saveNote(VerseLocation location, String text) async {
+    await _ensureSeeded();
+    final now = DateTime.now();
+    final existing =
+        await _dao.findNote(location.translationId, location.bookId, location.chapter, location.verse);
+    if (existing == null) {
+      final id = _uuid.v4();
+      await _dao.insertNote(
+        NotesCompanion.insert(
+          id: id,
+          translationId: location.translationId,
+          bookId: location.bookId,
+          chapter: location.chapter,
+          verse: location.verse,
+          text: text,
+          version: 1,
+          updatedAt: now.millisecondsSinceEpoch,
+        ),
+      );
+      await _dao.insertRevision(
+        NoteRevisionsCompanion.insert(
+          noteId: id,
+          version: 1,
+          text: text,
+          updatedAt: now.millisecondsSinceEpoch,
+        ),
+      );
+      return Note(
+        id: id,
+        location: location,
+        text: text,
+        version: 1,
+        updatedAt: now,
+        history: [
+          NoteHistoryEntry(version: 1, text: text, updatedAt: now),
+        ],
+      );
+    }
+
+    final newVersion = existing.version + 1;
+    await _dao.updateNote(
+      existing.id,
+      text,
+      newVersion,
+      now.millisecondsSinceEpoch,
+    );
+    await _dao.insertRevision(
+      NoteRevisionsCompanion.insert(
+        noteId: existing.id,
+        version: newVersion,
+        text: text,
+        updatedAt: now.millisecondsSinceEpoch,
+      ),
+    );
+    final updated = await _dao.findNote(
+      location.translationId,
+      location.bookId,
+      location.chapter,
+      location.verse,
+    );
+    final historyRows = await _dao.getRevisions(existing.id);
+    return _mapNote(updated!, historyRows);
+  }
+
+  @override
+  Future<void> deleteNote(String id) {
+    return (_db.delete(_db.notes)..where((tbl) => tbl.id.equals(id))).go();
+  }
+
+  @override
+  Future<List<NoteHistoryEntry>> getHistory(String noteId) async {
+    await _ensureSeeded();
+    final rows = await _dao.getRevisions(noteId);
+    return rows
+        .map(
+          (row) => NoteHistoryEntry(
+            version: row.version,
+            text: row.text,
+            updatedAt: DateTime.fromMillisecondsSinceEpoch(row.updatedAt),
+          ),
+        )
+        .toList();
+  }
+
+  @override
+  Future<Note?> revertToPreviousVersion(String noteId) async {
+    await _ensureSeeded();
+    final history = await _dao.getRevisions(noteId);
+    if (history.length < 2) {
+      return null;
+    }
+    final current = history.first;
+    final target = history[1];
+    final now = DateTime.now();
+    final newVersion = current.version + 1;
+    await _dao.updateNote(
+      noteId,
+      target.text,
+      newVersion,
+      now.millisecondsSinceEpoch,
+    );
+    await _dao.insertRevision(
+      NoteRevisionsCompanion.insert(
+        noteId: noteId,
+        version: newVersion,
+        text: target.text,
+        updatedAt: now.millisecondsSinceEpoch,
+      ),
+    );
+    final updated = await _dao.findNoteById(noteId);
+    if (updated == null) {
+      return null;
+    }
+    final updatedHistory = await _dao.getRevisions(noteId);
+    return _mapNote(updated, updatedHistory);
+  }
+
+  Bookmark _mapBookmark(BookmarksData row) {
+    return Bookmark(
+      id: row.id,
+      location: VerseLocation(
+        translationId: row.translationId,
+        bookId: row.bookId,
+        chapter: row.chapter,
+        verse: row.verse,
+      ),
+      createdAt: DateTime.fromMillisecondsSinceEpoch(row.createdAt),
+    );
+  }
+
+  Highlight _mapHighlight(HighlightsData row) {
+    return Highlight(
+      id: row.id,
+      location: VerseLocation(
+        translationId: row.translationId,
+        bookId: row.bookId,
+        chapter: row.chapter,
+        verse: row.verse,
+      ),
+      colour: row.colour,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(row.createdAt),
+    );
+  }
+
+  Note _mapNote(NotesData row, List<NoteRevisionsData> historyRows) {
+    final history = historyRows
+        .map(
+          (entry) => NoteHistoryEntry(
+            version: entry.version,
+            text: entry.text,
+            updatedAt: DateTime.fromMillisecondsSinceEpoch(entry.updatedAt),
+          ),
+        )
+        .toList();
+    return Note(
+      id: row.id,
+      location: VerseLocation(
+        translationId: row.translationId,
+        bookId: row.bookId,
+        chapter: row.chapter,
+        verse: row.verse,
+      ),
+      text: row.text,
+      version: row.version,
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(row.updatedAt),
+      history: history,
+    );
+  }
+}

--- a/lib/src/data/bible/bible_repository_impl.dart
+++ b/lib/src/data/bible/bible_repository_impl.dart
@@ -83,6 +83,28 @@ class BibleRepositoryImpl implements BibleRepository {
   }
 
   @override
+  Stream<List<BibleVerse>> watchChapter(
+    String translationId,
+    int bookId,
+    int chapter,
+  ) async* {
+    await _ensureSeeded();
+    yield* _dao.watchChapter(translationId, bookId, chapter).map(
+      (rows) => rows
+          .map(
+            (row) => BibleVerse(
+              translationId: row.translationId,
+              bookId: row.bookId,
+              chapter: row.chapter,
+              verse: row.verse,
+              text: row.text,
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  @override
   Future<List<BibleSearchResult>> searchVerses(
     String translationId,
     String query, {

--- a/lib/src/data/bible/reading_progress_repository_impl.dart
+++ b/lib/src/data/bible/reading_progress_repository_impl.dart
@@ -1,0 +1,70 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../domain/bible/reading_progress/entities.dart';
+import '../../domain/bible/reading_progress/repositories.dart';
+
+class ReadingProgressRepositoryImpl implements ReadingProgressRepository {
+  ReadingProgressRepositoryImpl();
+
+  static const _storageKey = 'reading_progress_state';
+  final _controller = StreamController<ReadingPosition?>.broadcast();
+  bool _initialised = false;
+
+  Future<void> _ensureInitialised() async {
+    if (_initialised) {
+      return;
+    }
+    final position = await getLastPosition();
+    _controller.add(position);
+    _initialised = true;
+  }
+
+  @override
+  Stream<ReadingPosition?> watch() async* {
+    await _ensureInitialised();
+    yield* _controller.stream;
+  }
+
+  @override
+  Future<ReadingPosition?> getLastPosition() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getString(_storageKey);
+    if (stored == null) {
+      return null;
+    }
+    try {
+      final decoded = jsonDecode(stored) as Map<String, dynamic>;
+      return ReadingPosition(
+        translationId: decoded['translationId'] as String,
+        bookId: decoded['bookId'] as int,
+        chapter: decoded['chapter'] as int,
+        verse: decoded['verse'] as int,
+        updatedAt: DateTime.fromMillisecondsSinceEpoch(decoded['updatedAt'] as int),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Future<void> savePosition(ReadingPosition position) async {
+    final prefs = await SharedPreferences.getInstance();
+    final payload = jsonEncode({
+      'translationId': position.translationId,
+      'bookId': position.bookId,
+      'chapter': position.chapter,
+      'verse': position.verse,
+      'updatedAt': position.updatedAt.millisecondsSinceEpoch,
+    });
+    await prefs.setString(_storageKey, payload);
+    await _ensureInitialised();
+    _controller.add(position);
+  }
+
+  void dispose() {
+    _controller.close();
+  }
+}

--- a/lib/src/domain/annotations/entities.dart
+++ b/lib/src/domain/annotations/entities.dart
@@ -1,0 +1,78 @@
+class VerseLocation {
+  const VerseLocation({
+    required this.translationId,
+    required this.bookId,
+    required this.chapter,
+    required this.verse,
+  });
+
+  final String translationId;
+  final int bookId;
+  final int chapter;
+  final int verse;
+}
+
+class Bookmark {
+  const Bookmark({
+    required this.id,
+    required this.location,
+    required this.createdAt,
+  });
+
+  final String id;
+  final VerseLocation location;
+  final DateTime createdAt;
+}
+
+class Highlight {
+  const Highlight({
+    required this.id,
+    required this.location,
+    required this.colour,
+    required this.createdAt,
+  });
+
+  final String id;
+  final VerseLocation location;
+  final String colour;
+  final DateTime createdAt;
+}
+
+class NoteHistoryEntry {
+  const NoteHistoryEntry({
+    required this.version,
+    required this.text,
+    required this.updatedAt,
+  });
+
+  final int version;
+  final String text;
+  final DateTime updatedAt;
+}
+
+class Note {
+  const Note({
+    required this.id,
+    required this.location,
+    required this.text,
+    required this.version,
+    required this.updatedAt,
+    this.history = const [],
+  });
+
+  final String id;
+  final VerseLocation location;
+  final String text;
+  final int version;
+  final DateTime updatedAt;
+  final List<NoteHistoryEntry> history;
+
+  bool get canUndo => history.length > 1;
+
+  NoteHistoryEntry? get previousVersion {
+    if (history.length < 2) {
+      return null;
+    }
+    return history[1];
+  }
+}

--- a/lib/src/domain/annotations/repositories.dart
+++ b/lib/src/domain/annotations/repositories.dart
@@ -1,0 +1,50 @@
+import 'entities.dart';
+
+abstract class AnnotationRepository {
+  Stream<List<Bookmark>> watchBookmarksForChapter(
+    String translationId,
+    int bookId,
+    int chapter,
+  );
+  Future<Bookmark?> findBookmark(
+    String translationId,
+    int bookId,
+    int chapter,
+    int verse,
+  );
+  Future<Bookmark> createBookmark(VerseLocation location);
+  Future<void> deleteBookmark(String id);
+
+  Stream<List<Highlight>> watchHighlightsForChapter(
+    String translationId,
+    int bookId,
+    int chapter,
+  );
+  Future<Highlight?> findHighlight(
+    String translationId,
+    int bookId,
+    int chapter,
+    int verse,
+  );
+  Future<Highlight> saveHighlight(Highlight highlight);
+  Future<void> deleteHighlight(String id);
+
+  Stream<List<Note>> watchNotesForChapter(
+    String translationId,
+    int bookId,
+    int chapter,
+  );
+  Future<Note?> findNote(
+    String translationId,
+    int bookId,
+    int chapter,
+    int verse,
+  );
+  Future<Note> saveNote(
+    VerseLocation location,
+    String text,
+  );
+  Future<void> deleteNote(String id);
+  Future<List<NoteHistoryEntry>> getHistory(String noteId);
+  Future<Note?> revertToPreviousVersion(String noteId);
+}

--- a/lib/src/domain/annotations/usecases.dart
+++ b/lib/src/domain/annotations/usecases.dart
@@ -1,0 +1,112 @@
+import 'entities.dart';
+import 'repositories.dart';
+
+class WatchBookmarksForChapterUseCase {
+  const WatchBookmarksForChapterUseCase(this._repository);
+
+  final AnnotationRepository _repository;
+
+  Stream<List<Bookmark>> call(String translationId, int bookId, int chapter) {
+    return _repository.watchBookmarksForChapter(translationId, bookId, chapter);
+  }
+}
+
+class ToggleBookmarkUseCase {
+  const ToggleBookmarkUseCase(this._repository);
+
+  final AnnotationRepository _repository;
+
+  Future<Bookmark?> call(VerseLocation location) async {
+    final existing = await _repository.findBookmark(
+      location.translationId,
+      location.bookId,
+      location.chapter,
+      location.verse,
+    );
+    if (existing != null) {
+      await _repository.deleteBookmark(existing.id);
+      return null;
+    }
+    return _repository.createBookmark(location);
+  }
+}
+
+class WatchHighlightsForChapterUseCase {
+  const WatchHighlightsForChapterUseCase(this._repository);
+
+  final AnnotationRepository _repository;
+
+  Stream<List<Highlight>> call(String translationId, int bookId, int chapter) {
+    return _repository.watchHighlightsForChapter(translationId, bookId, chapter);
+  }
+}
+
+class SaveHighlightUseCase {
+  const SaveHighlightUseCase(this._repository);
+
+  final AnnotationRepository _repository;
+
+  Future<Highlight> call(Highlight highlight) {
+    return _repository.saveHighlight(highlight);
+  }
+}
+
+class RemoveHighlightUseCase {
+  const RemoveHighlightUseCase(this._repository);
+
+  final AnnotationRepository _repository;
+
+  Future<void> call(String id) {
+    return _repository.deleteHighlight(id);
+  }
+}
+
+class WatchNotesForChapterUseCase {
+  const WatchNotesForChapterUseCase(this._repository);
+
+  final AnnotationRepository _repository;
+
+  Stream<List<Note>> call(String translationId, int bookId, int chapter) {
+    return _repository.watchNotesForChapter(translationId, bookId, chapter);
+  }
+}
+
+class SaveNoteUseCase {
+  const SaveNoteUseCase(this._repository);
+
+  final AnnotationRepository _repository;
+
+  Future<Note> call(VerseLocation location, String text) {
+    return _repository.saveNote(location, text);
+  }
+}
+
+class DeleteNoteUseCase {
+  const DeleteNoteUseCase(this._repository);
+
+  final AnnotationRepository _repository;
+
+  Future<void> call(String id) {
+    return _repository.deleteNote(id);
+  }
+}
+
+class UndoNoteUseCase {
+  const UndoNoteUseCase(this._repository);
+
+  final AnnotationRepository _repository;
+
+  Future<Note?> call(String id) {
+    return _repository.revertToPreviousVersion(id);
+  }
+}
+
+class GetNoteHistoryUseCase {
+  const GetNoteHistoryUseCase(this._repository);
+
+  final AnnotationRepository _repository;
+
+  Future<List<NoteHistoryEntry>> call(String noteId) {
+    return _repository.getHistory(noteId);
+  }
+}

--- a/lib/src/domain/bible/reading_progress/entities.dart
+++ b/lib/src/domain/bible/reading_progress/entities.dart
@@ -1,0 +1,15 @@
+class ReadingPosition {
+  const ReadingPosition({
+    required this.translationId,
+    required this.bookId,
+    required this.chapter,
+    required this.verse,
+    required this.updatedAt,
+  });
+
+  final String translationId;
+  final int bookId;
+  final int chapter;
+  final int verse;
+  final DateTime updatedAt;
+}

--- a/lib/src/domain/bible/reading_progress/repositories.dart
+++ b/lib/src/domain/bible/reading_progress/repositories.dart
@@ -1,0 +1,7 @@
+import 'entities.dart';
+
+abstract class ReadingProgressRepository {
+  Stream<ReadingPosition?> watch();
+  Future<ReadingPosition?> getLastPosition();
+  Future<void> savePosition(ReadingPosition position);
+}

--- a/lib/src/domain/bible/reading_progress/usecases.dart
+++ b/lib/src/domain/bible/reading_progress/usecases.dart
@@ -1,0 +1,27 @@
+import 'entities.dart';
+import 'repositories.dart';
+
+class WatchReadingProgressUseCase {
+  const WatchReadingProgressUseCase(this._repository);
+
+  final ReadingProgressRepository _repository;
+
+  Stream<ReadingPosition?> call() => _repository.watch();
+}
+
+class GetLastReadingPositionUseCase {
+  const GetLastReadingPositionUseCase(this._repository);
+
+  final ReadingProgressRepository _repository;
+
+  Future<ReadingPosition?> call() => _repository.getLastPosition();
+}
+
+class SaveReadingProgressUseCase {
+  const SaveReadingProgressUseCase(this._repository);
+
+  final ReadingProgressRepository _repository;
+
+  Future<void> call(ReadingPosition position) =>
+      _repository.savePosition(position);
+}

--- a/lib/src/domain/bible/repositories.dart
+++ b/lib/src/domain/bible/repositories.dart
@@ -8,6 +8,11 @@ abstract class BibleRepository {
     int bookId,
     int chapter,
   );
+  Stream<List<BibleVerse>> watchChapter(
+    String translationId,
+    int bookId,
+    int chapter,
+  );
   Future<List<BibleSearchResult>> searchVerses(
     String translationId,
     String query, {

--- a/lib/src/domain/bible/usecases.dart
+++ b/lib/src/domain/bible/usecases.dart
@@ -35,6 +35,20 @@ class GetChapterUseCase {
   }
 }
 
+class WatchChapterUseCase {
+  const WatchChapterUseCase(this._repository);
+
+  final BibleRepository _repository;
+
+  Stream<List<BibleVerse>> call(
+    String translationId,
+    int bookId,
+    int chapter,
+  ) {
+    return _repository.watchChapter(translationId, bookId, chapter);
+  }
+}
+
 class SearchVersesUseCase {
   final BibleRepository _repository;
 

--- a/lib/src/infrastructure/db/app_database.dart
+++ b/lib/src/infrastructure/db/app_database.dart
@@ -80,6 +80,17 @@ class Notes extends Table {
   Set<Column> get primaryKey => {id};
 }
 
+class NoteRevisions extends Table {
+  TextColumn get noteId => text()
+      .references(Notes, #id, onDelete: KeyAction.cascade)();
+  IntColumn get version => integer()();
+  TextColumn get text => text()();
+  IntColumn get updatedAt => integer()();
+
+  @override
+  Set<Column> get primaryKey => {noteId, version};
+}
+
 class Lessons extends Table {
   TextColumn get id => text()();
   TextColumn get title => text()();
@@ -155,6 +166,7 @@ class Messages extends Table {
     Bookmarks,
     Highlights,
     Notes,
+    NoteRevisions,
     Lessons,
     Progress,
     LocalUsers,
@@ -177,7 +189,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 2;
+  int get schemaVersion => 3;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -188,6 +200,9 @@ class AppDatabase extends _$AppDatabase {
           if (from < 2) {
             await m.addColumn(translations, translations.languageName);
             await m.addColumn(translations, translations.copyright);
+          }
+          if (from < 3) {
+            await m.createTable(noteRevisions);
           }
         },
       );

--- a/lib/src/infrastructure/db/app_database.g.dart
+++ b/lib/src/infrastructure/db/app_database.g.dart
@@ -19,6 +19,8 @@ class _$AppDatabase extends GeneratedDatabase {
       'Run build_runner to generate table bindings for `highlights`.');
   late final TableInfo<Table, dynamic> notes = throw UnimplementedError(
       'Run build_runner to generate table bindings for `notes`.');
+  late final TableInfo<Table, dynamic> noteRevisions = throw UnimplementedError(
+      'Run build_runner to generate table bindings for `note_revisions`.');
   late final TableInfo<Table, dynamic> lessons = throw UnimplementedError(
       'Run build_runner to generate table bindings for `lessons`.');
   late final TableInfo<Table, dynamic> progress = throw UnimplementedError(
@@ -35,5 +37,5 @@ class _$AppDatabase extends GeneratedDatabase {
       throw UnimplementedError('Run build_runner to generate table bindings.');
 
   @override
-  int get schemaVersion => 2;
+  int get schemaVersion => 3;
 }

--- a/lib/src/infrastructure/db/daos/annotation_dao.dart
+++ b/lib/src/infrastructure/db/daos/annotation_dao.dart
@@ -1,0 +1,184 @@
+import 'package:drift/drift.dart';
+
+import '../app_database.dart';
+
+class AnnotationDao {
+  AnnotationDao(this._db);
+
+  final AppDatabase _db;
+
+  Stream<List<BookmarksData>> watchBookmarksForChapter(
+    String translationId,
+    int bookId,
+    int chapter,
+  ) {
+    final query = _db.select(_db.bookmarks)
+      ..where((tbl) =>
+          tbl.translationId.equals(translationId) &
+          tbl.bookId.equals(bookId) &
+          tbl.chapter.equals(chapter))
+      ..orderBy([
+        (tbl) => OrderingTerm.asc(tbl.verse),
+      ]);
+    return query.watch();
+  }
+
+  Future<BookmarksData?> findBookmark(
+    String translationId,
+    int bookId,
+    int chapter,
+    int verse,
+  ) {
+    final query = _db.select(_db.bookmarks)
+      ..where((tbl) =>
+          tbl.translationId.equals(translationId) &
+          tbl.bookId.equals(bookId) &
+          tbl.chapter.equals(chapter) &
+          tbl.verse.equals(verse))
+      ..limit(1);
+    return query.getSingleOrNull();
+  }
+
+  Future<void> insertBookmark(BookmarksCompanion companion) {
+    return _db.into(_db.bookmarks).insertOnConflictUpdate(companion);
+  }
+
+  Future<void> deleteBookmark(String id) {
+    return (_db.delete(_db.bookmarks)..where((tbl) => tbl.id.equals(id))).go();
+  }
+
+  Stream<List<HighlightsData>> watchHighlightsForChapter(
+    String translationId,
+    int bookId,
+    int chapter,
+  ) {
+    final query = _db.select(_db.highlights)
+      ..where((tbl) =>
+          tbl.translationId.equals(translationId) &
+          tbl.bookId.equals(bookId) &
+          tbl.chapter.equals(chapter))
+      ..orderBy([
+        (tbl) => OrderingTerm.asc(tbl.verse),
+      ]);
+    return query.watch();
+  }
+
+  Future<HighlightsData?> findHighlight(
+    String translationId,
+    int bookId,
+    int chapter,
+    int verse,
+  ) {
+    final query = _db.select(_db.highlights)
+      ..where((tbl) =>
+          tbl.translationId.equals(translationId) &
+          tbl.bookId.equals(bookId) &
+          tbl.chapter.equals(chapter) &
+          tbl.verse.equals(verse))
+      ..limit(1);
+    return query.getSingleOrNull();
+  }
+
+  Future<void> upsertHighlight(HighlightsCompanion companion) async {
+    await (_db.delete(_db.highlights)
+          ..where((tbl) =>
+              tbl.translationId.equals(companion.translationId.value) &
+              tbl.bookId.equals(companion.bookId.value) &
+              tbl.chapter.equals(companion.chapter.value) &
+              tbl.verse.equals(companion.verse.value)))
+        .go();
+    await _db.into(_db.highlights).insert(companion, mode: InsertMode.insertOrReplace);
+  }
+
+  Future<void> deleteHighlight(String id) {
+    return (_db.delete(_db.highlights)..where((tbl) => tbl.id.equals(id))).go();
+  }
+
+  Stream<List<NotesData>> watchNotesForChapter(
+    String translationId,
+    int bookId,
+    int chapter,
+  ) {
+    final query = _db.select(_db.notes)
+      ..where((tbl) =>
+          tbl.translationId.equals(translationId) &
+          tbl.bookId.equals(bookId) &
+          tbl.chapter.equals(chapter))
+      ..orderBy([
+        (tbl) => OrderingTerm.asc(tbl.verse),
+      ]);
+    return query.watch();
+  }
+
+  Stream<List<NotesData>> watchNotesForVerse(String noteId) {
+    final query = _db.select(_db.notes)
+      ..where((tbl) => tbl.id.equals(noteId))
+      ..limit(1);
+    return query.watch();
+  }
+
+  Future<NotesData?> findNote(
+    String translationId,
+    int bookId,
+    int chapter,
+    int verse,
+  ) {
+    final query = _db.select(_db.notes)
+      ..where((tbl) =>
+          tbl.translationId.equals(translationId) &
+          tbl.bookId.equals(bookId) &
+          tbl.chapter.equals(chapter) &
+          tbl.verse.equals(verse))
+      ..limit(1);
+    return query.getSingleOrNull();
+  }
+
+  Future<NotesData?> findNoteById(String id) {
+    final query = _db.select(_db.notes)
+      ..where((tbl) => tbl.id.equals(id))
+      ..limit(1);
+    return query.getSingleOrNull();
+  }
+
+  Future<void> insertNote(NotesCompanion companion) {
+    return _db.into(_db.notes).insert(companion, mode: InsertMode.insertOrReplace);
+  }
+
+  Future<void> updateNote(
+    String id,
+    String text,
+    int version,
+    int updatedAt,
+  ) {
+    return (_db.update(_db.notes)..where((tbl) => tbl.id.equals(id))).write(
+      NotesCompanion(
+        text: Value(text),
+        version: Value(version),
+        updatedAt: Value(updatedAt),
+      ),
+    );
+  }
+
+  Future<void> insertRevision(NoteRevisionsCompanion companion) {
+    return _db
+        .into(_db.noteRevisions)
+        .insert(companion, mode: InsertMode.insertOrReplace);
+  }
+
+  Future<NoteRevisionsData?> findRevision(String noteId, int version) {
+    final query = _db.select(_db.noteRevisions)
+      ..where((tbl) =>
+          tbl.noteId.equals(noteId) & tbl.version.equals(version))
+      ..limit(1);
+    return query.getSingleOrNull();
+  }
+
+  Future<List<NoteRevisionsData>> getRevisions(String noteId) {
+    final query = _db.select(_db.noteRevisions)
+      ..where((tbl) => tbl.noteId.equals(noteId))
+      ..orderBy([
+        (tbl) => OrderingTerm.desc(tbl.version),
+      ]);
+    return query.get();
+  }
+}

--- a/lib/src/infrastructure/db/daos/bible_dao.dart
+++ b/lib/src/infrastructure/db/daos/bible_dao.dart
@@ -32,6 +32,22 @@ class BibleDao {
     return query.get();
   }
 
+  Stream<List<Verse>> watchChapter(
+    String translationId,
+    int bookId,
+    int chapter,
+  ) {
+    final query = _db.select(_db.verses)
+      ..where((tbl) =>
+          tbl.translationId.equals(translationId) &
+          tbl.bookId.equals(bookId) &
+          tbl.chapter.equals(chapter))
+      ..orderBy([
+        (tbl) => OrderingTerm.asc(tbl.verse),
+      ]);
+    return query.watch();
+  }
+
   Future<List<VerseSearchRow>> search(
     String translationId,
     String query, {

--- a/lib/src/presentation/bible/bible_screen.dart
+++ b/lib/src/presentation/bible/bible_screen.dart
@@ -33,36 +33,79 @@ class BibleScreen extends ConsumerWidget {
         children: [
           translationsAsync.when(
             data: (translations) {
-              final selectedId = ref.watch(selectedTranslationIdProvider);
+              final selectedIds = ref.watch(selectedTranslationIdsProvider);
+              final notifier = ref.read(selectedTranslationIdsProvider.notifier);
+              final availableIds = translations.map((t) => t.id).toSet();
+              if (selectedIds.isEmpty) {
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  notifier.setAll([translations.first.id]);
+                });
+              } else if (selectedIds.any((id) => !availableIds.contains(id))) {
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  notifier.setAll(selectedIds.where(availableIds.contains));
+                });
+              }
+
               return Padding(
                 padding: const EdgeInsets.all(16.0),
-                child: DropdownButtonFormField<String>(
-                  value: selectedId,
-                  items: [
-                    for (final translation in translations)
-                      DropdownMenuItem(
-                        value: translation.id,
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(translation.name),
-                            Text(
-                              '${translation.languageName} · ${translation.language.toUpperCase()}',
-                              style: Theme.of(context).textTheme.bodySmall,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Text(
+                      'Translations',
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 8),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        for (final translation in translations)
+                          FilterChip(
+                            selected: selectedIds.contains(translation.id),
+                            onSelected: (value) {
+                              notifier.toggle(translation.id);
+                            },
+                            label: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(translation.name),
+                                Text(
+                                  '${translation.languageName} · ${translation.language.toUpperCase()}',
+                                  style: Theme.of(context).textTheme.bodySmall,
+                                ),
+                              ],
                             ),
-                          ],
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    if (selectedIds.isNotEmpty)
+                      DropdownButtonFormField<String>(
+                        value: selectedIds.first,
+                        items: [
+                          for (final id in selectedIds)
+                            DropdownMenuItem(
+                              value: id,
+                              child: Text(
+                                translations
+                                    .firstWhere((element) => element.id == id)
+                                    .name,
+                              ),
+                            ),
+                        ],
+                        onChanged: (value) {
+                          if (value != null) {
+                            notifier.setPrimary(value);
+                          }
+                        },
+                        decoration: const InputDecoration(
+                          labelText: 'Primary column',
+                          border: OutlineInputBorder(),
                         ),
                       ),
                   ],
-                  onChanged: (value) {
-                    if (value != null) {
-                      ref.read(selectedTranslationIdProvider.notifier).state = value;
-                    }
-                  },
-                  decoration: const InputDecoration(
-                    labelText: 'Translation',
-                    border: OutlineInputBorder(),
-                  ),
                 ),
               );
             },

--- a/lib/src/presentation/bible/chapter_screen.dart
+++ b/lib/src/presentation/bible/chapter_screen.dart
@@ -1,10 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../domain/annotations/entities.dart';
 import '../../domain/bible/entities.dart';
+import '../../domain/bible/reading_progress/entities.dart';
 import '../providers.dart';
 
-class ChapterScreen extends ConsumerWidget {
+const _highlightPalette = <String>[
+  '#FFF59D',
+  '#FFE082',
+  '#FFCDD2',
+  '#C5CAE9',
+  '#C8E6C9',
+];
+
+class ChapterScreen extends ConsumerStatefulWidget {
   const ChapterScreen({
     super.key,
     required this.book,
@@ -15,50 +25,143 @@ class ChapterScreen extends ConsumerWidget {
   final int chapter;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final translationId = ref.watch(selectedTranslationIdProvider);
-    final versesAsync = ref.watch(
-      chapterProvider(
-        ChapterRequest(
-          translationId: translationId,
-          bookId: book.id,
-          chapter: chapter,
+  ConsumerState<ChapterScreen> createState() => _ChapterScreenState();
+}
+
+class _ChapterScreenState extends ConsumerState<ChapterScreen> {
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+
+  @override
+  Widget build(BuildContext context) {
+    final translationIds = ref.watch(selectedTranslationIdsProvider);
+    final translationsAsync = ref.watch(translationsProvider);
+    final translationsById = translationsAsync.maybeWhen(
+      data: (data) => {for (final translation in data) translation.id: translation},
+      orElse: () => <String, BibleTranslation>{},
+    );
+
+    final parallelAsync = ref.watch(
+      parallelChapterProvider(
+        ParallelChapterRequest(
+          translationIds: translationIds,
+          bookId: widget.book.id,
+          chapter: widget.chapter,
         ),
       ),
     );
 
+    final bookmarkLookup = <String, Map<int, Bookmark>>{};
+    final highlightLookup = <String, Map<int, Highlight>>{};
+    final noteLookup = <String, Map<int, Note>>{};
+
+    for (final translationId in translationIds) {
+      final request = AnnotationRequest(
+        translationId: translationId,
+        bookId: widget.book.id,
+        chapter: widget.chapter,
+      );
+      final bookmarks = ref.watch(chapterBookmarksProvider(request));
+      final highlights = ref.watch(chapterHighlightsProvider(request));
+      final notes = ref.watch(chapterNotesProvider(request));
+      bookmarkLookup[translationId] = bookmarks.maybeWhen(
+        data: (list) => {for (final item in list) item.location.verse: item},
+        orElse: () => <int, Bookmark>{},
+      );
+      highlightLookup[translationId] = highlights.maybeWhen(
+        data: (list) => {for (final item in list) item.location.verse: item},
+        orElse: () => <int, Highlight>{},
+      );
+      noteLookup[translationId] = notes.maybeWhen(
+        data: (list) => {for (final item in list) item.location.verse: item},
+        orElse: () => <int, Note>{},
+      );
+    }
+
     return Scaffold(
+      key: _scaffoldKey,
       appBar: AppBar(
-        title: Text('${book.name} $chapter'),
+        title: Text('${widget.book.name} ${widget.chapter}'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.sticky_note_2_outlined),
+            tooltip: 'Annotations',
+            onPressed: () => _scaffoldKey.currentState?.openEndDrawer(),
+          ),
+        ],
       ),
-      body: versesAsync.when(
-        data: (verses) => ListView.builder(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
-          itemCount: verses.length,
-          itemBuilder: (context, index) {
-            final verse = verses[index];
-            return Padding(
-              padding: const EdgeInsets.only(bottom: 16),
-              child: RichText(
-                text: TextSpan(
+      endDrawer: _AnnotationDrawer(book: widget.book, chapter: widget.chapter),
+      body: parallelAsync.when(
+        data: (rows) {
+          if (rows.isEmpty) {
+            return const Center(child: Text('No verses available for this chapter.'));
+          }
+          return Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                child: Row(
                   children: [
-                    TextSpan(
-                      text: '${verse.verse}. ',
-                      style: Theme.of(context)
-                          .textTheme
-                          .titleMedium
-                          ?.copyWith(fontWeight: FontWeight.bold),
-                    ),
-                    TextSpan(
-                      text: verse.text,
-                      style: Theme.of(context).textTheme.bodyLarge,
-                    ),
+                    for (final translationId in translationIds)
+                      Expanded(
+                        child: Text(
+                          translationsById[translationId]?.name ?? translationId,
+                          textAlign: TextAlign.center,
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                      ),
                   ],
                 ),
               ),
-            );
-          },
-        ),
+              const Divider(height: 1),
+              Expanded(
+                child: ListView.builder(
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                  itemCount: rows.length,
+                  itemBuilder: (context, index) {
+                    final row = rows[index];
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: 16),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          for (final translationId in translationIds) ...[
+                            Expanded(
+                              child: _VerseColumn(
+                                translationId: translationId,
+                                verse: row.versesByTranslation[translationId],
+                                isPrimary: translationId == translationIds.first,
+                                bookmark: bookmarkLookup[translationId]?[row.verseNumber],
+                                highlight: highlightLookup[translationId]?[row.verseNumber],
+                                note: noteLookup[translationId]?[row.verseNumber],
+                                onLongPress: (verse) {
+                                  if (verse == null) {
+                                    return;
+                                  }
+                                  final bookmark = bookmarkLookup[translationId]?[verse.verse];
+                                  final highlight = highlightLookup[translationId]?[verse.verse];
+                                  final note = noteLookup[translationId]?[verse.verse];
+                                  _showVerseActions(
+                                    context,
+                                    verse,
+                                    bookmark,
+                                    highlight,
+                                    note,
+                                  );
+                                },
+                              ),
+                            ),
+                            if (translationId != translationIds.last)
+                              const SizedBox(width: 12),
+                          ],
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          );
+        },
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (error, stack) => Center(
           child: Text('Failed to load chapter: $error'),
@@ -66,4 +169,509 @@ class ChapterScreen extends ConsumerWidget {
       ),
     );
   }
+  Future<void> _showVerseActions(
+    BuildContext context,
+    BibleVerse verse,
+    Bookmark? bookmark,
+    Highlight? highlight,
+    Note? note,
+  ) async {
+    final location = VerseLocation(
+      translationId: verse.translationId,
+      bookId: verse.bookId,
+      chapter: verse.chapter,
+      verse: verse.verse,
+    );
+    await showModalBottomSheet<void>(
+      context: context,
+      builder: (sheetContext) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading:
+                  Icon(bookmark == null ? Icons.bookmark_add_outlined : Icons.bookmark_remove),
+              title: Text(bookmark == null ? 'Add bookmark' : 'Remove bookmark'),
+              onTap: () async {
+                Navigator.pop(sheetContext);
+                await _toggleBookmark(context, location);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.color_lens_outlined),
+              title: const Text('Highlight verse'),
+              onTap: () async {
+                Navigator.pop(sheetContext);
+                await _pickHighlightColour(context, location, highlight);
+              },
+            ),
+            if (highlight != null)
+              ListTile(
+                leading: const Icon(Icons.format_color_reset),
+                title: const Text('Remove highlight'),
+                onTap: () async {
+                  Navigator.pop(sheetContext);
+                  await ref.read(removeHighlightUseCaseProvider)(highlight.id);
+                  if (!mounted) return;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Highlight removed.')),
+                  );
+                },
+              ),
+            ListTile(
+              leading: const Icon(Icons.note_alt_outlined),
+              title: Text(note == null ? 'Add note' : 'Edit note'),
+              onTap: () async {
+                Navigator.pop(sheetContext);
+                await _editNote(context, location, note);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.menu_open),
+              title: const Text('Manage annotations'),
+              onTap: () {
+                Navigator.pop(sheetContext);
+                _scaffoldKey.currentState?.openEndDrawer();
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _toggleBookmark(BuildContext context, VerseLocation location) async {
+    final result = await ref.read(toggleBookmarkUseCaseProvider)(location);
+    if (!mounted) return;
+    if (result != null) {
+      await _updateReadingProgress(location);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Bookmark added.')),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Bookmark removed.')),
+      );
+    }
+  }
+
+  Future<void> _pickHighlightColour(
+    BuildContext context,
+    VerseLocation location,
+    Highlight? existing,
+  ) async {
+    final selected = await showDialog<String>(
+      context: context,
+      builder: (dialogContext) => SimpleDialog(
+        title: const Text('Choose highlight colour'),
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: [
+                for (final hex in _highlightPalette)
+                  GestureDetector(
+                    onTap: () => Navigator.pop(dialogContext, hex),
+                    child: Container(
+                      width: 36,
+                      height: 36,
+                      decoration: BoxDecoration(
+                        color: _colourFromHex(hex),
+                        shape: BoxShape.circle,
+                        border: Border.all(color: Colors.black26),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: const Text('Cancel'),
+          ),
+        ],
+      ),
+    );
+    if (selected == null) {
+      return;
+    }
+    await ref.read(saveHighlightUseCaseProvider)(
+      Highlight(
+        id: existing?.id ?? '',
+        location: location,
+        colour: selected,
+        createdAt: DateTime.now(),
+      ),
+    );
+    await _updateReadingProgress(location);
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Highlight saved.')),
+    );
+  }
+
+  Future<void> _editNote(
+    BuildContext context,
+    VerseLocation location,
+    Note? note,
+  ) async {
+    final controller = TextEditingController(text: note?.text ?? '');
+    try {
+      final result = await showDialog<String>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: Text(note == null ? 'Add note' : 'Edit note'),
+          content: TextField(
+            controller: controller,
+            maxLines: 6,
+            decoration: const InputDecoration(
+              labelText: 'Note',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext, controller.text.trim()),
+              child: const Text('Save'),
+            ),
+          ],
+        ),
+      );
+      if (result == null) {
+        return;
+      }
+      if (result.isEmpty) {
+        if (note != null) {
+          await ref.read(deleteNoteUseCaseProvider)(note.id);
+          if (!mounted) return;
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Note removed.')),
+          );
+        }
+        return;
+      }
+      await ref.read(saveNoteUseCaseProvider)(location, result);
+      await _updateReadingProgress(location);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Note saved.')),
+      );
+    } finally {
+      controller.dispose();
+    }
+  }
+
+  Future<void> _updateReadingProgress(VerseLocation location) {
+    final saveProgress = ref.read(saveReadingProgressUseCaseProvider);
+    return saveProgress(
+      ReadingPosition(
+        translationId: location.translationId,
+        bookId: location.bookId,
+        chapter: location.chapter,
+        verse: location.verse,
+        updatedAt: DateTime.now(),
+      ),
+    );
+  }
+}
+class _VerseColumn extends StatelessWidget {
+  const _VerseColumn({
+    required this.translationId,
+    required this.verse,
+    required this.isPrimary,
+    required this.bookmark,
+    required this.highlight,
+    required this.note,
+    required this.onLongPress,
+  });
+
+  final String translationId;
+  final BibleVerse? verse;
+  final bool isPrimary;
+  final Bookmark? bookmark;
+  final Highlight? highlight;
+  final Note? note;
+  final ValueChanged<BibleVerse?> onLongPress;
+
+  @override
+  Widget build(BuildContext context) {
+    final highlightColour = highlight != null ? _colourFromHex(highlight!.colour) : null;
+    return GestureDetector(
+      onLongPress: () => onLongPress(verse),
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 4),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: highlightColour?.withOpacity(0.3),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: isPrimary
+                ? Theme.of(context).colorScheme.primary
+                : Colors.transparent,
+            width: 1.5,
+          ),
+        ),
+        child: verse == null
+            ? const Center(child: Text('—'))
+            : Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Text(
+                        '${verse!.verse}.',
+                        style: Theme.of(context)
+                            .textTheme
+                            .titleMedium
+                            ?.copyWith(fontWeight: FontWeight.bold),
+                      ),
+                      if (bookmark != null) ...[
+                        const SizedBox(width: 6),
+                        Icon(
+                          Icons.bookmark,
+                          size: 18,
+                          color: Theme.of(context).colorScheme.secondary,
+                        ),
+                      ],
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    verse!.text,
+                    style:
+                        Theme.of(context).textTheme.bodyLarge?.copyWith(height: 1.6),
+                  ),
+                  if (note != null) ...[
+                    const SizedBox(height: 8),
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Icon(Icons.sticky_note_2_outlined, size: 16),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            note!.text,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ],
+              ),
+      ),
+    );
+  }
+}
+
+class _AnnotationDrawer extends ConsumerWidget {
+  const _AnnotationDrawer({required this.book, required this.chapter});
+
+  final BibleBook book;
+  final int chapter;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final translationIds = ref.watch(selectedTranslationIdsProvider);
+    final translations = ref.watch(translationsProvider).maybeWhen(
+      data: (data) => {for (final translation in data) translation.id: translation},
+      orElse: () => <String, BibleTranslation>{},
+    );
+    return Drawer(
+      child: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            ListTile(
+              title: Text('${book.name} $chapter'),
+              subtitle: const Text('Annotations'),
+            ),
+            const Divider(height: 1),
+            Expanded(
+              child: ListView(
+                children: [
+                  for (final translationId in translationIds)
+                    _TranslationAnnotationSection(
+                      book: book,
+                      chapter: chapter,
+                      translationId: translationId,
+                      translationName:
+                          translations[translationId]?.name ?? translationId,
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TranslationAnnotationSection extends ConsumerWidget {
+  const _TranslationAnnotationSection({
+    required this.book,
+    required this.chapter,
+    required this.translationId,
+    required this.translationName,
+  });
+
+  final BibleBook book;
+  final int chapter;
+  final String translationId;
+  final String translationName;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final request = AnnotationRequest(
+      translationId: translationId,
+      bookId: book.id,
+      chapter: chapter,
+    );
+    final bookmarksAsync = ref.watch(chapterBookmarksProvider(request));
+    final highlightsAsync = ref.watch(chapterHighlightsProvider(request));
+    final notesAsync = ref.watch(chapterNotesProvider(request));
+
+    final bookmarks = bookmarksAsync.maybeWhen(
+      data: (data) => data,
+      orElse: () => const <Bookmark>[],
+    );
+    final highlights = highlightsAsync.maybeWhen(
+      data: (data) => data,
+      orElse: () => const <Highlight>[],
+    );
+    final notes = notesAsync.maybeWhen(
+      data: (data) => data,
+      orElse: () => const <Note>[],
+    );
+
+    return ExpansionTile(
+      title: Text(translationName),
+      subtitle: Text('${book.name} $chapter'),
+      children: [
+        if (bookmarks.isEmpty && highlights.isEmpty && notes.isEmpty)
+          const ListTile(
+            title: Text('No annotations yet'),
+          ),
+        if (bookmarks.isNotEmpty) ...[
+          const ListTile(title: Text('Bookmarks')),
+          for (final bookmark in bookmarks)
+            ListTile(
+              leading: const Icon(Icons.bookmark),
+              title: Text('Verse ${bookmark.location.verse}'),
+              trailing: IconButton(
+                icon: const Icon(Icons.delete_outline),
+                onPressed: () async {
+                  await ref
+                      .read(toggleBookmarkUseCaseProvider)(bookmark.location);
+                  if (!context.mounted) return;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(
+                        'Bookmark removed from verse ${bookmark.location.verse}.',
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+        ],
+        if (highlights.isNotEmpty) ...[
+          const ListTile(title: Text('Highlights')),
+          for (final highlight in highlights)
+            ListTile(
+              leading: CircleAvatar(
+                backgroundColor: _colourFromHex(highlight.colour),
+              ),
+              title: Text('Verse ${highlight.location.verse}'),
+              trailing: IconButton(
+                icon: const Icon(Icons.delete_outline),
+                onPressed: () async {
+                  await ref.read(removeHighlightUseCaseProvider)(highlight.id);
+                  if (!context.mounted) return;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(
+                        'Highlight removed from verse ${highlight.location.verse}.',
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+        ],
+        if (notes.isNotEmpty) ...[
+          const ListTile(title: Text('Notes')),
+          for (final note in notes) _NoteListTile(note: note),
+        ],
+      ],
+    );
+  }
+}
+
+class _NoteListTile extends ConsumerWidget {
+  const _NoteListTile({required this.note});
+
+  final Note note;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ExpansionTile(
+      title: Text('Verse ${note.location.verse} · v${note.version}'),
+      subtitle: Text(note.text),
+      children: [
+        ButtonBar(
+          alignment: MainAxisAlignment.end,
+          children: [
+            IconButton(
+              icon: const Icon(Icons.undo),
+              tooltip: 'Undo to previous version',
+              onPressed: note.canUndo
+                  ? () async {
+                      await ref.read(undoNoteUseCaseProvider)(note.id);
+                      if (!context.mounted) return;
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Note reverted.')),
+                      );
+                    }
+                  : null,
+            ),
+            IconButton(
+              icon: const Icon(Icons.delete_outline),
+              onPressed: () async {
+                await ref.read(deleteNoteUseCaseProvider)(note.id);
+                if (!context.mounted) return;
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Note deleted.')),
+                );
+              },
+            ),
+          ],
+        ),
+        for (final history in note.history)
+          ListTile(
+            dense: true,
+            title: Text('Version ${history.version}'),
+            subtitle: Text(history.text),
+            trailing: Text(history.updatedAt.toLocal().toString()),
+          ),
+      ],
+    );
+  }
+}
+
+Color _colourFromHex(String hex) {
+  final buffer = StringBuffer();
+  if (hex.length == 6 || hex.length == 7) buffer.write('ff');
+  buffer.write(hex.replaceFirst('#', ''));
+  return Color(int.parse(buffer.toString(), radix: 16));
 }

--- a/lib/src/presentation/home/home_screen.dart
+++ b/lib/src/presentation/home/home_screen.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:share_plus/share_plus.dart';
 
 import '../bible/bible_screen.dart';
+import '../bible/chapter_screen.dart';
+import '../../domain/bible/entities.dart';
 import '../lessons/lessons_screen.dart';
 import '../settings/settings_screen.dart';
 import '../providers.dart';
@@ -58,6 +60,9 @@ class _HomeDashboard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final verseAsync = ref.watch(verseOfTheDayProvider);
+    final readingProgressAsync = ref.watch(readingProgressProvider);
+    final readingPosition =
+        readingProgressAsync.maybeWhen(data: (value) => value, orElse: () => null);
 
     return Container(
       color: Theme.of(context).colorScheme.surface,
@@ -154,6 +159,43 @@ class _HomeDashboard extends ConsumerWidget {
                       );
                     },
                   ),
+                  if (readingPosition != null)
+                    ElevatedButton.icon(
+                      icon: const Icon(Icons.play_arrow),
+                      label: const Text('Continue Reading'),
+                      onPressed: () async {
+                        final position = readingPosition;
+                        ref
+                            .read(selectedTranslationIdsProvider.notifier)
+                            .setPrimary(position.translationId);
+                        final books =
+                            await ref.read(getBooksUseCaseProvider)(position.translationId);
+                        BibleBook? book;
+                        try {
+                          book = books.firstWhere((b) => b.id == position.bookId);
+                        } catch (_) {
+                          book = null;
+                        }
+                        if (!context.mounted) return;
+                        if (book == null) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('Saved reading location is unavailable.'),
+                            ),
+                          );
+                          return;
+                        }
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => ChapterScreen(
+                              book: book!,
+                              chapter: position.chapter,
+                            ),
+                          ),
+                        );
+                      },
+                    ),
                   ElevatedButton.icon(
                     icon: const Icon(Icons.school_outlined),
                     label: const Text('Browse Lessons'),

--- a/lib/src/presentation/providers.dart
+++ b/lib/src/presentation/providers.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:rxdart/rxdart.dart';
 
 import '../data/accounts/account_repository_impl.dart';
+import '../data/bible/annotation_repository_impl.dart';
 import '../data/bible/bible_repository_impl.dart';
+import '../data/bible/reading_progress_repository_impl.dart';
 import '../data/chat/chat_repository_impl.dart';
 import '../data/lessons/lesson_repository_impl.dart';
 import '../data/settings/settings_repository_impl.dart';
@@ -10,7 +13,13 @@ import '../data/sync/sync_repository_impl.dart';
 import '../data/bible/verse_of_the_day_service.dart';
 import '../domain/accounts/repositories.dart';
 import '../domain/accounts/usecases.dart';
+import '../domain/annotations/entities.dart';
+import '../domain/annotations/repositories.dart';
+import '../domain/annotations/usecases.dart';
 import '../domain/bible/entities.dart';
+import '../domain/bible/reading_progress/entities.dart';
+import '../domain/bible/reading_progress/repositories.dart';
+import '../domain/bible/reading_progress/usecases.dart';
 import '../domain/bible/repositories.dart';
 import '../domain/bible/usecases.dart';
 import '../domain/bible/import/import_bible_package_usecase.dart';
@@ -25,6 +34,7 @@ import '../domain/sync/usecases.dart';
 import '../domain/settings/entities.dart';
 import '../infrastructure/db/app_database.dart';
 import '../infrastructure/db/daos/account_dao.dart';
+import '../infrastructure/db/daos/annotation_dao.dart';
 import '../infrastructure/db/daos/bible_dao.dart';
 import '../infrastructure/db/daos/chat_dao.dart';
 import '../infrastructure/db/daos/lesson_dao.dart';
@@ -42,6 +52,8 @@ final lessonDaoProvider = Provider((ref) => LessonDao(ref.watch(appDatabaseProvi
 final accountDaoProvider = Provider((ref) => AccountDao(ref.watch(appDatabaseProvider)));
 final syncDaoProvider = Provider((ref) => SyncDao(ref.watch(appDatabaseProvider)));
 final chatDaoProvider = Provider((ref) => ChatDao(ref.watch(appDatabaseProvider)));
+final annotationDaoProvider =
+    Provider((ref) => AnnotationDao(ref.watch(appDatabaseProvider)));
 
 final bibleRepositoryProvider = Provider<BibleRepository>((ref) {
   final db = ref.watch(appDatabaseProvider);
@@ -72,6 +84,17 @@ final chatRepositoryProvider = Provider<ChatRepository>((ref) {
   final dao = ref.watch(chatDaoProvider);
   return ChatRepositoryImpl(db, dao);
 });
+final annotationRepositoryProvider = Provider<AnnotationRepository>((ref) {
+  final db = ref.watch(appDatabaseProvider);
+  final dao = ref.watch(annotationDaoProvider);
+  return AnnotationRepositoryImpl(db, dao);
+});
+final readingProgressRepositoryProvider =
+    Provider<ReadingProgressRepository>((ref) {
+  final repository = ReadingProgressRepositoryImpl();
+  ref.onDispose(repository.dispose);
+  return repository;
+});
 
 final settingsRepositoryProvider = Provider<SettingsRepository>((ref) {
   return SettingsRepositoryImpl();
@@ -89,12 +112,78 @@ final getChapterUseCaseProvider = Provider((ref) {
   return GetChapterUseCase(ref.watch(bibleRepositoryProvider));
 });
 
+final watchChapterUseCaseProvider = Provider((ref) {
+  return WatchChapterUseCase(ref.watch(bibleRepositoryProvider));
+});
+
 final searchVersesUseCaseProvider = Provider((ref) {
   return SearchVersesUseCase(ref.watch(bibleRepositoryProvider));
 });
 
 final importBiblePackageUseCaseProvider = Provider((ref) {
   return ImportBiblePackageUseCase(ref.watch(bibleRepositoryProvider));
+});
+
+final watchBookmarksForChapterUseCaseProvider = Provider((ref) {
+  return WatchBookmarksForChapterUseCase(
+    ref.watch(annotationRepositoryProvider),
+  );
+});
+
+final toggleBookmarkUseCaseProvider = Provider((ref) {
+  return ToggleBookmarkUseCase(ref.watch(annotationRepositoryProvider));
+});
+
+final watchHighlightsForChapterUseCaseProvider = Provider((ref) {
+  return WatchHighlightsForChapterUseCase(
+    ref.watch(annotationRepositoryProvider),
+  );
+});
+
+final saveHighlightUseCaseProvider = Provider((ref) {
+  return SaveHighlightUseCase(ref.watch(annotationRepositoryProvider));
+});
+
+final removeHighlightUseCaseProvider = Provider((ref) {
+  return RemoveHighlightUseCase(ref.watch(annotationRepositoryProvider));
+});
+
+final watchNotesForChapterUseCaseProvider = Provider((ref) {
+  return WatchNotesForChapterUseCase(ref.watch(annotationRepositoryProvider));
+});
+
+final saveNoteUseCaseProvider = Provider((ref) {
+  return SaveNoteUseCase(ref.watch(annotationRepositoryProvider));
+});
+
+final deleteNoteUseCaseProvider = Provider((ref) {
+  return DeleteNoteUseCase(ref.watch(annotationRepositoryProvider));
+});
+
+final undoNoteUseCaseProvider = Provider((ref) {
+  return UndoNoteUseCase(ref.watch(annotationRepositoryProvider));
+});
+
+final getNoteHistoryUseCaseProvider = Provider((ref) {
+  return GetNoteHistoryUseCase(ref.watch(annotationRepositoryProvider));
+});
+
+final watchReadingProgressUseCaseProvider = Provider((ref) {
+  return WatchReadingProgressUseCase(
+    ref.watch(readingProgressRepositoryProvider),
+  );
+});
+
+final getLastReadingPositionUseCaseProvider = Provider((ref) {
+  return GetLastReadingPositionUseCase(
+    ref.watch(readingProgressRepositoryProvider),
+  );
+});
+
+final saveReadingProgressUseCaseProvider = Provider((ref) {
+  return SaveReadingProgressUseCase(
+    ref.watch(readingProgressRepositoryProvider),
+  );
 });
 
 final watchLessonsUseCaseProvider = Provider((ref) {
@@ -182,21 +271,48 @@ final translationsProvider = FutureProvider((ref) async {
   return translations;
 });
 
-final selectedTranslationIdProvider = StateProvider<String>((ref) {
-  final translationsAsync = ref.watch(translationsProvider);
-  return translationsAsync.maybeWhen(
-    data: (data) {
-      if (data.isEmpty) {
-        return 'kjv';
+class SelectedTranslationsNotifier extends StateNotifier<List<String>> {
+  SelectedTranslationsNotifier() : super(const ['kjv']);
+
+  void setPrimary(String translationId) {
+    final current = state.toList();
+    current.remove(translationId);
+    current.insert(0, translationId);
+    state = List.unmodifiable(current);
+  }
+
+  void toggle(String translationId) {
+    final current = state.toList();
+    if (current.contains(translationId)) {
+      if (current.length == 1) {
+        return;
       }
-      final preferred = data.firstWhere(
-        (translation) => translation.id == 'kjv',
-        orElse: () => data.first,
-      );
-      return preferred.id;
-    },
-    orElse: () => 'kjv',
-  );
+      current.remove(translationId);
+    } else {
+      current.add(translationId);
+    }
+    state = List.unmodifiable(current);
+  }
+
+  void setAll(Iterable<String> translationIds) {
+    final list = translationIds.isEmpty
+        ? const ['kjv']
+        : translationIds.toSet().toList();
+    state = List.unmodifiable(list);
+  }
+}
+
+final selectedTranslationIdsProvider =
+    StateNotifierProvider<SelectedTranslationsNotifier, List<String>>(
+  (ref) => SelectedTranslationsNotifier(),
+);
+
+final selectedTranslationIdProvider = Provider<String>((ref) {
+  final ids = ref.watch(selectedTranslationIdsProvider);
+  if (ids.isEmpty) {
+    return 'kjv';
+  }
+  return ids.first;
 });
 
 final booksProvider = FutureProvider((ref) async {
@@ -276,6 +392,103 @@ final chapterProvider =
     FutureProvider.family.autoDispose<List<BibleVerse>, ChapterRequest>((ref, request) async {
   final useCase = ref.watch(getChapterUseCaseProvider);
   return useCase(request.translationId, request.bookId, request.chapter);
+});
+
+class ParallelChapterRequest {
+  const ParallelChapterRequest({
+    required this.translationIds,
+    required this.bookId,
+    required this.chapter,
+  });
+
+  final List<String> translationIds;
+  final int bookId;
+  final int chapter;
+}
+
+class ParallelVerseRow {
+  ParallelVerseRow({
+    required this.verseNumber,
+    required Map<String, BibleVerse> versesByTranslation,
+  }) : versesByTranslation = Map.unmodifiable(versesByTranslation);
+
+  final int verseNumber;
+  final Map<String, BibleVerse> versesByTranslation;
+}
+
+final parallelChapterProvider = StreamProvider.autoDispose
+    .family<List<ParallelVerseRow>, ParallelChapterRequest>((ref, request) {
+  final watchChapter = ref.watch(watchChapterUseCaseProvider);
+  final translationIds = request.translationIds.isEmpty
+      ? [ref.watch(selectedTranslationIdProvider)]
+      : request.translationIds;
+  if (translationIds.isEmpty) {
+    return Stream.value(const []);
+  }
+  final streams = translationIds
+      .map((id) => watchChapter(id, request.bookId, request.chapter))
+      .toList();
+  return Rx.combineLatestList<List<BibleVerse>>(streams).map(
+    (chapters) => _mergeParallelVerses(translationIds, chapters),
+  );
+});
+
+List<ParallelVerseRow> _mergeParallelVerses(
+  List<String> translationIds,
+  List<List<BibleVerse>> chapters,
+) {
+  final verseMap = <int, Map<String, BibleVerse>>{};
+  for (var i = 0; i < translationIds.length; i++) {
+    final translationId = translationIds[i];
+    final verses = chapters.length > i ? chapters[i] : const <BibleVerse>[];
+    for (final verse in verses) {
+      final bucket = verseMap.putIfAbsent(verse.verse, () => {});
+      bucket[translationId] = verse;
+    }
+  }
+  final keys = verseMap.keys.toList()..sort();
+  return [
+    for (final key in keys)
+      ParallelVerseRow(
+        verseNumber: key,
+        versesByTranslation: verseMap[key]!,
+      ),
+  ];
+}
+
+class AnnotationRequest {
+  const AnnotationRequest({
+    required this.translationId,
+    required this.bookId,
+    required this.chapter,
+  });
+
+  final String translationId;
+  final int bookId;
+  final int chapter;
+}
+
+final chapterBookmarksProvider = StreamProvider.autoDispose
+    .family<List<Bookmark>, AnnotationRequest>((ref, request) {
+  final useCase = ref.watch(watchBookmarksForChapterUseCaseProvider);
+  return useCase(request.translationId, request.bookId, request.chapter);
+});
+
+final chapterHighlightsProvider = StreamProvider.autoDispose
+    .family<List<Highlight>, AnnotationRequest>((ref, request) {
+  final useCase = ref.watch(watchHighlightsForChapterUseCaseProvider);
+  return useCase(request.translationId, request.bookId, request.chapter);
+});
+
+final chapterNotesProvider = StreamProvider.autoDispose
+    .family<List<Note>, AnnotationRequest>((ref, request) {
+  final useCase = ref.watch(watchNotesForChapterUseCaseProvider);
+  return useCase(request.translationId, request.bookId, request.chapter);
+});
+
+final readingProgressProvider = StreamProvider<ReadingPosition?>((ref) {
+  final useCase = ref.watch(watchReadingProgressUseCaseProvider);
+  return useCase();
 });
 
 class ThemeModeController extends AsyncNotifier<ThemeMode> {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   flutter_archive: ^6.0.3
   file_picker: ^8.1.2
   crypto: ^3.0.3
+  rxdart: ^0.28.0
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- enable multi-translation chapter view with annotation drawer, long-press actions, and note undo support
- add Drift annotation DAO/repository implementations with note revision history and highlight colors
- wire up reading progress persistence so annotations update the continue-reading entry point

## Testing
- not run (flutter/dart tooling unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df743e71f883209e52c6de4fb903ad