### PR TITLE
Add lesson sync registry, offline attachment cache, and background worker

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <application
         android:label="myapp"
         android:name="${applicationName}"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -20,6 +22,9 @@ class _AppBootstrap extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     // Ensure the local database has baseline data available.
     ref.read(appDatabaseProvider).ensureSeeded();
+    final syncService = ref.read(lessonSyncServiceProvider);
+    syncService.ensureBackgroundScheduled();
+    unawaited(syncService.syncAll());
     return const StudyMateApp();
   }
 }

--- a/lib/src/data/lessons/lesson_repository_impl.dart
+++ b/lib/src/data/lessons/lesson_repository_impl.dart
@@ -123,6 +123,7 @@ class LessonRepositoryImpl implements LessonRepository {
               url: attachment.url,
               position: attachment.position,
               title: attachment.title,
+              localPath: attachment.localPath,
             ),
           )
           .toList(),

--- a/lib/src/domain/lessons/entities.dart
+++ b/lib/src/domain/lessons/entities.dart
@@ -25,12 +25,14 @@ class LessonAttachment {
     required this.url,
     required this.position,
     this.title,
+    this.localPath,
   });
 
   final LessonAttachmentType type;
   final String url;
   final int position;
   final String? title;
+  final String? localPath;
 }
 
 enum LessonQuizType { mcq, trueFalse, shortAnswer }

--- a/lib/src/infrastructure/db/app_database.dart
+++ b/lib/src/infrastructure/db/app_database.dart
@@ -144,6 +144,9 @@ class LessonAttachments extends Table {
   TextColumn get type => text()();
   TextColumn get title => text().nullable()();
   TextColumn get url => text()();
+  TextColumn get localPath => text().nullable()();
+  IntColumn get sizeBytes => integer().nullable()();
+  IntColumn get downloadedAt => integer().nullable()();
 
   @override
   Set<Column> get primaryKey => {lessonId, position};
@@ -187,6 +190,32 @@ class LessonFeeds extends Table {
   IntColumn get lastModified => integer().nullable()();
   IntColumn get lastFetchedAt => integer().nullable()();
   IntColumn get lastCheckedAt => integer().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+@DataClassName('LessonSourceRow')
+class LessonSources extends Table {
+  TextColumn get id => text()();
+  TextColumn get type => text()();
+  TextColumn get location => text()();
+  TextColumn get label => text().nullable()();
+  TextColumn get cohort => text().nullable()();
+  TextColumn get lessonClass => text().nullable()();
+  BoolColumn get enabled => boolean().withDefault(const Constant(true))();
+  BoolColumn get isBundled => boolean().withDefault(const Constant(false))();
+  IntColumn get priority => integer().withDefault(const Constant(0))();
+  TextColumn get checksum => text().nullable()();
+  TextColumn get etag => text().nullable()();
+  IntColumn get lastModified => integer().nullable()();
+  IntColumn get lastSyncedAt => integer().nullable()();
+  IntColumn get lastAttemptedAt => integer().nullable()();
+  IntColumn get lastCheckedAt => integer().nullable()();
+  TextColumn get lastError => text().nullable()();
+  IntColumn get lessonCount => integer().withDefault(const Constant(0))();
+  IntColumn get attachmentBytes => integer().withDefault(const Constant(0))();
+  IntColumn get quotaBytes => integer().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};
@@ -256,6 +285,7 @@ class Messages extends Table {
     LessonQuizzes,
     LessonQuizOptions,
     LessonFeeds,
+    LessonSources,
     Progress,
     LocalUsers,
     SyncQueue,
@@ -277,7 +307,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 4;
+  int get schemaVersion => 5;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -301,6 +331,15 @@ class AppDatabase extends _$AppDatabase {
             await m.createTable(lessonQuizzes);
             await m.createTable(lessonQuizOptions);
             await m.createTable(lessonFeeds);
+          }
+          if (from < 5) {
+            await m.addColumn(
+                lessonAttachments, lessonAttachments.localPath);
+            await m.addColumn(
+                lessonAttachments, lessonAttachments.sizeBytes);
+            await m.addColumn(
+                lessonAttachments, lessonAttachments.downloadedAt);
+            await m.createTable(lessonSources);
           }
         },
       );

--- a/lib/src/infrastructure/db/app_database.g.dart
+++ b/lib/src/infrastructure/db/app_database.g.dart
@@ -35,6 +35,8 @@ class _$AppDatabase extends GeneratedDatabase {
       'Run build_runner to generate table bindings for `lesson_quiz_options`.');
   late final TableInfo<Table, dynamic> lessonFeeds = throw UnimplementedError(
       'Run build_runner to generate table bindings for `lesson_feeds`.');
+  late final TableInfo<Table, dynamic> lessonSources = throw UnimplementedError(
+      'Run build_runner to generate table bindings for `lesson_sources`.');
   late final TableInfo<Table, dynamic> progress = throw UnimplementedError(
       'Run build_runner to generate table bindings for `progress`.');
   late final TableInfo<Table, dynamic> localUsers = throw UnimplementedError(
@@ -49,5 +51,5 @@ class _$AppDatabase extends GeneratedDatabase {
       throw UnimplementedError('Run build_runner to generate table bindings.');
 
   @override
-  int get schemaVersion => 4;
+  int get schemaVersion => 5;
 }

--- a/lib/src/infrastructure/lessons/lesson_attachment_cache.dart
+++ b/lib/src/infrastructure/lessons/lesson_attachment_cache.dart
@@ -1,0 +1,255 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:drift/drift.dart';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../db/app_database.dart';
+import 'lesson_sync_constants.dart';
+
+class AttachmentCacheSummary {
+  const AttachmentCacheSummary({
+    required this.downloaded,
+    required this.skipped,
+    required this.removed,
+    required this.totalBytes,
+  });
+
+  final int downloaded;
+  final int skipped;
+  final int removed;
+  final int totalBytes;
+
+  static const AttachmentCacheSummary empty = AttachmentCacheSummary(
+    downloaded: 0,
+    skipped: 0,
+    removed: 0,
+    totalBytes: 0,
+  );
+}
+
+class LessonAttachmentCache {
+  LessonAttachmentCache(this._db, {http.Client? client})
+      : _client = client ?? http.Client();
+
+  final AppDatabase _db;
+  final http.Client _client;
+  Directory? _cacheDirectory;
+
+  Future<AttachmentCacheSummary> ensureForLessons(
+    Iterable<String> lessonIds, {
+    int? quotaBytes,
+  }) async {
+    final ids = lessonIds.toSet();
+    if (ids.isEmpty) {
+      final usage = await _currentUsage();
+      return AttachmentCacheSummary.empty.copyWith(totalBytes: usage);
+    }
+
+    final attachments = await (_db.select(_db.lessonAttachments)
+          ..where((tbl) => tbl.lessonId.isIn(ids.toList())))
+        .get();
+    if (attachments.isEmpty) {
+      final usage = await _currentUsage();
+      return AttachmentCacheSummary.empty.copyWith(totalBytes: usage);
+    }
+
+    final directory = await _ensureCacheDirectory();
+    var downloaded = 0;
+    var skipped = 0;
+
+    for (final attachment in attachments) {
+      final uri = Uri.tryParse(attachment.url);
+      if (uri == null || !(uri.isScheme('http') || uri.isScheme('https'))) {
+        skipped++;
+        continue;
+      }
+
+      final file = await _resolveFile(directory, attachment.url);
+      if (await file.exists()) {
+        final fileLength = await file.length();
+        if (attachment.localPath != file.path ||
+            (attachment.sizeBytes ?? 0) != fileLength) {
+          await (_db.update(_db.lessonAttachments)
+                ..where((tbl) => tbl.lessonId.equals(attachment.lessonId) &
+                    tbl.position.equals(attachment.position)))
+              .write(
+                LessonAttachmentsCompanion(
+                  localPath: Value(file.path),
+                  sizeBytes: Value(fileLength),
+                  downloadedAt: Value(attachment.downloadedAt ??
+                      DateTime.now().millisecondsSinceEpoch),
+                ),
+              );
+        }
+        skipped++;
+        continue;
+      }
+
+      try {
+        final response = await _client.get(uri).timeout(
+              const Duration(seconds: 20),
+            );
+        if (response.statusCode >= 400) {
+          skipped++;
+          continue;
+        }
+        await file.create(recursive: true);
+        await file.writeAsBytes(response.bodyBytes);
+        downloaded++;
+        await (_db.update(_db.lessonAttachments)
+              ..where((tbl) =>
+                  tbl.lessonId.equals(attachment.lessonId) &
+                  tbl.position.equals(attachment.position)))
+            .write(
+              LessonAttachmentsCompanion(
+                localPath: Value(file.path),
+                sizeBytes: Value(response.bodyBytes.length),
+                downloadedAt:
+                    Value(DateTime.now().millisecondsSinceEpoch),
+              ),
+            );
+      } on TimeoutException {
+        skipped++;
+      } on SocketException {
+        skipped++;
+      }
+    }
+
+    await _enforceQuota(quotaBytes ?? kDefaultLessonAttachmentQuotaBytes);
+
+    final removed = await _evictMissingFiles();
+    final usage = await _currentUsage();
+
+    return AttachmentCacheSummary(
+      downloaded: downloaded,
+      skipped: skipped,
+      removed: removed,
+      totalBytes: usage,
+    );
+  }
+
+  Future<int> _enforceQuota(int quotaBytes) async {
+    if (quotaBytes <= 0) {
+      return 0;
+    }
+    final attachments = await (_db.select(_db.lessonAttachments)
+          ..where((tbl) => tbl.localPath.isNotNull())
+          ..orderBy([(tbl) => OrderingTerm(expression: tbl.downloadedAt)]))
+        .get();
+
+    var total = 0;
+    final toDelete = <LessonAttachmentRow>[];
+    for (final attachment in attachments) {
+      final size = attachment.sizeBytes ?? 0;
+      if (total + size > quotaBytes) {
+        toDelete.add(attachment);
+      } else {
+        total += size;
+      }
+    }
+
+    for (final attachment in toDelete) {
+      if (attachment.localPath != null) {
+        final file = File(attachment.localPath!);
+        if (await file.exists()) {
+          await file.delete();
+        }
+      }
+      await (_db.update(_db.lessonAttachments)
+            ..where((tbl) => tbl.lessonId.equals(attachment.lessonId) &
+                tbl.position.equals(attachment.position)))
+          .write(
+            const LessonAttachmentsCompanion(
+              localPath: Value(null),
+              sizeBytes: Value(null),
+              downloadedAt: Value(null),
+            ),
+          );
+    }
+
+    return total;
+  }
+
+  Future<int> _evictMissingFiles() async {
+    final attachments = await (_db.select(_db.lessonAttachments)
+          ..where((tbl) => tbl.localPath.isNotNull()))
+        .get();
+
+    var removed = 0;
+    for (final attachment in attachments) {
+      final path = attachment.localPath;
+      if (path == null) {
+        continue;
+      }
+      final file = File(path);
+      if (await file.exists()) {
+        continue;
+      }
+      removed++;
+      await (_db.update(_db.lessonAttachments)
+            ..where((tbl) => tbl.lessonId.equals(attachment.lessonId) &
+                tbl.position.equals(attachment.position)))
+          .write(
+            const LessonAttachmentsCompanion(
+              localPath: Value(null),
+              sizeBytes: Value(null),
+              downloadedAt: Value(null),
+            ),
+          );
+    }
+
+    return removed;
+  }
+
+  Future<int> _currentUsage() async {
+    final attachments = await (_db.select(_db.lessonAttachments)
+          ..where((tbl) => tbl.sizeBytes.isNotNull()))
+        .get();
+    return attachments.fold<int>(0, (sum, item) => sum + (item.sizeBytes ?? 0));
+  }
+
+  Future<File> _resolveFile(Directory directory, String url) async {
+    final digest = sha1.convert(utf8.encode(url)).toString();
+    final uri = Uri.parse(url);
+    final extension = p.extension(uri.path);
+    return File(p.join(directory.path, '$digest$extension'));
+  }
+
+  Future<Directory> _ensureCacheDirectory() async {
+    if (_cacheDirectory != null) {
+      return _cacheDirectory!;
+    }
+    final base = await getApplicationSupportDirectory();
+    final directory = Directory(p.join(base.path, 'lesson_attachments'));
+    if (!(await directory.exists())) {
+      await directory.create(recursive: true);
+    }
+    _cacheDirectory = directory;
+    return directory;
+  }
+
+  void dispose() {
+    _client.close();
+  }
+}
+
+extension on AttachmentCacheSummary {
+  AttachmentCacheSummary copyWith({
+    int? downloaded,
+    int? skipped,
+    int? removed,
+    int? totalBytes,
+  }) {
+    return AttachmentCacheSummary(
+      downloaded: downloaded ?? this.downloaded,
+      skipped: skipped ?? this.skipped,
+      removed: removed ?? this.removed,
+      totalBytes: totalBytes ?? this.totalBytes,
+    );
+  }
+}

--- a/lib/src/infrastructure/lessons/lesson_cache_invalidator.dart
+++ b/lib/src/infrastructure/lessons/lesson_cache_invalidator.dart
@@ -1,100 +1,34 @@
 import 'dart:async';
-import 'dart:io';
 
-import 'package:drift/drift.dart';
-import 'package:http/http.dart' as http;
-
-import '../db/app_database.dart';
-import 'lesson_ingestion_pipeline.dart';
+import 'lesson_sync_service.dart';
 
 class LessonCacheInvalidator {
   LessonCacheInvalidator(
-    this._db,
-    this._pipeline, {
-    Duration interval = const Duration(hours: 1),
-    http.Client? client,
-  })  : _interval = interval,
-        _client = client ?? http.Client();
+    this._service, {
+    Duration interval = const Duration(hours: 6),
+  }) : _interval = interval;
 
-  final AppDatabase _db;
-  final LessonIngestionPipeline _pipeline;
+  final LessonSyncService _service;
   final Duration _interval;
-  final http.Client _client;
 
   Timer? _timer;
-  bool _runningCheck = false;
+  bool _started = false;
 
   void start() {
-    _timer ??= Timer.periodic(_interval, (_) => _checkFeeds());
-    scheduleMicrotask(_checkFeeds);
-  }
-
-  Future<void> _checkFeeds() async {
-    if (_runningCheck) {
+    if (_started) {
       return;
     }
-    _runningCheck = true;
-    try {
-      final feeds = await _db.select(_db.lessonFeeds).get();
-      for (final feed in feeds) {
-        final source = feed.source;
-        if (!source.startsWith('http')) {
-          continue;
-        }
-        final uri = Uri.tryParse(source);
-        if (uri == null) {
-          continue;
-        }
-        try {
-          final response = await _client.head(uri).timeout(
-                const Duration(seconds: 10),
-              );
-          final etag = response.headers['etag'];
-          DateTime? lastModified;
-          final lastModifiedHeader = response.headers['last-modified'];
-          if (lastModifiedHeader != null) {
-            try {
-              lastModified = HttpDate.parse(lastModifiedHeader);
-            } on FormatException {
-              lastModified = null;
-            }
-          }
-
-          final hasChanged = (etag != null && etag != feed.etag) ||
-              (lastModified != null &&
-                  feed.lastModified != lastModified.millisecondsSinceEpoch);
-          if (hasChanged) {
-            await _pipeline.ingestRemoteFeed(uri, feedId: feed.id);
-          }
-
-          await _db.into(_db.lessonFeeds).insertOnConflictUpdate(
-                LessonFeedsCompanion(
-                  id: Value(feed.id),
-                  source: Value(feed.source),
-                  cohort: Value(feed.cohort),
-                  lessonClass: Value(feed.lessonClass),
-                  checksum: Value(feed.checksum),
-                  etag: Value(etag ?? feed.etag),
-                  lastModified: Value(lastModified?.millisecondsSinceEpoch ?? feed.lastModified),
-                  lastFetchedAt: Value(feed.lastFetchedAt),
-                  lastCheckedAt: Value(DateTime.now().millisecondsSinceEpoch),
-                ),
-              );
-        } on http.ClientException {
-          continue;
-        } on SocketException {
-          continue;
-        } on TimeoutException {
-          continue;
-        }
-      }
-    } finally {
-      _runningCheck = false;
-    }
+    _started = true;
+    _timer ??= Timer.periodic(_interval, (_) {
+      _service.syncAll();
+    });
+    scheduleMicrotask(() async {
+      await _service.ensureBackgroundScheduled();
+      await _service.syncAll();
+    });
   }
 
   void dispose() {
     _timer?.cancel();
-    _client.close();
   }
 }

--- a/lib/src/infrastructure/lessons/lesson_ingestion_pipeline.dart
+++ b/lib/src/infrastructure/lessons/lesson_ingestion_pipeline.dart
@@ -7,16 +7,20 @@ import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 
 import '../db/app_database.dart';
+import 'lesson_source_registry.dart';
 
 class LessonIngestionPipeline {
   LessonIngestionPipeline(
     this._db,
     this._bundle, {
+    LessonSourceRegistry? registry,
     http.Client? httpClient,
-  }) : _httpClient = httpClient ?? http.Client();
+  })  : _registry = registry,
+        _httpClient = httpClient ?? http.Client();
 
   final AppDatabase _db;
   final AssetBundle _bundle;
+  final LessonSourceRegistry? _registry;
   final http.Client _httpClient;
 
   Future<void>? _bundledIngestion;
@@ -26,6 +30,7 @@ class LessonIngestionPipeline {
   }
 
   Future<void> _ingestBundledFeeds() async {
+    await _registry?.registerBundledSources(_bundle);
     final indexJson = await _safeLoadString('assets/lessons/index.json');
     if (indexJson == null || indexJson.trim().isEmpty) {
       return;
@@ -46,27 +51,17 @@ class LessonIngestionPipeline {
       if (assetPath == null) {
         continue;
       }
-      final jsonString = await _safeLoadString(assetPath);
-      if (jsonString == null) {
-        continue;
-      }
-      final checksum = sha1.convert(utf8.encode(jsonString)).toString();
-      final parsed = _parseFeed(
-        jsonString,
-        fallbackClass: feed['class'] as String?,
-      );
-      await _persistFeed(
+      await ingestAssetFeed(
+        assetPath: assetPath,
         feedId: feed['id'] as String? ?? 'asset:$assetPath',
-        source: 'asset:$assetPath',
-        checksum: checksum,
-        cohortTitle: parsed.cohortTitle ?? feed['title'] as String?,
-        cohortClass: parsed.cohortClass ?? feed['class'] as String?,
-        lessons: parsed.lessons,
+        fallbackClass: feed['class'] as String?,
+        fallbackTitle: feed['title'] as String?,
       );
     }
   }
 
-  Future<void> ingestRemoteFeed(Uri uri, {String? feedId}) async {
+  Future<LessonFeedIngestionResult> ingestRemoteFeed(Uri uri,
+      {String? feedId}) async {
     final response = await _httpClient.get(uri);
     if (response.statusCode >= 400) {
       throw http.ClientException(
@@ -89,7 +84,14 @@ class LessonIngestionPipeline {
       }
     }
 
-    await _persistFeed(
+    final id = feedId ?? uri.toString();
+    await _registry?.upsertSource(
+      id: id,
+      type: LessonSourceType.remote,
+      location: uri.toString(),
+    );
+
+    final result = await _persistFeed(
       feedId: feedId ?? uri.toString(),
       source: uri.toString(),
       checksum: checksum,
@@ -99,9 +101,66 @@ class LessonIngestionPipeline {
       etag: response.headers['etag'],
       lastModified: lastModified,
     );
+
+    await _registry?.updateSuccess(
+      id,
+      checksum: result.checksum,
+      etag: result.etag,
+      lastModified: result.lastModified,
+      lessonCount: result.lessonCount,
+    );
+
+    return result;
   }
 
-  Future<void> _persistFeed({
+  Future<LessonFeedIngestionResult?> ingestAssetFeed({
+    required String assetPath,
+    required String feedId,
+    String? fallbackClass,
+    String? fallbackTitle,
+  }) async {
+    await _registry?.upsertSource(
+      id: feedId,
+      type: LessonSourceType.asset,
+      location: 'asset:$assetPath',
+      label: fallbackTitle,
+      lessonClass: fallbackClass,
+      cohort: fallbackTitle,
+      isBundled: true,
+    );
+
+    final jsonString = await _safeLoadString(assetPath);
+    if (jsonString == null) {
+      return null;
+    }
+
+    final checksum = sha1.convert(utf8.encode(jsonString)).toString();
+    final parsed = _parseFeed(
+      jsonString,
+      fallbackClass: fallbackClass,
+    );
+
+    final result = await _persistFeed(
+      feedId: feedId,
+      source: 'asset:$assetPath',
+      checksum: checksum,
+      cohortTitle: parsed.cohortTitle ?? fallbackTitle,
+      cohortClass: parsed.cohortClass ?? fallbackClass,
+      lessons: parsed.lessons,
+    );
+
+    if (result != null) {
+      await _registry?.updateSuccess(
+        feedId,
+        checksum: result.checksum,
+        lessonCount: result.lessonCount,
+      );
+    }
+
+    return result;
+  }
+
+  Future<LessonFeedIngestionResult?> _persistFeed({
     required String feedId,
     required String source,
     required String checksum,
@@ -114,6 +173,7 @@ class LessonIngestionPipeline {
     final now = DateTime.now().millisecondsSinceEpoch;
     final lessonIds = lessons.map((lesson) => lesson.id).toList();
 
+    LessonFeedIngestionResult? result;
     await _db.transaction(() async {
       if (lessonIds.isNotEmpty) {
         final existing = await (_db.select(_db.lessons)
@@ -163,6 +223,13 @@ class LessonIngestionPipeline {
       }
 
       if (lessons.isEmpty) {
+        result = LessonFeedIngestionResult(
+          feedId: feedId,
+          checksum: checksum,
+          lessonIds: const [],
+          etag: etag,
+          lastModified: lastModified,
+        );
         return;
       }
 
@@ -286,6 +353,16 @@ class LessonIngestionPipeline {
             lastCheckedAt: Value(now),
           ),
         );
+
+    result ??= LessonFeedIngestionResult(
+      feedId: feedId,
+      checksum: checksum,
+      lessonIds: lessonIds,
+      etag: etag,
+      lastModified: lastModified,
+    );
+
+    return result;
   }
 
   Future<String?> _safeLoadString(String assetPath) async {
@@ -469,6 +546,24 @@ class LessonIngestionPipeline {
   void dispose() {
     _httpClient.close();
   }
+}
+
+class LessonFeedIngestionResult {
+  const LessonFeedIngestionResult({
+    required this.feedId,
+    required this.checksum,
+    required this.lessonIds,
+    this.etag,
+    this.lastModified,
+  });
+
+  final String feedId;
+  final String checksum;
+  final List<String> lessonIds;
+  final String? etag;
+  final DateTime? lastModified;
+
+  int get lessonCount => lessonIds.length;
 }
 
 class _ParsedFeed {

--- a/lib/src/infrastructure/lessons/lesson_source_registry.dart
+++ b/lib/src/infrastructure/lessons/lesson_source_registry.dart
@@ -1,0 +1,205 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+import 'package:flutter/services.dart';
+
+import '../db/app_database.dart';
+import 'lesson_sync_constants.dart';
+
+class LessonSourceType {
+  const LessonSourceType._();
+
+  static const String asset = 'asset';
+  static const String remote = 'remote';
+}
+
+class LessonSourceRegistry {
+  LessonSourceRegistry(this._db);
+
+  final AppDatabase _db;
+
+  Future<void> registerBundledSources(AssetBundle bundle) async {
+    final jsonString = await _safeLoad(bundle, 'assets/lessons/index.json');
+    if (jsonString == null || jsonString.trim().isEmpty) {
+      return;
+    }
+
+    Map<String, dynamic> data;
+    try {
+      data = json.decode(jsonString) as Map<String, dynamic>;
+    } on FormatException {
+      return;
+    }
+
+    final feeds = (data['feeds'] as List<dynamic>? ?? const [])
+        .cast<Map<String, dynamic>>();
+
+    for (final feed in feeds) {
+      final assetPath = feed['assetPath'] as String?;
+      if (assetPath == null) {
+        continue;
+      }
+      final id = feed['id'] as String? ?? 'asset:$assetPath';
+      await upsertSource(
+        id: id,
+        type: LessonSourceType.asset,
+        location: 'asset:$assetPath',
+        label: feed['title'] as String?,
+        cohort: feed['title'] as String?,
+        lessonClass: feed['class'] as String?,
+        isBundled: true,
+        quotaBytes: kDefaultLessonAttachmentQuotaBytes,
+      );
+    }
+  }
+
+  Future<void> upsertSource({
+    required String id,
+    required String type,
+    required String location,
+    String? label,
+    String? cohort,
+    String? lessonClass,
+    bool isBundled = false,
+    bool enabled = true,
+    int? priority,
+    int? quotaBytes,
+  }) async {
+    final existing = await (_db.select(_db.lessonSources)
+          ..where((tbl) => tbl.id.equals(id)))
+        .getSingleOrNull();
+
+    final effectiveEnabled = existing == null
+        ? (isBundled ? true : enabled)
+        : (existing.isBundled ? true : existing.enabled);
+    final effectivePriority = priority ?? existing?.priority ?? 0;
+    final effectiveQuota = quotaBytes ?? existing?.quotaBytes;
+    final effectiveIsBundled = existing?.isBundled ?? isBundled;
+
+    await _db.into(_db.lessonSources).insertOnConflictUpdate(
+          LessonSourcesCompanion(
+            id: Value(id),
+            type: Value(type),
+            location: Value(location),
+            label: Value(label ?? existing?.label),
+            cohort: Value(cohort ?? existing?.cohort),
+            lessonClass: Value(lessonClass ?? existing?.lessonClass),
+            enabled: Value(effectiveEnabled),
+            isBundled: Value(effectiveIsBundled),
+            priority: Value(effectivePriority),
+            quotaBytes: Value(effectiveQuota),
+          ),
+        );
+  }
+
+  Future<List<LessonSourceRow>> getEnabledSources() async {
+    final query = _db.select(_db.lessonSources)
+      ..where((tbl) => tbl.enabled.equals(true))
+      ..orderBy([(tbl) => OrderingTerm(expression: tbl.priority)]);
+    return query.get();
+  }
+
+  Future<List<LessonSourceRow>> getAllSources() {
+    final query = _db.select(_db.lessonSources)
+      ..orderBy([(tbl) => OrderingTerm(expression: tbl.priority)]);
+    return query.get();
+  }
+
+  Stream<List<LessonSourceRow>> watchSources() {
+    final query = _db.select(_db.lessonSources)
+      ..orderBy([(tbl) => OrderingTerm(expression: tbl.priority)]);
+    return query.watch();
+  }
+
+  Future<void> markAttempt(String id) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await (_db.update(_db.lessonSources)
+          ..where((tbl) => tbl.id.equals(id)))
+        .write(
+          LessonSourcesCompanion(
+            lastAttemptedAt: Value(now),
+            lastError: const Value(null),
+          ),
+        );
+  }
+
+  Future<void> markChecked(
+    String id, {
+    String? etag,
+    DateTime? lastModified,
+  }) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await (_db.update(_db.lessonSources)
+          ..where((tbl) => tbl.id.equals(id)))
+        .write(
+          LessonSourcesCompanion(
+            lastCheckedAt: Value(now),
+            etag: Value(etag),
+            lastModified: Value(lastModified?.millisecondsSinceEpoch),
+          ),
+        );
+  }
+
+  Future<void> updateSuccess(
+    String id, {
+    required String checksum,
+    int? lessonCount,
+    String? etag,
+    DateTime? lastModified,
+  }) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await (_db.update(_db.lessonSources)
+          ..where((tbl) => tbl.id.equals(id)))
+        .write(
+          LessonSourcesCompanion(
+            checksum: Value(checksum),
+            lessonCount: Value(lessonCount ?? 0),
+            lastSyncedAt: Value(now),
+            lastCheckedAt: Value(now),
+            lastError: const Value(null),
+            etag: Value(etag),
+            lastModified: Value(lastModified?.millisecondsSinceEpoch),
+          ),
+        );
+  }
+
+  Future<void> updateAttachmentUsage(String id, int bytes) async {
+    await (_db.update(_db.lessonSources)
+          ..where((tbl) => tbl.id.equals(id)))
+        .write(
+          LessonSourcesCompanion(
+            attachmentBytes: Value(bytes),
+          ),
+        );
+  }
+
+  Future<void> updateError(String id, String message) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await (_db.update(_db.lessonSources)
+          ..where((tbl) => tbl.id.equals(id)))
+        .write(
+          LessonSourcesCompanion(
+            lastAttemptedAt: Value(now),
+            lastError: Value(message),
+          ),
+        );
+  }
+
+  Future<void> setEnabled(String id, bool enabled) async {
+    await (_db.update(_db.lessonSources)
+          ..where((tbl) => tbl.id.equals(id)))
+        .write(
+          LessonSourcesCompanion(
+            enabled: Value(enabled),
+          ),
+        );
+  }
+
+  Future<String?> _safeLoad(AssetBundle bundle, String assetPath) async {
+    try {
+      return await bundle.loadString(assetPath);
+    } on FlutterError {
+      return null;
+    }
+  }
+}

--- a/lib/src/infrastructure/lessons/lesson_sync_constants.dart
+++ b/lib/src/infrastructure/lessons/lesson_sync_constants.dart
@@ -1,0 +1,1 @@
+const int kDefaultLessonAttachmentQuotaBytes = 200 * 1024 * 1024; // 200 MB

--- a/lib/src/infrastructure/lessons/lesson_sync_service.dart
+++ b/lib/src/infrastructure/lessons/lesson_sync_service.dart
@@ -1,0 +1,359 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:http/http.dart' as http;
+import 'package:http_parser/http_parser.dart' as http_parser;
+import 'package:workmanager/workmanager.dart';
+
+import '../db/app_database.dart';
+import 'lesson_attachment_cache.dart';
+import 'lesson_ingestion_pipeline.dart';
+import 'lesson_source_registry.dart';
+import 'lesson_sync_constants.dart';
+
+const String kLessonSyncBackgroundTask = 'afc_lesson_sync';
+
+class LessonSyncService {
+  LessonSyncService({
+    required AssetBundle bundle,
+    required LessonIngestionPipeline pipeline,
+    required LessonSourceRegistry registry,
+    required LessonAttachmentCache attachmentCache,
+    http.Client? client,
+  })  : _bundle = bundle,
+        _pipeline = pipeline,
+        _registry = registry,
+        _attachmentCache = attachmentCache,
+        _client = client ?? http.Client();
+
+  final AssetBundle _bundle;
+  final LessonIngestionPipeline _pipeline;
+  final LessonSourceRegistry _registry;
+  final LessonAttachmentCache _attachmentCache;
+  final http.Client _client;
+
+  Future<LessonSyncSummary>? _runningSync;
+  static bool _workmanagerInitialised = false;
+
+  Future<void> ensureBackgroundScheduled() async {
+    if (!_supportsBackgroundScheduling) {
+      return;
+    }
+
+    if (!_workmanagerInitialised) {
+      try {
+        await Workmanager().initialize(
+          lessonSyncCallbackDispatcher,
+          isInDebugMode: kDebugMode,
+        );
+        _workmanagerInitialised = true;
+      } catch (_) {
+        return;
+      }
+    }
+
+    try {
+      await Workmanager().registerPeriodicTask(
+        kLessonSyncBackgroundTask,
+        kLessonSyncBackgroundTask,
+        frequency: const Duration(hours: 6),
+        initialDelay: const Duration(minutes: 15),
+        existingWorkPolicy: ExistingWorkPolicy.keep,
+        constraints: const Constraints(
+          networkType: NetworkType.connected,
+        ),
+      );
+    } catch (_) {
+      // Ignore registration errors.
+    }
+  }
+
+  Future<LessonSyncSummary> syncAll({bool force = false}) {
+    final running = _runningSync;
+    if (running != null) {
+      return running;
+    }
+
+    final completer = Completer<LessonSyncSummary>();
+    _runningSync = completer.future;
+
+    () async {
+      try {
+        await _registry.registerBundledSources(_bundle);
+        final sources = await _registry.getAllSources();
+        final results = <LessonSyncSourceResult>[];
+        for (final source in sources) {
+          if (!source.enabled) {
+            results.add(LessonSyncSourceResult(
+              sourceId: source.id,
+              type: source.type,
+              status: LessonSyncStatus.skipped,
+              message: 'Disabled',
+            ));
+            continue;
+          }
+          try {
+            final result = await _syncSource(source, force: force);
+            results.add(result);
+          } catch (error) {
+            final message = error.toString();
+            await _registry.updateError(source.id, message);
+            results.add(LessonSyncSourceResult(
+              sourceId: source.id,
+              type: source.type,
+              status: LessonSyncStatus.failed,
+              message: message,
+            ));
+          }
+        }
+        final summary = LessonSyncSummary(results: results);
+        completer.complete(summary);
+      } catch (error, stackTrace) {
+        if (!completer.isCompleted) {
+          completer.completeError(error, stackTrace);
+        }
+      } finally {
+        _runningSync = null;
+      }
+    }();
+
+    return completer.future;
+  }
+
+  Future<LessonSyncSourceResult> _syncSource(
+    LessonSourceRow source, {
+    required bool force,
+  }) async {
+    await _registry.markAttempt(source.id);
+    switch (source.type) {
+      case LessonSourceType.asset:
+        return _syncAssetSource(source, force: force);
+      case LessonSourceType.remote:
+        return _syncRemoteSource(source, force: force);
+      default:
+        final message = 'Unsupported source type ${source.type}';
+        await _registry.updateError(source.id, message);
+        return LessonSyncSourceResult(
+          sourceId: source.id,
+          type: source.type,
+          status: LessonSyncStatus.failed,
+          message: message,
+        );
+    }
+  }
+
+  Future<LessonSyncSourceResult> _syncAssetSource(
+    LessonSourceRow source, {
+    required bool force,
+  }) async {
+    final assetPath = source.location.startsWith('asset:')
+        ? source.location.substring(6)
+        : source.location;
+    final result = await _pipeline.ingestAssetFeed(
+      assetPath: assetPath,
+      feedId: source.id,
+      fallbackClass: source.lessonClass,
+      fallbackTitle: source.label ?? source.cohort,
+    );
+    if (result == null) {
+      const message = 'Bundled lesson feed missing';
+      await _registry.updateError(source.id, message);
+      return LessonSyncSourceResult(
+        sourceId: source.id,
+        type: source.type,
+        status: LessonSyncStatus.failed,
+        message: message,
+      );
+    }
+    final attachmentSummary = await _attachmentCache.ensureForLessons(
+      result.lessonIds,
+      quotaBytes: source.quotaBytes ?? kDefaultLessonAttachmentQuotaBytes,
+    );
+    await _registry.updateAttachmentUsage(
+      source.id,
+      attachmentSummary.totalBytes,
+    );
+    final message =
+        'Synced ${result.lessonCount} lessons (${attachmentSummary.downloaded} attachments updated)';
+    return LessonSyncSourceResult(
+      sourceId: source.id,
+      type: source.type,
+      status: LessonSyncStatus.success,
+      message: message,
+      attachmentSummary: attachmentSummary,
+    );
+  }
+
+  Future<LessonSyncSourceResult> _syncRemoteSource(
+    LessonSourceRow source, {
+    required bool force,
+  }) async {
+    final uri = Uri.tryParse(source.location);
+    if (uri == null) {
+      const message = 'Invalid URL';
+      await _registry.updateError(source.id, message);
+      return LessonSyncSourceResult(
+        sourceId: source.id,
+        type: source.type,
+        status: LessonSyncStatus.failed,
+        message: message,
+      );
+    }
+
+    bool shouldDownload = true;
+    if (!force) {
+      try {
+        final response = await _client.head(uri).timeout(
+              const Duration(seconds: 10),
+            );
+        final etag = response.headers['etag'];
+        DateTime? lastModified;
+        final lastModifiedHeader = response.headers['last-modified'];
+        if (lastModifiedHeader != null) {
+          try {
+            lastModified = http_parser.parseHttpDate(lastModifiedHeader);
+          } catch (_) {
+            lastModified = null;
+          }
+        }
+
+        final unchanged = response.statusCode == 304 ||
+            (etag != null && etag == source.etag) ||
+            (lastModified != null &&
+                source.lastModified != null &&
+                source.lastModified == lastModified.millisecondsSinceEpoch);
+        if (unchanged) {
+          await _registry.markChecked(
+            source.id,
+            etag: etag ?? source.etag,
+            lastModified: lastModified ??
+                (source.lastModified == null
+                    ? null
+                    : DateTime.fromMillisecondsSinceEpoch(source.lastModified!)),
+          );
+          shouldDownload = false;
+        }
+      } on TimeoutException {
+        // ignore
+      } on http.ClientException {
+        // ignore
+      } catch (_) {
+        // ignore other errors and proceed to download
+      }
+    }
+
+    if (!shouldDownload) {
+      return LessonSyncSourceResult(
+        sourceId: source.id,
+        type: source.type,
+        status: LessonSyncStatus.skipped,
+        message: 'Up to date',
+      );
+    }
+
+    try {
+      final result = await _pipeline.ingestRemoteFeed(uri, feedId: source.id);
+      final attachmentSummary = await _attachmentCache.ensureForLessons(
+        result.lessonIds,
+        quotaBytes: source.quotaBytes ?? kDefaultLessonAttachmentQuotaBytes,
+      );
+      await _registry.updateAttachmentUsage(
+        source.id,
+        attachmentSummary.totalBytes,
+      );
+      final message =
+          'Fetched ${result.lessonCount} lessons (${attachmentSummary.downloaded} attachments updated)';
+      return LessonSyncSourceResult(
+        sourceId: source.id,
+        type: source.type,
+        status: LessonSyncStatus.success,
+        message: message,
+        attachmentSummary: attachmentSummary,
+      );
+    } catch (error) {
+      await _registry.updateError(source.id, error.toString());
+      return LessonSyncSourceResult(
+        sourceId: source.id,
+        type: source.type,
+        status: LessonSyncStatus.failed,
+        message: error.toString(),
+      );
+    }
+  }
+
+  void dispose() {
+    _client.close();
+    _attachmentCache.dispose();
+  }
+
+  bool get _supportsBackgroundScheduling {
+    if (kIsWeb) {
+      return false;
+    }
+    final platform = defaultTargetPlatform;
+    return platform == TargetPlatform.android || platform == TargetPlatform.iOS;
+  }
+}
+
+class LessonSyncSummary {
+  LessonSyncSummary({required this.results});
+
+  final List<LessonSyncSourceResult> results;
+
+  int get successCount =>
+      results.where((result) => result.status == LessonSyncStatus.success).length;
+  int get failureCount =>
+      results.where((result) => result.status == LessonSyncStatus.failed).length;
+  List<LessonSyncSourceResult> get failedSources => results
+      .where((result) => result.status == LessonSyncStatus.failed)
+      .toList();
+}
+
+enum LessonSyncStatus { success, skipped, failed }
+
+class LessonSyncSourceResult {
+  LessonSyncSourceResult({
+    required this.sourceId,
+    required this.type,
+    required this.status,
+    required this.message,
+    this.attachmentSummary,
+  });
+
+  final String sourceId;
+  final String type;
+  final LessonSyncStatus status;
+  final String message;
+  final AttachmentCacheSummary? attachmentSummary;
+}
+
+@pragma('vm:entry-point')
+void lessonSyncCallbackDispatcher() {
+  Workmanager().executeTask((task, inputData) async {
+    WidgetsFlutterBinding.ensureInitialized();
+    DartPluginRegistrant.ensureInitialized();
+
+    final db = AppDatabase();
+    final registry = LessonSourceRegistry(db);
+    final cache = LessonAttachmentCache(db);
+    final pipeline = LessonIngestionPipeline(db, rootBundle, registry: registry);
+    final service = LessonSyncService(
+      bundle: rootBundle,
+      pipeline: pipeline,
+      registry: registry,
+      attachmentCache: cache,
+    );
+
+    try {
+      final summary = await service.syncAll();
+      service.dispose();
+      await db.close();
+      return summary.failureCount == 0;
+    } catch (_) {
+      service.dispose();
+      await db.close();
+      return false;
+    }
+  });
+}

--- a/lib/src/presentation/lessons/lesson_detail_screen.dart
+++ b/lib/src/presentation/lessons/lesson_detail_screen.dart
@@ -104,7 +104,14 @@ class LessonDetailScreen extends StatelessWidget {
                   child: ListTile(
                     leading: Icon(_iconForAttachment(attachment.type)),
                     title: Text(attachment.title ?? attachment.url),
-                    subtitle: Text(attachment.url),
+                    subtitle: Text(
+                      attachment.localPath == null
+                          ? attachment.url
+                          : 'Available offline · ${attachment.url}',
+                    ),
+                    trailing: attachment.localPath == null
+                        ? null
+                        : const Icon(Icons.offline_pin, size: 18),
                     onTap: () {
                       // Attachments currently open externally; integration can be added later.
                     },

--- a/lib/src/presentation/providers.dart
+++ b/lib/src/presentation/providers.dart
@@ -41,9 +41,13 @@ import '../infrastructure/db/daos/bible_dao.dart';
 import '../infrastructure/db/daos/chat_dao.dart';
 import '../infrastructure/db/daos/lesson_dao.dart';
 import '../infrastructure/db/daos/sync_dao.dart';
+import '../infrastructure/lessons/lesson_attachment_cache.dart';
 import '../infrastructure/lessons/lesson_cache_invalidator.dart';
 import '../infrastructure/lessons/lesson_ingestion_pipeline.dart';
+import '../infrastructure/lessons/lesson_source_registry.dart';
+import '../infrastructure/lessons/lesson_sync_service.dart';
 import 'settings/bible_import_controller.dart';
+import 'settings/lesson_sync_controller.dart';
 
 final appDatabaseProvider = Provider<AppDatabase>((ref) {
   final db = AppDatabase();
@@ -59,11 +63,41 @@ final chatDaoProvider = Provider((ref) => ChatDao(ref.watch(appDatabaseProvider)
 final annotationDaoProvider =
     Provider((ref) => AnnotationDao(ref.watch(appDatabaseProvider)));
 
+final lessonSourceRegistryProvider = Provider<LessonSourceRegistry>((ref) {
+  final db = ref.watch(appDatabaseProvider);
+  return LessonSourceRegistry(db);
+});
+
 final lessonIngestionPipelineProvider = Provider<LessonIngestionPipeline>((ref) {
   final db = ref.watch(appDatabaseProvider);
-  final pipeline = LessonIngestionPipeline(db, rootBundle);
+  final registry = ref.watch(lessonSourceRegistryProvider);
+  final pipeline = LessonIngestionPipeline(db, rootBundle, registry: registry);
   ref.onDispose(pipeline.dispose);
   return pipeline;
+});
+
+final lessonSyncServiceProvider = Provider<LessonSyncService>((ref) {
+  final db = ref.watch(appDatabaseProvider);
+  final pipeline = ref.watch(lessonIngestionPipelineProvider);
+  final registry = ref.watch(lessonSourceRegistryProvider);
+  final attachmentCache = LessonAttachmentCache(db);
+  final service = LessonSyncService(
+    bundle: rootBundle,
+    pipeline: pipeline,
+    registry: registry,
+    attachmentCache: attachmentCache,
+  );
+  ref.onDispose(service.dispose);
+  return service;
+});
+
+final lessonSyncControllerProvider =
+    StateNotifierProvider<LessonSyncController, LessonSyncState>((ref) {
+  final registry = ref.watch(lessonSourceRegistryProvider);
+  final service = ref.watch(lessonSyncServiceProvider);
+  final controller = LessonSyncController(registry, service);
+  ref.onDispose(controller.dispose);
+  return controller;
 });
 
 final bibleRepositoryProvider = Provider<BibleRepository>((ref) {
@@ -80,9 +114,8 @@ final lessonRepositoryProvider = Provider<LessonRepository>((ref) {
 });
 
 final lessonCacheInvalidatorProvider = Provider<LessonCacheInvalidator>((ref) {
-  final db = ref.watch(appDatabaseProvider);
-  final pipeline = ref.watch(lessonIngestionPipelineProvider);
-  final invalidator = LessonCacheInvalidator(db, pipeline);
+  final service = ref.watch(lessonSyncServiceProvider);
+  final invalidator = LessonCacheInvalidator(service);
   invalidator.start();
   ref.onDispose(invalidator.dispose);
   return invalidator;

--- a/lib/src/presentation/settings/lesson_sync_controller.dart
+++ b/lib/src/presentation/settings/lesson_sync_controller.dart
@@ -1,0 +1,159 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../infrastructure/db/app_database.dart';
+import '../../infrastructure/lessons/lesson_source_registry.dart';
+import '../../infrastructure/lessons/lesson_sync_service.dart';
+
+class LessonSyncState {
+  const LessonSyncState({
+    this.isSyncing = false,
+    this.lastRun,
+    this.lastError,
+    this.sources = const [],
+  });
+
+  final bool isSyncing;
+  final DateTime? lastRun;
+  final String? lastError;
+  final List<LessonSourceStatus> sources;
+
+  LessonSyncState copyWith({
+    bool? isSyncing,
+    DateTime? lastRun,
+    String? lastError,
+    bool lastErrorSet = false,
+    List<LessonSourceStatus>? sources,
+  }) {
+    return LessonSyncState(
+      isSyncing: isSyncing ?? this.isSyncing,
+      lastRun: lastRun ?? this.lastRun,
+      lastError: lastErrorSet ? lastError : this.lastError,
+      sources: sources ?? this.sources,
+    );
+  }
+}
+
+class LessonSourceStatus {
+  LessonSourceStatus({
+    required this.id,
+    required this.type,
+    required this.location,
+    required this.enabled,
+    required this.isBundled,
+    this.label,
+    this.cohort,
+    this.lessonClass,
+    this.checksum,
+    this.lessonCount,
+    this.lastSyncedAt,
+    this.lastAttemptedAt,
+    this.lastCheckedAt,
+    this.lastError,
+    this.attachmentBytes = 0,
+    this.quotaBytes,
+  });
+
+  final String id;
+  final String type;
+  final String location;
+  final bool enabled;
+  final bool isBundled;
+  final String? label;
+  final String? cohort;
+  final String? lessonClass;
+  final String? checksum;
+  final int? lessonCount;
+  final DateTime? lastSyncedAt;
+  final DateTime? lastAttemptedAt;
+  final DateTime? lastCheckedAt;
+  final String? lastError;
+  final int attachmentBytes;
+  final int? quotaBytes;
+
+  String get displayName => label ?? cohort ?? id;
+}
+
+class LessonSyncController extends StateNotifier<LessonSyncState> {
+  LessonSyncController(this._registry, this._service)
+      : super(const LessonSyncState()) {
+    _subscription = _registry.watchSources().listen(_onSources);
+    _loadInitial();
+  }
+
+  final LessonSourceRegistry _registry;
+  final LessonSyncService _service;
+  StreamSubscription<List<LessonSourceRow>>? _subscription;
+
+  Future<void> _loadInitial() async {
+    final rows = await _registry.getAllSources();
+    state = state.copyWith(sources: rows.map(_mapRow).toList());
+  }
+
+  void _onSources(List<LessonSourceRow> rows) {
+    state = state.copyWith(sources: rows.map(_mapRow).toList());
+  }
+
+  LessonSourceStatus _mapRow(LessonSourceRow row) {
+    DateTime? convert(int? millis) {
+      if (millis == null) return null;
+      return DateTime.fromMillisecondsSinceEpoch(millis);
+    }
+
+    return LessonSourceStatus(
+      id: row.id,
+      type: row.type,
+      location: row.location,
+      enabled: row.enabled,
+      isBundled: row.isBundled,
+      label: row.label,
+      cohort: row.cohort,
+      lessonClass: row.lessonClass,
+      checksum: row.checksum,
+      lessonCount: row.lessonCount,
+      lastSyncedAt: convert(row.lastSyncedAt),
+      lastAttemptedAt: convert(row.lastAttemptedAt),
+      lastCheckedAt: convert(row.lastCheckedAt),
+      lastError: row.lastError,
+      attachmentBytes: row.attachmentBytes,
+      quotaBytes: row.quotaBytes,
+    );
+  }
+
+  Future<void> syncNow() async {
+    if (state.isSyncing) {
+      return;
+    }
+    state = state.copyWith(isSyncing: true, lastError: null, lastErrorSet: true);
+    try {
+      final summary = await _service.syncAll(force: true);
+      final error = summary.failureCount > 0
+          ? '${summary.failureCount} source(s) failed to sync'
+          : null;
+      state = state.copyWith(
+        isSyncing: false,
+        lastRun: DateTime.now(),
+        lastError: error,
+        lastErrorSet: true,
+      );
+    } catch (error) {
+      state = state.copyWith(
+        isSyncing: false,
+        lastRun: DateTime.now(),
+        lastError: error.toString(),
+        lastErrorSet: true,
+      );
+    }
+  }
+
+  Future<void> toggleSource(String id, bool enabled) {
+    return _registry.setEnabled(id, enabled);
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/src/presentation/settings/settings_screen.dart
+++ b/lib/src/presentation/settings/settings_screen.dart
@@ -7,9 +7,11 @@ import 'package:share_plus/share_plus.dart';
 
 import '../../domain/bible/import/exceptions.dart';
 import '../../domain/bible/import/import_models.dart';
+import '../../infrastructure/lessons/lesson_source_registry.dart';
 import '../providers.dart';
 import 'bible_import_controller.dart';
 import 'about_screen.dart';
+import 'lesson_sync_controller.dart';
 import 'privacy_policy_screen.dart';
 
 class SettingsScreen extends ConsumerWidget {
@@ -19,6 +21,7 @@ class SettingsScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final themeModeAsync = ref.watch(themeModeControllerProvider);
     final translationsAsync = ref.watch(translationsProvider);
+    final syncState = ref.watch(lessonSyncControllerProvider);
     final importState = ref.watch(bibleImportControllerProvider);
 
     ref.listen<BibleImportState>(bibleImportControllerProvider,
@@ -131,7 +134,7 @@ class SettingsScreen extends ConsumerWidget {
                   ),
                 ],
               ),
-            ),
+          ),
           translationsAsync.when(
             data: (translations) => Column(
               children: [
@@ -163,6 +166,48 @@ class SettingsScreen extends ConsumerWidget {
               child: Text('Failed to load translations: $error'),
             ),
           ),
+          const Divider(),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+            child: Text('Lessons'),
+          ),
+          ListTile(
+            leading: const Icon(Icons.sync_outlined),
+            title: const Text('Sync lessons'),
+            subtitle: Text(_buildSyncSubtitle(syncState)),
+            trailing: syncState.isSyncing
+                ? const SizedBox(
+                    height: 20,
+                    width: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : IconButton(
+                    icon: const Icon(Icons.refresh),
+                    onPressed: () => ref
+                        .read(lessonSyncControllerProvider.notifier)
+                        .syncNow(),
+                  ),
+            enabled: !syncState.isSyncing,
+            onTap: syncState.isSyncing
+                ? null
+                : () => ref
+                    .read(lessonSyncControllerProvider.notifier)
+                    .syncNow(),
+          ),
+          if (syncState.lastError != null)
+            Padding(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0),
+              child: Text(
+                syncState.lastError!,
+                style: Theme.of(context)
+                    .textTheme
+                    .bodySmall
+                    ?.copyWith(color: Theme.of(context).colorScheme.error),
+              ),
+            ),
+          for (final status in syncState.sources)
+            _LessonSourceTile(status: status),
           const Divider(),
           const Padding(
             padding: EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
@@ -269,6 +314,103 @@ class SettingsScreen extends ConsumerWidget {
           ],
         );
       },
+    );
+  }
+}
+
+String _buildSyncSubtitle(LessonSyncState state) {
+  final parts = <String>[];
+  if (state.isSyncing) {
+    parts.add('Sync in progress…');
+  } else if (state.lastRun != null) {
+    parts.add('Last sync: ${_formatTimestamp(state.lastRun!)}');
+  } else {
+    parts.add('Not yet synced');
+  }
+  return parts.join(' • ');
+}
+
+String _formatTimestamp(DateTime timestamp) {
+  final now = DateTime.now();
+  final difference = now.difference(timestamp);
+  if (difference.inMinutes < 1) {
+    return 'just now';
+  } else if (difference.inHours < 1) {
+    return '${difference.inMinutes} minute${difference.inMinutes == 1 ? '' : 's'} ago';
+  } else if (difference.inDays < 1) {
+    return '${difference.inHours} hour${difference.inHours == 1 ? '' : 's'} ago';
+  }
+  return '${timestamp.year}-${timestamp.month.toString().padLeft(2, '0')}-${timestamp.day.toString().padLeft(2, '0')}';
+}
+
+String _formatBytes(int bytes) {
+  if (bytes <= 0) {
+    return '0 B';
+  }
+  const units = ['B', 'KB', 'MB', 'GB'];
+  var size = bytes.toDouble();
+  var unitIndex = 0;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex++;
+  }
+  return '${size.toStringAsFixed(unitIndex == 0 ? 0 : 1)} ${units[unitIndex]}';
+}
+
+class _LessonSourceTile extends ConsumerWidget {
+  const _LessonSourceTile({required this.status});
+
+  final LessonSourceStatus status;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final checksumLabel = status.checksum == null || status.checksum!.isEmpty
+        ? '—'
+        : status.checksum!.substring(
+            0,
+            status.checksum!.length < 7 ? status.checksum!.length : 7,
+          );
+    final subtitle = <Widget>[
+      Text(
+        'Last sync: ${status.lastSyncedAt == null ? '—' : _formatTimestamp(status.lastSyncedAt!)}',
+        style: theme.textTheme.bodySmall,
+      ),
+      Text(
+        'Version: $checksumLabel',
+        style: theme.textTheme.bodySmall,
+      ),
+      Text(
+        'Attachments: ${_formatBytes(status.attachmentBytes)} cached',
+        style: theme.textTheme.bodySmall,
+      ),
+    ];
+    if (status.lastError != null && status.lastError!.isNotEmpty) {
+      subtitle.add(
+        Text(
+          'Error: ${status.lastError}',
+          style: theme.textTheme.bodySmall
+              ?.copyWith(color: theme.colorScheme.error),
+        ),
+      );
+    }
+    return SwitchListTile.adaptive(
+      title: Text(status.displayName),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: subtitle,
+      ),
+      secondary: Icon(
+        status.type == LessonSourceType.remote
+            ? Icons.cloud_download_outlined
+            : Icons.folder_copy_outlined,
+      ),
+      value: status.enabled,
+      onChanged: status.isBundled
+          ? null
+          : (value) => ref
+              .read(lessonSyncControllerProvider.notifier)
+              .toggleSource(status.id, value),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   file_picker: ^8.1.2
   crypto: ^3.0.3
   rxdart: ^0.28.0
+  workmanager: ^0.5.2
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- extend the Drift schema with a `lesson_sources` registry and local attachment metadata plus helpers to manage source status and cache usage
- add a reusable lesson sync service that schedules Workmanager background jobs, validates feeds, and downloads attachment content with quota management
- expose manual sync controls in settings, surface per-source status, and show offline availability for lesson attachments

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df7ec51da8832092aafb399b4f9261