### PR TITLE
Add drift-backed lesson progress tracking and dashboards

### DIFF
--- a/lib/src/data/lessons/lesson_repository_impl.dart
+++ b/lib/src/data/lessons/lesson_repository_impl.dart
@@ -59,6 +59,12 @@ class LessonRepositoryImpl implements LessonRepository {
       status: Value(progress.status),
       quizScore: Value(progress.quizScore),
       timeSpentSeconds: Value(progress.timeSpentSeconds),
+      startedAt: progress.startedAt == null
+          ? const Value.absent()
+          : Value(progress.startedAt!.millisecondsSinceEpoch),
+      completedAt: progress.completedAt == null
+          ? const Value.absent()
+          : Value(progress.completedAt!.millisecondsSinceEpoch),
       updatedAt: Value(progress.updatedAt.millisecondsSinceEpoch),
     );
     return _dao.upsertProgress(companion);
@@ -191,6 +197,12 @@ class LessonRepositoryImpl implements LessonRepository {
             quizScore: row.quizScore,
             timeSpentSeconds: row.timeSpentSeconds,
             updatedAt: DateTime.fromMillisecondsSinceEpoch(row.updatedAt),
+            startedAt: row.startedAt == null
+                ? null
+                : DateTime.fromMillisecondsSinceEpoch(row.startedAt!),
+            completedAt: row.completedAt == null
+                ? null
+                : DateTime.fromMillisecondsSinceEpoch(row.completedAt!),
           ),
         )
         .toList();

--- a/lib/src/domain/lessons/entities.dart
+++ b/lib/src/domain/lessons/entities.dart
@@ -97,6 +97,8 @@ class LessonProgress {
   final double? quizScore;
   final int timeSpentSeconds;
   final DateTime updatedAt;
+  final DateTime? startedAt;
+  final DateTime? completedAt;
 
   const LessonProgress({
     required this.id,
@@ -106,7 +108,38 @@ class LessonProgress {
     this.quizScore,
     this.timeSpentSeconds = 0,
     required this.updatedAt,
+    this.startedAt,
+    this.completedAt,
   });
+
+  LessonProgress copyWith({
+    String? id,
+    String? userId,
+    String? lessonId,
+    String? status,
+    double? quizScore,
+    bool removeQuizScore = false,
+    int? timeSpentSeconds,
+    DateTime? updatedAt,
+    DateTime? startedAt,
+    bool removeStartedAt = false,
+    DateTime? completedAt,
+    bool removeCompletedAt = false,
+  }) {
+    return LessonProgress(
+      id: id ?? this.id,
+      userId: userId ?? this.userId,
+      lessonId: lessonId ?? this.lessonId,
+      status: status ?? this.status,
+      quizScore: removeQuizScore ? null : quizScore ?? this.quizScore,
+      timeSpentSeconds: timeSpentSeconds ?? this.timeSpentSeconds,
+      updatedAt: updatedAt ?? this.updatedAt,
+      startedAt:
+          removeStartedAt ? null : startedAt ?? this.startedAt,
+      completedAt:
+          removeCompletedAt ? null : completedAt ?? this.completedAt,
+    );
+  }
 }
 
 enum LessonCompletionFilter { all, notStarted, inProgress, completed }

--- a/lib/src/domain/lessons/progress_dashboard.dart
+++ b/lib/src/domain/lessons/progress_dashboard.dart
@@ -1,0 +1,59 @@
+import 'entities.dart';
+
+class LessonProgressSnapshot {
+  const LessonProgressSnapshot({
+    required this.lesson,
+    required this.progress,
+  });
+
+  final Lesson lesson;
+  final LessonProgress? progress;
+}
+
+class LessonClassSummary {
+  const LessonClassSummary({
+    required this.lessonClass,
+    required this.totalLessons,
+    required this.completedLessons,
+    required this.inProgressLessons,
+    required this.notStartedLessons,
+    required this.totalTimeSpentSeconds,
+    required this.averageQuizScore,
+  });
+
+  final String lessonClass;
+  final int totalLessons;
+  final int completedLessons;
+  final int inProgressLessons;
+  final int notStartedLessons;
+  final int totalTimeSpentSeconds;
+  final double averageQuizScore;
+}
+
+class LessonProgressDashboardData {
+  const LessonProgressDashboardData({
+    required this.snapshots,
+    required this.completedCount,
+    required this.inProgressCount,
+    required this.notStartedCount,
+    required this.totalTimeSpentSeconds,
+    required this.averageQuizScore,
+    required this.classSummaries,
+    required this.completionsByDay,
+  });
+
+  final List<LessonProgressSnapshot> snapshots;
+  final int completedCount;
+  final int inProgressCount;
+  final int notStartedCount;
+  final int totalTimeSpentSeconds;
+  final double averageQuizScore;
+  final List<LessonClassSummary> classSummaries;
+  final Map<DateTime, int> completionsByDay;
+
+  int get totalLessons =>
+      completedCount + inProgressCount + notStartedCount;
+
+  double get completionRate =>
+      totalLessons == 0 ? 0 : completedCount / totalLessons;
+}

--- a/lib/src/domain/lessons/services/lesson_quiz_grader.dart
+++ b/lib/src/domain/lessons/services/lesson_quiz_grader.dart
@@ -1,0 +1,58 @@
+import '../entities.dart';
+
+typedef LessonQuizResponses = Map<String, LessonQuizSubmission>;
+
+class LessonQuizSubmission {
+  const LessonQuizSubmission({
+    this.selectedOptions = const <String>{},
+    this.shortAnswer,
+  });
+
+  final Set<String> selectedOptions;
+  final String? shortAnswer;
+}
+
+class LessonQuizGrader {
+  const LessonQuizGrader();
+
+  double grade(List<LessonQuiz> quizzes, LessonQuizResponses responses) {
+    if (quizzes.isEmpty) {
+      return 0;
+    }
+    var earned = 0.0;
+    for (final quiz in quizzes) {
+      final response = responses[quiz.id];
+      if (response == null) {
+        continue;
+      }
+      switch (quiz.type) {
+        case LessonQuizType.mcq:
+        case LessonQuizType.trueFalse:
+          if (quiz.answers.isEmpty) {
+            continue;
+          }
+          if (quiz.answers.toSet().containsAll(response.selectedOptions) &&
+              response.selectedOptions.length == quiz.answers.length) {
+            earned += 1;
+          }
+          break;
+        case LessonQuizType.shortAnswer:
+          if (quiz.answers.isEmpty) {
+            continue;
+          }
+          final normalizedExpected = quiz.answers
+              .map((answer) => answer.trim().toLowerCase())
+              .toSet();
+          final submission = response.shortAnswer?.trim().toLowerCase();
+          if (submission != null && normalizedExpected.contains(submission)) {
+            earned += 1;
+          }
+          break;
+      }
+    }
+    if (earned == 0) {
+      return 0;
+    }
+    return earned / quizzes.length;
+  }
+}

--- a/lib/src/domain/lessons/services/lesson_timer_service.dart
+++ b/lib/src/domain/lessons/services/lesson_timer_service.dart
@@ -1,0 +1,65 @@
+import 'dart:async';
+
+class LessonTimerService {
+  LessonTimerService();
+
+  final Stopwatch _stopwatch = Stopwatch();
+  Timer? _ticker;
+  final _tickController = StreamController<int>.broadcast();
+  int _accumulatedSeconds = 0;
+
+  Stream<int> get ticks => _tickController.stream;
+
+  bool get isRunning => _stopwatch.isRunning;
+
+  int get elapsedSeconds => _accumulatedSeconds + _stopwatch.elapsed.inSeconds;
+
+  void start() {
+    if (_stopwatch.isRunning) {
+      return;
+    }
+    _stopwatch.start();
+    _tickController.add(elapsedSeconds);
+    _ticker ??= Timer.periodic(const Duration(seconds: 1), (_) {
+      _tickController.add(elapsedSeconds);
+    });
+  }
+
+  void resume() => start();
+
+  int pause() {
+    if (!_stopwatch.isRunning) {
+      return elapsedSeconds;
+    }
+    _stopwatch.stop();
+    _accumulatedSeconds += _stopwatch.elapsed.inSeconds;
+    _stopwatch.reset();
+    _tickController.add(elapsedSeconds);
+    _ticker?.cancel();
+    _ticker = null;
+    return _accumulatedSeconds;
+  }
+
+  int consume() {
+    pause();
+    final total = _accumulatedSeconds;
+    _accumulatedSeconds = 0;
+    _tickController.add(0);
+    return total;
+  }
+
+  void reset() {
+    _stopwatch
+      ..stop()
+      ..reset();
+    _accumulatedSeconds = 0;
+    _ticker?.cancel();
+    _ticker = null;
+    _tickController.add(0);
+  }
+
+  void dispose() {
+    _ticker?.cancel();
+    _tickController.close();
+  }
+}

--- a/lib/src/infrastructure/db/app_database.dart
+++ b/lib/src/infrastructure/db/app_database.dart
@@ -229,6 +229,8 @@ class Progress extends Table {
   TextColumn get status => text()();
   RealColumn get quizScore => real().nullable()();
   IntColumn get timeSpentSeconds => integer().withDefault(const Constant(0))();
+  IntColumn get startedAt => integer().nullable()();
+  IntColumn get completedAt => integer().nullable()();
   IntColumn get updatedAt => integer()();
 
   @override
@@ -307,7 +309,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 5;
+  int get schemaVersion => 6;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -340,6 +342,10 @@ class AppDatabase extends _$AppDatabase {
             await m.addColumn(
                 lessonAttachments, lessonAttachments.downloadedAt);
             await m.createTable(lessonSources);
+          }
+          if (from < 6) {
+            await m.addColumn(progress, progress.startedAt);
+            await m.addColumn(progress, progress.completedAt);
           }
         },
       );

--- a/lib/src/infrastructure/db/app_database.g.dart
+++ b/lib/src/infrastructure/db/app_database.g.dart
@@ -51,5 +51,5 @@ class _$AppDatabase extends GeneratedDatabase {
       throw UnimplementedError('Run build_runner to generate table bindings.');
 
   @override
-  int get schemaVersion => 5;
+  int get schemaVersion => 6;
 }

--- a/lib/src/presentation/lessons/lesson_detail_screen.dart
+++ b/lib/src/presentation/lessons/lesson_detail_screen.dart
@@ -1,22 +1,100 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../domain/lessons/entities.dart';
+import '../../domain/lessons/services/lesson_quiz_grader.dart';
+import '../../domain/lessons/services/lesson_timer_service.dart';
+import '../providers.dart';
 
-class LessonDetailScreen extends StatelessWidget {
+class LessonDetailScreen extends ConsumerStatefulWidget {
   const LessonDetailScreen({super.key, required this.lesson});
 
   final Lesson lesson;
 
   @override
+  ConsumerState<LessonDetailScreen> createState() =>
+      _LessonDetailScreenState();
+}
+
+class _LessonDetailScreenState extends ConsumerState<LessonDetailScreen> {
+  static const _userId = 'local-user';
+
+  LessonProgress? _progress;
+  late LessonTimerService _timerService;
+  StreamSubscription<int>? _timerSub;
+  int _sessionSeconds = 0;
+  Map<String, LessonQuizSubmission> _responses = const {};
+  double? _lastQuizScore;
+  bool _isPersisting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _timerService =
+        ref.read(lessonTimerServiceProvider(widget.lesson.id));
+    _timerSub = _timerService.ticks.listen((seconds) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _sessionSeconds = seconds;
+      });
+    });
+    ref.listen<AsyncValue<LessonProgress?>>(
+      lessonProgressProvider(
+        LessonProgressRequest(
+          userId: _userId,
+          lessonId: widget.lesson.id,
+        ),
+      ),
+      (previous, next) {
+        next.whenData((value) {
+          if (!mounted) {
+            return;
+          }
+          setState(() {
+            _progress = value;
+          });
+        });
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _timerSub?.cancel();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final ageLabel = lesson.ageRange != null
-        ? '${lesson.ageRange!.min}-${lesson.ageRange!.max} years'
+    final ageLabel = widget.lesson.ageRange != null
+        ? '${widget.lesson.ageRange!.min}-${widget.lesson.ageRange!.max} years'
         : 'All ages';
+    final progressAsync = ref.watch(
+      lessonProgressProvider(
+        LessonProgressRequest(
+          userId: _userId,
+          lessonId: widget.lesson.id,
+        ),
+      ),
+    );
+    final progress = progressAsync.maybeWhen(
+      data: (value) => value,
+      orElse: () => _progress,
+    );
+    final status = progress?.status ?? 'not_started';
+    final totalSeconds = (progress?.timeSpentSeconds ?? 0) +
+        (_timerService.isRunning ? _sessionSeconds : 0);
+    final quizScore = progress?.quizScore ?? _lastQuizScore;
+
     return Scaffold(
       appBar: AppBar(
-        title: Text(lesson.title),
+        title: Text(widget.lesson.title),
       ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
@@ -24,7 +102,7 @@ class LessonDetailScreen extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              lesson.lessonClass,
+              widget.lesson.lessonClass,
               style: theme.textTheme.titleMedium,
             ),
             const SizedBox(height: 4),
@@ -32,11 +110,32 @@ class LessonDetailScreen extends StatelessWidget {
               ageLabel,
               style: theme.textTheme.bodySmall,
             ),
-            if (lesson.objectives.isNotEmpty) ...[
-              const SizedBox(height: 16),
+            const SizedBox(height: 16),
+            _ProgressOverviewCard(
+              status: status,
+              totalSeconds: totalSeconds,
+              startedAt: progress?.startedAt,
+              completedAt: progress?.completedAt,
+              updatedAt: progress?.updatedAt,
+              quizScore: quizScore,
+              isTimerRunning: _timerService.isRunning,
+              sessionSeconds: _sessionSeconds,
+              onStart: _isPersisting || _timerService.isRunning
+                  ? null
+                  : () =>
+                      _handleStart(clearCompletion: status == 'completed'),
+              onPause: _isPersisting || !_timerService.isRunning
+                  ? null
+                  : _handlePause,
+              onComplete: _isPersisting || status == 'completed'
+                  ? null
+                  : _handleComplete,
+            ),
+            if (widget.lesson.objectives.isNotEmpty) ...[
+              const SizedBox(height: 24),
               Text('Objectives', style: theme.textTheme.titleMedium),
               const SizedBox(height: 8),
-              ...lesson.objectives.map(
+              ...widget.lesson.objectives.map(
                 (objective) => Padding(
                   padding: const EdgeInsets.symmetric(vertical: 4),
                   child: Row(
@@ -49,14 +148,14 @@ class LessonDetailScreen extends StatelessWidget {
                 ),
               ),
             ],
-            if (lesson.scriptures.isNotEmpty) ...[
-              const SizedBox(height: 16),
+            if (widget.lesson.scriptures.isNotEmpty) ...[
+              const SizedBox(height: 24),
               Text('Scriptures', style: theme.textTheme.titleMedium),
               const SizedBox(height: 8),
               Wrap(
                 spacing: 8,
                 runSpacing: 4,
-                children: lesson.scriptures
+                children: widget.lesson.scriptures
                     .map(
                       (scripture) => Chip(
                         label: Text(scripture.reference),
@@ -74,12 +173,14 @@ class LessonDetailScreen extends StatelessWidget {
                     .toList(),
               ),
             ],
-            const SizedBox(height: 16),
-            if (lesson.contentHtml != null && lesson.contentHtml!.trim().isNotEmpty)
-              Html(data: lesson.contentHtml)
+            const SizedBox(height: 24),
+            if (widget.lesson.contentHtml != null &&
+                widget.lesson.contentHtml!.trim().isNotEmpty)
+              Html(data: widget.lesson.contentHtml)
             else
               const Text('This lesson does not have content yet.'),
-            if (lesson.teacherNotes != null && lesson.teacherNotes!.trim().isNotEmpty) ...[
+            if (widget.lesson.teacherNotes != null &&
+                widget.lesson.teacherNotes!.trim().isNotEmpty) ...[
               const SizedBox(height: 24),
               Card(
                 child: Padding(
@@ -87,19 +188,20 @@ class LessonDetailScreen extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text('Teacher Notes', style: theme.textTheme.titleMedium),
+                      Text('Teacher Notes',
+                          style: theme.textTheme.titleMedium),
                       const SizedBox(height: 8),
-                      Html(data: lesson.teacherNotes),
+                      Html(data: widget.lesson.teacherNotes),
                     ],
                   ),
                 ),
               ),
             ],
-            if (lesson.attachments.isNotEmpty) ...[
+            if (widget.lesson.attachments.isNotEmpty) ...[
               const SizedBox(height: 24),
               Text('Attachments', style: theme.textTheme.titleMedium),
               const SizedBox(height: 8),
-              ...lesson.attachments.map(
+              ...widget.lesson.attachments.map(
                 (attachment) => Card(
                   child: ListTile(
                     leading: Icon(_iconForAttachment(attachment.type)),
@@ -119,11 +221,60 @@ class LessonDetailScreen extends StatelessWidget {
                 ),
               ),
             ],
-            if (lesson.quizzes.isNotEmpty) ...[
+            if (widget.lesson.quizzes.isNotEmpty) ...[
               const SizedBox(height: 24),
               Text('Quizzes', style: theme.textTheme.titleMedium),
               const SizedBox(height: 8),
-              ...lesson.quizzes.map((quiz) => _QuizCard(quiz: quiz)),
+              ...widget.lesson.quizzes.map(
+                (quiz) => _InteractiveQuizCard(
+                  quiz: quiz,
+                  submission: _responses[quiz.id] ??
+                      const LessonQuizSubmission(),
+                  onOptionsChanged: (options) {
+                    setState(() {
+                      _responses = {
+                        ..._responses,
+                        quiz.id: LessonQuizSubmission(
+                          selectedOptions: options,
+                          shortAnswer:
+                              _responses[quiz.id]?.shortAnswer,
+                        ),
+                      };
+                    });
+                  },
+                  onShortAnswerChanged: (value) {
+                    setState(() {
+                      _responses = {
+                        ..._responses,
+                        quiz.id: LessonQuizSubmission(
+                          selectedOptions:
+                              _responses[quiz.id]?.selectedOptions ??
+                                  const <String>{},
+                          shortAnswer: value,
+                        ),
+                      };
+                    });
+                  },
+                ),
+              ),
+              const SizedBox(height: 12),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: ElevatedButton.icon(
+                  onPressed:
+                      _isPersisting || _responses.isEmpty ? null : _submitQuiz,
+                  icon: const Icon(Icons.check_circle_outline),
+                  label: const Text('Submit quiz'),
+                ),
+              ),
+              if (_lastQuizScore != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Text(
+                    'Latest quiz score: ${(_lastQuizScore! * 100).toStringAsFixed(0)}%',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                ),
             ],
           ],
         ),
@@ -145,17 +296,305 @@ class LessonDetailScreen extends StatelessWidget {
         return Icons.link_outlined;
     }
   }
+  Future<void> _handleStart({required bool clearCompletion}) async {
+    if (_timerService.isRunning) {
+      return;
+    }
+    _timerService.start();
+    await _persistProgress(
+      status: 'in_progress',
+      consumeTimer: false,
+      markStart: true,
+      clearCompletion: clearCompletion,
+    );
+  }
+
+  Future<void> _handlePause() async {
+    if (!_timerService.isRunning) {
+      return;
+    }
+    await _persistProgress(
+      status: 'in_progress',
+      consumeTimer: true,
+      markStart: true,
+    );
+  }
+
+  Future<void> _handleComplete() async {
+    final score = _responses.isEmpty
+        ? _progress?.quizScore
+        : _computeQuizScore();
+    await _persistProgress(
+      status: 'completed',
+      consumeTimer: true,
+      markStart: true,
+      markCompletion: true,
+      quizScore: score,
+    );
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Lesson marked as completed.')),
+    );
+  }
+
+  Future<void> _submitQuiz() async {
+    final score = _computeQuizScore();
+    await _persistProgress(
+      status: _progress?.status ?? 'in_progress',
+      consumeTimer: false,
+      markStart: _progress?.status == null,
+      quizScore: score,
+    );
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _lastQuizScore = score;
+    });
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          'Quiz graded: ${(score * 100).toStringAsFixed(0)}%',
+        ),
+      ),
+    );
+  }
+
+  double _computeQuizScore() {
+    final grader = ref.read(lessonQuizGraderProvider);
+    final score = grader.grade(widget.lesson.quizzes, _responses);
+    setState(() {
+      _lastQuizScore = score;
+    });
+    return score;
+  }
+
+  Future<void> _persistProgress({
+    required String status,
+    required bool consumeTimer,
+    required bool markStart,
+    bool markCompletion = false,
+    bool clearCompletion = false,
+    double? quizScore,
+  }) async {
+    if (_isPersisting) {
+      return;
+    }
+    setState(() {
+      _isPersisting = true;
+    });
+    final elapsedSeconds = consumeTimer ? _timerService.consume() : 0;
+    final now = DateTime.now();
+    final existing = _progress;
+    final startedAt = markStart
+        ? (existing?.startedAt ?? now)
+        : existing?.startedAt;
+    final completedAt = markCompletion
+        ? now
+        : (clearCompletion ? null : existing?.completedAt);
+    final progress = LessonProgress(
+      id: existing?.id ?? '${_userId}_${widget.lesson.id}',
+      userId: _userId,
+      lessonId: widget.lesson.id,
+      status: status,
+      quizScore: quizScore ?? existing?.quizScore,
+      timeSpentSeconds:
+          (existing?.timeSpentSeconds ?? 0) + elapsedSeconds,
+      updatedAt: now,
+      startedAt: startedAt,
+      completedAt: completedAt,
+    );
+    final update = ref.read(updateProgressUseCaseProvider);
+    await update(progress);
+    if (mounted) {
+      setState(() {
+        _isPersisting = false;
+      });
+    }
+  }
 }
 
-class _QuizCard extends StatelessWidget {
-  const _QuizCard({required this.quiz});
+class _ProgressOverviewCard extends StatelessWidget {
+  const _ProgressOverviewCard({
+    required this.status,
+    required this.totalSeconds,
+    required this.startedAt,
+    required this.completedAt,
+    required this.updatedAt,
+    required this.quizScore,
+    required this.isTimerRunning,
+    required this.sessionSeconds,
+    required this.onStart,
+    required this.onPause,
+    required this.onComplete,
+  });
+
+  final String status;
+  final int totalSeconds;
+  final DateTime? startedAt;
+  final DateTime? completedAt;
+  final DateTime? updatedAt;
+  final double? quizScore;
+  final bool isTimerRunning;
+  final int sessionSeconds;
+  final VoidCallback? onStart;
+  final VoidCallback? onPause;
+  final VoidCallback? onComplete;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final statusLabel = _statusLabel(status);
+    final totalDuration = _formatDuration(totalSeconds);
+    final sessionDuration = _formatDuration(sessionSeconds);
+    final quizLabel = quizScore == null
+        ? 'Not graded'
+        : '${(quizScore! * 100).toStringAsFixed(0)}%';
+    final startLabel = status == 'completed'
+        ? 'Restart'
+        : (isTimerRunning ? 'Resume' : 'Start');
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Progress', style: theme.textTheme.titleMedium),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 12,
+              runSpacing: 8,
+              children: [
+                _InfoChip(label: 'Status', value: statusLabel),
+                _InfoChip(label: 'Total time', value: totalDuration),
+                if (isTimerRunning)
+                  _InfoChip(label: 'Current session', value: sessionDuration),
+                if (startedAt != null)
+                  _InfoChip(
+                    label: 'Started',
+                    value: _formatDate(startedAt!),
+                  ),
+                if (completedAt != null)
+                  _InfoChip(
+                    label: 'Completed',
+                    value: _formatDate(completedAt!),
+                  ),
+                if (updatedAt != null)
+                  _InfoChip(
+                    label: 'Updated',
+                    value: _formatDate(updatedAt!),
+                  ),
+                _InfoChip(label: 'Quiz score', value: quizLabel),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                ElevatedButton.icon(
+                  onPressed: onStart,
+                  icon: Icon(isTimerRunning ? Icons.timer : Icons.play_arrow),
+                  label: Text(startLabel),
+                ),
+                const SizedBox(width: 12),
+                OutlinedButton.icon(
+                  onPressed: onPause,
+                  icon: const Icon(Icons.pause_circle_outline),
+                  label: const Text('Pause'),
+                ),
+                const SizedBox(width: 12),
+                OutlinedButton.icon(
+                  onPressed: onComplete,
+                  icon: const Icon(Icons.flag_outlined),
+                  label: const Text('Complete'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static String _statusLabel(String status) {
+    switch (status) {
+      case 'completed':
+        return 'Completed';
+      case 'in_progress':
+        return 'In progress';
+      default:
+        return 'Not started';
+    }
+  }
+
+  static String _formatDuration(int seconds) {
+    final duration = Duration(seconds: seconds);
+    final hours = duration.inHours;
+    final minutes = duration.inMinutes % 60;
+    final secs = duration.inSeconds % 60;
+    if (hours > 0) {
+      return '${hours}h ${minutes}m';
+    }
+    if (minutes > 0) {
+      return '${minutes}m ${secs}s';
+    }
+    return '${secs}s';
+  }
+
+  static String _formatDate(DateTime dateTime) {
+    final local = dateTime.toLocal();
+    final twoDigits = (int n) => n.toString().padLeft(2, '0');
+    final year = local.year.toString().padLeft(4, '0');
+    final month = twoDigits(local.month);
+    final day = twoDigits(local.day);
+    final hour = twoDigits(local.hour);
+    final minute = twoDigits(local.minute);
+    return '$year-$month-$day $hour:$minute';
+  }
+}
+
+class _InfoChip extends StatelessWidget {
+  const _InfoChip({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Chip(
+      label: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(label, style: theme.textTheme.labelSmall),
+          Text(value, style: theme.textTheme.bodyMedium),
+        ],
+      ),
+    );
+  }
+}
+
+class _InteractiveQuizCard extends StatelessWidget {
+  const _InteractiveQuizCard({
+    required this.quiz,
+    required this.submission,
+    required this.onOptionsChanged,
+    required this.onShortAnswerChanged,
+  });
 
   final LessonQuiz quiz;
+  final LessonQuizSubmission submission;
+  final ValueChanged<Set<String>> onOptionsChanged;
+  final ValueChanged<String> onShortAnswerChanged;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final hasOptions = quiz.options.isNotEmpty;
+    final allowMultiple = quiz.answers.length > 1;
     return Card(
       margin: const EdgeInsets.only(bottom: 12),
       child: Padding(
@@ -166,29 +605,43 @@ class _QuizCard extends StatelessWidget {
             Text(quiz.prompt, style: theme.textTheme.titleMedium),
             const SizedBox(height: 12),
             if (hasOptions)
-              ...quiz.options.map(
-                (option) {
-                  final isCorrect = quiz.answers.contains(option);
-                  return Row(
-                    children: [
-                      Icon(
-                        isCorrect
-                            ? Icons.check_circle_outlined
-                            : Icons.circle_outlined,
-                        color: isCorrect ? theme.colorScheme.primary : null,
-                      ),
-                      const SizedBox(width: 8),
-                      Expanded(child: Text(option)),
-                    ],
+              ...quiz.options.map((option) {
+                if (allowMultiple) {
+                  return CheckboxListTile(
+                    value: submission.selectedOptions.contains(option),
+                    onChanged: (selected) {
+                      final updated = <String>{
+                        ...submission.selectedOptions,
+                      };
+                      if (selected ?? false) {
+                        updated.add(option);
+                      } else {
+                        updated.remove(option);
+                      }
+                      onOptionsChanged(updated);
+                    },
+                    title: Text(option),
                   );
-                },
-              )
+                }
+                final groupValue =
+                    submission.selectedOptions.isEmpty
+                        ? null
+                        : submission.selectedOptions.first;
+                return RadioListTile<String>(
+                  value: option,
+                  groupValue: groupValue,
+                  onChanged: (_) {
+                    onOptionsChanged({option});
+                  },
+                  title: Text(option),
+                );
+              })
             else
-              Text(
-                quiz.answers.isEmpty
-                    ? 'Short answer question'
-                    : 'Expected answer: ${quiz.answers.join(", ")}',
-                style: theme.textTheme.bodyMedium,
+              TextFormField(
+                initialValue: submission.shortAnswer,
+                decoration:
+                    const InputDecoration(labelText: 'Your answer'),
+                onChanged: onShortAnswerChanged,
               ),
           ],
         ),

--- a/lib/src/presentation/lessons/lesson_progress_dashboard_screen.dart
+++ b/lib/src/presentation/lessons/lesson_progress_dashboard_screen.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../../domain/lessons/progress_dashboard.dart';
+import '../providers.dart';
+
+class LessonProgressDashboardScreen extends ConsumerWidget {
+  const LessonProgressDashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final dashboardAsync = ref.watch(lessonProgressDashboardProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Progress dashboard'),
+        actions: [
+          dashboardAsync.maybeWhen(
+            data: (data) => IconButton(
+              icon: const Icon(Icons.ios_share),
+              tooltip: 'Export CSV',
+              onPressed: () => _export(context, data),
+            ),
+            orElse: () => const SizedBox.shrink(),
+          ),
+        ],
+      ),
+      body: dashboardAsync.when(
+        data: (data) => _DashboardBody(data: data),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stackTrace) => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Text('Failed to load dashboard: $error'),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _export(
+    BuildContext context,
+    LessonProgressDashboardData data,
+  ) async {
+    final csv = _buildCsv(data);
+    await Share.share(
+      csv,
+      subject: 'Lesson progress export',
+    );
+  }
+
+  String _buildCsv(LessonProgressDashboardData data) {
+    final buffer = StringBuffer()
+      ..writeln(
+        'Lesson,Class,Status,TimeSpentSeconds,QuizScore,StartedAt,CompletedAt,UpdatedAt',
+      );
+    for (final snapshot in data.snapshots) {
+      final progress = snapshot.progress;
+      final status = progress?.status ?? 'not_started';
+      final timeSpent = progress?.timeSpentSeconds ?? 0;
+      final quizScore = progress?.quizScore ?? 0;
+      final startedAt = progress?.startedAt?.toIso8601String() ?? '';
+      final completedAt = progress?.completedAt?.toIso8601String() ?? '';
+      final updatedAt = progress?.updatedAt.toIso8601String() ?? '';
+      buffer.writeln(
+        '"${snapshot.lesson.title}",' // lesson title quoted
+        '"${snapshot.lesson.lessonClass}",' // class
+        '$status,'
+        '$timeSpent,'
+        '${quizScore.toStringAsFixed(2)},'
+        '$startedAt,'
+        '$completedAt,'
+        '$updatedAt',
+      );
+    }
+    return buffer.toString();
+  }
+}
+
+class _DashboardBody extends StatelessWidget {
+  const _DashboardBody({required this.data});
+
+  final LessonProgressDashboardData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final totalLessons = data.totalLessons;
+    final completionRate = data.completionRate * 100;
+    final totalTime = _formatDuration(data.totalTimeSpentSeconds);
+    final averageScore = (data.averageQuizScore * 100).toStringAsFixed(0);
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Wrap(
+          spacing: 16,
+          runSpacing: 16,
+          children: [
+            _SummaryTile(
+              label: 'Total lessons',
+              value: '$totalLessons',
+              color: colorScheme.primaryContainer,
+            ),
+            _SummaryTile(
+              label: 'Completed',
+              value: '${data.completedCount}',
+              color: colorScheme.secondaryContainer,
+            ),
+            _SummaryTile(
+              label: 'In progress',
+              value: '${data.inProgressCount}',
+              color: colorScheme.tertiaryContainer,
+            ),
+            _SummaryTile(
+              label: 'Completion rate',
+              value: '${completionRate.toStringAsFixed(0)}%',
+              color: colorScheme.surfaceVariant,
+            ),
+            _SummaryTile(
+              label: 'Time spent',
+              value: totalTime,
+              color: colorScheme.primaryContainer.withOpacity(0.7),
+            ),
+            _SummaryTile(
+              label: 'Avg quiz score',
+              value: '$averageScore%',
+              color: colorScheme.secondaryContainer.withOpacity(0.7),
+            ),
+          ],
+        ),
+        const SizedBox(height: 24),
+        Text('Class breakdown', style: theme.textTheme.titleMedium),
+        const SizedBox(height: 8),
+        if (data.classSummaries.isEmpty)
+          const Text('No tracked progress yet.')
+        else
+          ...data.classSummaries.map(
+            (summary) => Card(
+              child: ListTile(
+                title: Text(summary.lessonClass),
+                subtitle: Text(
+                  'Completed ${summary.completedLessons}/${summary.totalLessons} · '
+                  'In progress ${summary.inProgressLessons} · '
+                  'Not started ${summary.notStartedLessons}',
+                ),
+                trailing: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Text('Time ${_formatDuration(summary.totalTimeSpentSeconds)}'),
+                    Text('Avg score ${(summary.averageQuizScore * 100).toStringAsFixed(0)}%'),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        const SizedBox(height: 24),
+        Text('Completion trend', style: theme.textTheme.titleMedium),
+        const SizedBox(height: 8),
+        if (data.completionsByDay.isEmpty)
+          const Text('No completions recorded yet.')
+        else
+          ...[
+            for (final entry
+                in data.completionsByDay.entries.toList()
+                  ..sort((a, b) => a.key.compareTo(b.key)))
+              ListTile(
+                leading: const Icon(Icons.event_available_outlined),
+                title: Text(_formatDate(entry.key)),
+                trailing: Text('${entry.value} completed'),
+              ),
+          ],
+      ],
+    );
+  }
+
+  static String _formatDuration(int seconds) {
+    final duration = Duration(seconds: seconds);
+    final hours = duration.inHours;
+    final minutes = duration.inMinutes % 60;
+    if (hours > 0) {
+      return '${hours}h ${minutes}m';
+    }
+    if (minutes > 0) {
+      return '${minutes}m';
+    }
+    return '${duration.inSeconds}s';
+  }
+
+  static String _formatDate(DateTime date) {
+    final local = date.toLocal();
+    final twoDigits = (int n) => n.toString().padLeft(2, '0');
+    return '${local.year}-${twoDigits(local.month)}-${twoDigits(local.day)}';
+  }
+}
+
+class _SummaryTile extends StatelessWidget {
+  const _SummaryTile({
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  final String label;
+  final String value;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: 160,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: theme.textTheme.labelSmall),
+          const SizedBox(height: 8),
+          Text(
+            value,
+            style: theme.textTheme.headlineSmall
+                ?.copyWith(fontWeight: FontWeight.w600),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/presentation/lessons/lessons_screen.dart
+++ b/lib/src/presentation/lessons/lessons_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../domain/lessons/entities.dart';
 import '../providers.dart';
 import 'lesson_detail_screen.dart';
+import 'lesson_progress_dashboard_screen.dart';
 
 class LessonsScreen extends ConsumerWidget {
   const LessonsScreen({super.key});
@@ -16,6 +17,20 @@ class LessonsScreen extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Lessons'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.bar_chart_rounded),
+            tooltip: 'Progress dashboard',
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const LessonProgressDashboardScreen(),
+                ),
+              );
+            },
+          ),
+        ],
       ),
       body: Column(
         children: [

--- a/lib/src/presentation/providers.dart
+++ b/lib/src/presentation/providers.dart
@@ -27,6 +27,9 @@ import '../domain/bible/import/import_bible_package_usecase.dart';
 import '../domain/chat/repositories.dart';
 import '../domain/chat/usecases.dart';
 import '../domain/lessons/entities.dart';
+import '../domain/lessons/progress_dashboard.dart';
+import '../domain/lessons/services/lesson_quiz_grader.dart';
+import '../domain/lessons/services/lesson_timer_service.dart';
 import '../domain/lessons/repositories.dart';
 import '../domain/lessons/usecases.dart';
 import '../domain/settings/repositories.dart';
@@ -46,6 +49,7 @@ import '../infrastructure/lessons/lesson_cache_invalidator.dart';
 import '../infrastructure/lessons/lesson_ingestion_pipeline.dart';
 import '../infrastructure/lessons/lesson_source_registry.dart';
 import '../infrastructure/lessons/lesson_sync_service.dart';
+import '../utils/iterable_extensions.dart';
 import 'settings/bible_import_controller.dart';
 import 'settings/lesson_sync_controller.dart';
 
@@ -258,6 +262,169 @@ final watchLessonProgressUseCaseProvider = Provider((ref) {
 
 final updateProgressUseCaseProvider = Provider((ref) {
   return UpdateProgressUseCase(ref.watch(lessonRepositoryProvider));
+});
+
+final lessonTimerServiceProvider =
+    Provider.autoDispose.family<LessonTimerService, String>((ref, lessonId) {
+  final service = LessonTimerService();
+  ref.onDispose(service.dispose);
+  return service;
+});
+
+final lessonQuizGraderProvider = Provider((ref) {
+  return const LessonQuizGrader();
+});
+
+class LessonProgressRequest {
+  const LessonProgressRequest({
+    required this.userId,
+    required this.lessonId,
+  });
+
+  final String userId;
+  final String lessonId;
+}
+
+final lessonProgressProvider = StreamProvider.autoDispose
+    .family<LessonProgress?, LessonProgressRequest>((ref, request) {
+  final useCase = ref.watch(watchLessonProgressUseCaseProvider);
+  return useCase(request.userId).map((progressList) {
+    return progressList.firstWhereOrNull(
+      (progress) => progress.lessonId == request.lessonId,
+    );
+  });
+});
+
+final lessonProgressDashboardProvider =
+    StreamProvider.autoDispose<LessonProgressDashboardData>((ref) {
+  const userId = 'local-user';
+  final lessonsStream = ref.watch(watchLessonsUseCaseProvider)(
+    filter: const LessonQuery(),
+  );
+  final progressStream =
+      ref.watch(watchLessonProgressUseCaseProvider)(userId);
+
+  return Rx.combineLatest2<List<Lesson>, List<LessonProgress>,
+      LessonProgressDashboardData>(
+    lessonsStream,
+    progressStream,
+    (lessons, progress) {
+      final snapshots = <LessonProgressSnapshot>[];
+      final classBuckets = <String, List<LessonProgressSnapshot>>{};
+      var completed = 0;
+      var inProgress = 0;
+      var notStarted = 0;
+      var totalTime = 0;
+      final quizScores = <double>[];
+      final completionsByDay = <DateTime, int>{};
+
+      for (final lesson in lessons) {
+        final entry =
+            progress.firstWhereOrNull((item) => item.lessonId == lesson.id);
+        final snapshot =
+            LessonProgressSnapshot(lesson: lesson, progress: entry);
+        snapshots.add(snapshot);
+        classBuckets.putIfAbsent(lesson.lessonClass, () => []).add(snapshot);
+        if (entry == null) {
+          notStarted += 1;
+          continue;
+        }
+        totalTime += entry.timeSpentSeconds;
+        if (entry.quizScore != null) {
+          quizScores.add(entry.quizScore!);
+        }
+        switch (entry.status) {
+          case 'completed':
+            completed += 1;
+            if (entry.completedAt != null) {
+              final completedAt = entry.completedAt!;
+              final date = DateTime(
+                completedAt.year,
+                completedAt.month,
+                completedAt.day,
+              );
+              completionsByDay[date] =
+                  (completionsByDay[date] ?? 0) + 1;
+            }
+            break;
+          case 'in_progress':
+            inProgress += 1;
+            break;
+          default:
+            notStarted += 1;
+            break;
+        }
+      }
+
+      final classSummaries = <LessonClassSummary>[];
+      classBuckets.forEach((lessonClass, entries) {
+        final totalLessons = entries.length;
+        var classCompleted = 0;
+        var classInProgress = 0;
+        var classNotStarted = 0;
+        var classTime = 0;
+        final classScores = <double>[];
+
+        for (final snapshot in entries) {
+          final progressEntry = snapshot.progress;
+          if (progressEntry == null) {
+            classNotStarted += 1;
+            continue;
+          }
+          classTime += progressEntry.timeSpentSeconds;
+          if (progressEntry.quizScore != null) {
+            classScores.add(progressEntry.quizScore!);
+          }
+          switch (progressEntry.status) {
+            case 'completed':
+              classCompleted += 1;
+              break;
+            case 'in_progress':
+              classInProgress += 1;
+              break;
+            default:
+              classNotStarted += 1;
+              break;
+          }
+        }
+
+        final averageScore = classScores.isEmpty
+            ? 0
+            : classScores.reduce((a, b) => a + b) / classScores.length;
+
+        classSummaries.add(
+          LessonClassSummary(
+            lessonClass: lessonClass,
+            totalLessons: totalLessons,
+            completedLessons: classCompleted,
+            inProgressLessons: classInProgress,
+            notStartedLessons: classNotStarted,
+            totalTimeSpentSeconds: classTime,
+            averageQuizScore: averageScore,
+          ),
+        );
+      });
+
+      classSummaries.sort(
+        (a, b) => a.lessonClass.compareTo(b.lessonClass),
+      );
+
+      final averageQuizScore = quizScores.isEmpty
+          ? 0
+          : quizScores.reduce((a, b) => a + b) / quizScores.length;
+
+      return LessonProgressDashboardData(
+        snapshots: snapshots,
+        completedCount: completed,
+        inProgressCount: inProgress,
+        notStartedCount: notStarted,
+        totalTimeSpentSeconds: totalTime,
+        averageQuizScore: averageQuizScore,
+        classSummaries: classSummaries,
+        completionsByDay: completionsByDay,
+      );
+    },
+  );
 });
 
 final getCurrentAccountUseCaseProvider = Provider((ref) {

--- a/lib/src/utils/iterable_extensions.dart
+++ b/lib/src/utils/iterable_extensions.dart
@@ -1,0 +1,10 @@
+extension IterableExtensions<T> on Iterable<T> {
+  T? firstWhereOrNull(bool Function(T element) test) {
+    for (final element in this) {
+      if (test(element)) {
+        return element;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- extend the Drift `progress` table and domain models to capture start/completion timestamps alongside quiz scores and time spent
- introduce lesson timer and quiz grading services with Riverpod providers to drive interactive progress controls in the lesson detail screen
- add a progress dashboard screen that aggregates per-class metrics, completion trends, and provides CSV export

## Testing
- Not run (Flutter tooling is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68df82ae5bcc83209179eb16c0105897