### PR TITLE
Add local profile onboarding and per-user data scoping

### DIFF
--- a/lib/src/data/accounts/account_repository_impl.dart
+++ b/lib/src/data/accounts/account_repository_impl.dart
@@ -14,9 +14,22 @@ class AccountRepositoryImpl implements AccountRepository {
   Future<void> _ensureSeeded() => _db.ensureSeeded();
 
   @override
+  Stream<List<LocalAccount>> watchAccounts() async* {
+    await _ensureSeeded();
+    yield* _dao.watchAccounts().map((rows) => rows.map(_map).toList());
+  }
+
+  @override
+  Future<List<LocalAccount>> getAccounts() async {
+    await _ensureSeeded();
+    final rows = await _dao.getAccounts();
+    return rows.map(_map).toList();
+  }
+
+  @override
   Future<LocalAccount?> getCurrentAccount() async {
     await _ensureSeeded();
-    final row = await _dao.getAccount();
+    final row = await _dao.getActiveAccount();
     if (row == null) {
       return null;
     }
@@ -26,7 +39,15 @@ class AccountRepositoryImpl implements AccountRepository {
   @override
   Stream<LocalAccount?> watchCurrentAccount() async* {
     await _ensureSeeded();
-    yield* _dao.watchAccount().map((row) => row == null ? null : _map(row));
+    yield* _dao
+        .watchActiveAccount()
+        .map((row) => row == null ? null : _map(row));
+  }
+
+  @override
+  Future<void> setActiveAccount(String id) async {
+    await _ensureSeeded();
+    await _dao.setActiveAccount(id);
   }
 
   @override
@@ -35,13 +56,25 @@ class AccountRepositoryImpl implements AccountRepository {
       id: Value(account.id),
       displayName: Value(account.displayName),
       avatarUrl: Value(account.avatarUrl),
+      preferredCohortId: Value(account.preferredCohortId),
+      preferredCohortTitle: Value(account.preferredCohortTitle),
+      preferredLessonClass: Value(account.preferredLessonClass),
+      isActive: Value(account.isActive),
     );
     return _dao.upsertAccount(companion);
   }
 
   @override
-  Future<void> deleteAccount(String id) {
-    return _dao.deleteAccount(id);
+  Future<void> deleteAccount(String id) async {
+    await _ensureSeeded();
+    final account = await _dao.getAccountById(id);
+    await _dao.deleteAccount(id);
+    if (account?.isActive == true) {
+      final remaining = await _dao.getAccounts();
+      if (remaining.isNotEmpty) {
+        await _dao.setActiveAccount(remaining.first.id);
+      }
+    }
   }
 
   LocalAccount _map(LocalUser row) {
@@ -49,6 +82,10 @@ class AccountRepositoryImpl implements AccountRepository {
       id: row.id,
       displayName: row.displayName,
       avatarUrl: row.avatarUrl,
+      preferredCohortId: row.preferredCohortId,
+      preferredCohortTitle: row.preferredCohortTitle,
+      preferredLessonClass: row.preferredLessonClass,
+      isActive: row.isActive,
     );
   }
 }

--- a/lib/src/data/bible/annotation_repository_impl.dart
+++ b/lib/src/data/bible/annotation_repository_impl.dart
@@ -16,36 +16,40 @@ class AnnotationRepositoryImpl implements AnnotationRepository {
 
   @override
   Stream<List<Bookmark>> watchBookmarksForChapter(
+    String userId,
     String translationId,
     int bookId,
     int chapter,
   ) async* {
     await _ensureSeeded();
-    yield* _dao.watchBookmarksForChapter(translationId, bookId, chapter).map(
-      (rows) => rows.map(_mapBookmark).toList(),
-    );
+    yield* _dao
+        .watchBookmarksForChapter(userId, translationId, bookId, chapter)
+        .map((rows) => rows.map(_mapBookmark).toList());
   }
 
   @override
   Future<Bookmark?> findBookmark(
+    String userId,
     String translationId,
     int bookId,
     int chapter,
     int verse,
   ) async {
     await _ensureSeeded();
-    final row = await _dao.findBookmark(translationId, bookId, chapter, verse);
+    final row =
+        await _dao.findBookmark(userId, translationId, bookId, chapter, verse);
     return row == null ? null : _mapBookmark(row);
   }
 
   @override
-  Future<Bookmark> createBookmark(VerseLocation location) async {
+  Future<Bookmark> createBookmark(String userId, VerseLocation location) async {
     await _ensureSeeded();
     final id = _uuid.v4();
     final now = DateTime.now();
     await _dao.insertBookmark(
       BookmarksCompanion.insert(
         id: id,
+        userId: userId,
         translationId: location.translationId,
         bookId: location.bookId,
         chapter: location.chapter,
@@ -57,42 +61,51 @@ class AnnotationRepositoryImpl implements AnnotationRepository {
   }
 
   @override
-  Future<void> deleteBookmark(String id) {
-    return _dao.deleteBookmark(id);
+  Future<void> deleteBookmark(String userId, String id) {
+    return _dao.deleteBookmark(userId, id);
   }
 
   @override
   Stream<List<Highlight>> watchHighlightsForChapter(
+    String userId,
     String translationId,
     int bookId,
     int chapter,
   ) async* {
     await _ensureSeeded();
-    yield* _dao.watchHighlightsForChapter(translationId, bookId, chapter).map(
-      (rows) => rows.map(_mapHighlight).toList(),
-    );
+    yield* _dao
+        .watchHighlightsForChapter(userId, translationId, bookId, chapter)
+        .map((rows) => rows.map(_mapHighlight).toList());
   }
 
   @override
   Future<Highlight?> findHighlight(
+    String userId,
     String translationId,
     int bookId,
     int chapter,
     int verse,
   ) async {
     await _ensureSeeded();
-    final row = await _dao.findHighlight(translationId, bookId, chapter, verse);
+    final row = await _dao.findHighlight(
+      userId,
+      translationId,
+      bookId,
+      chapter,
+      verse,
+    );
     return row == null ? null : _mapHighlight(row);
   }
 
   @override
-  Future<Highlight> saveHighlight(Highlight highlight) async {
+  Future<Highlight> saveHighlight(String userId, Highlight highlight) async {
     await _ensureSeeded();
     final id = highlight.id.isEmpty ? _uuid.v4() : highlight.id;
     final now = DateTime.now();
     await _dao.upsertHighlight(
       HighlightsCompanion.insert(
         id: id,
+        userId: userId,
         translationId: highlight.location.translationId,
         bookId: highlight.location.bookId,
         chapter: highlight.location.chapter,
@@ -110,56 +123,74 @@ class AnnotationRepositoryImpl implements AnnotationRepository {
   }
 
   @override
-  Future<void> deleteHighlight(String id) {
-    return _dao.deleteHighlight(id);
+  Future<void> deleteHighlight(String userId, String id) {
+    return _dao.deleteHighlight(userId, id);
   }
 
   @override
   Stream<List<Note>> watchNotesForChapter(
+    String userId,
     String translationId,
     int bookId,
     int chapter,
   ) async* {
     await _ensureSeeded();
-    yield* _dao.watchNotesForChapter(translationId, bookId, chapter).asyncMap(
-      (rows) async {
-        final notes = <Note>[];
-        for (final row in rows) {
-          final historyRows = await _dao.getRevisions(row.id);
-          notes.add(_mapNote(row, historyRows));
-        }
-        return notes;
-      },
-    );
+    yield* _dao
+        .watchNotesForChapter(userId, translationId, bookId, chapter)
+        .asyncMap((rows) async {
+      final notes = <Note>[];
+      for (final row in rows) {
+        final historyRows = await _dao.getRevisions(userId, row.id);
+        notes.add(_mapNote(row, historyRows));
+      }
+      return notes;
+    });
   }
 
   @override
   Future<Note?> findNote(
+    String userId,
     String translationId,
     int bookId,
     int chapter,
     int verse,
   ) async {
     await _ensureSeeded();
-    final row = await _dao.findNote(translationId, bookId, chapter, verse);
+    final row = await _dao.findNote(
+      userId,
+      translationId,
+      bookId,
+      chapter,
+      verse,
+    );
     if (row == null) {
       return null;
     }
-    final historyRows = await _dao.getRevisions(row.id);
+    final historyRows = await _dao.getRevisions(userId, row.id);
     return _mapNote(row, historyRows);
   }
 
   @override
-  Future<Note> saveNote(VerseLocation location, String text) async {
+  Future<Note> saveNote(
+    String userId,
+    VerseLocation location,
+    String text,
+  ) async {
     await _ensureSeeded();
     final now = DateTime.now();
-    final existing =
-        await _dao.findNote(location.translationId, location.bookId, location.chapter, location.verse);
+    final existing = await _dao.findNote(
+      userId,
+      location.translationId,
+      location.bookId,
+      location.chapter,
+      location.verse,
+    );
     if (existing == null) {
       final id = _uuid.v4();
       await _dao.insertNote(
         NotesCompanion.insert(
           id: id,
+          userId: userId,
           translationId: location.translationId,
           bookId: location.bookId,
           chapter: location.chapter,
@@ -192,6 +223,7 @@ class AnnotationRepositoryImpl implements AnnotationRepository {
     final newVersion = existing.version + 1;
     await _dao.updateNote(
       existing.id,
+      userId,
       text,
       newVersion,
       now.millisecondsSinceEpoch,
@@ -205,24 +237,28 @@ class AnnotationRepositoryImpl implements AnnotationRepository {
       ),
     );
     final updated = await _dao.findNote(
+      userId,
       location.translationId,
       location.bookId,
       location.chapter,
       location.verse,
     );
-    final historyRows = await _dao.getRevisions(existing.id);
+    final historyRows = await _dao.getRevisions(userId, existing.id);
     return _mapNote(updated!, historyRows);
   }
 
   @override
-  Future<void> deleteNote(String id) {
-    return (_db.delete(_db.notes)..where((tbl) => tbl.id.equals(id))).go();
+  Future<void> deleteNote(String userId, String id) {
+    return _dao.deleteNote(userId, id);
   }
 
   @override
-  Future<List<NoteHistoryEntry>> getHistory(String noteId) async {
+  Future<List<NoteHistoryEntry>> getHistory(
+    String userId,
+    String noteId,
+  ) async {
     await _ensureSeeded();
-    final rows = await _dao.getRevisions(noteId);
+    final rows = await _dao.getRevisions(userId, noteId);
     return rows
         .map(
           (row) => NoteHistoryEntry(
@@ -235,19 +271,23 @@ class AnnotationRepositoryImpl implements AnnotationRepository {
   }
 
   @override
-  Future<Note?> revertToPreviousVersion(String noteId) async {
+  Future<Note?> revertToPreviousVersion(String userId, String noteId) async {
     await _ensureSeeded();
-    final history = await _dao.getRevisions(noteId);
+    final note = await _dao.findNoteById(userId, noteId);
+    if (note == null) {
+      return null;
+    }
+    final history = await _dao.getRevisions(userId, noteId);
     if (history.length < 2) {
       return null;
     }
-    final current = history.first;
-    final target = history[1];
+    final previous = history[1];
     final now = DateTime.now();
-    final newVersion = current.version + 1;
+    final newVersion = note.version + 1;
     await _dao.updateNote(
       noteId,
-      target.text,
+      userId,
+      previous.text,
       newVersion,
       now.millisecondsSinceEpoch,
     );
@@ -255,16 +295,13 @@ class AnnotationRepositoryImpl implements AnnotationRepository {
       NoteRevisionsCompanion.insert(
         noteId: noteId,
         version: newVersion,
-        text: target.text,
+        text: previous.text,
         updatedAt: now.millisecondsSinceEpoch,
       ),
     );
-    final updated = await _dao.findNoteById(noteId);
-    if (updated == null) {
-      return null;
-    }
-    final updatedHistory = await _dao.getRevisions(noteId);
-    return _mapNote(updated, updatedHistory);
+    final updated = await _dao.findNoteById(userId, noteId);
+    final updatedHistory = await _dao.getRevisions(userId, noteId);
+    return updated == null ? null : _mapNote(updated, updatedHistory);
   }
 
   Bookmark _mapBookmark(BookmarksData row) {

--- a/lib/src/data/bible/reading_progress_repository_impl.dart
+++ b/lib/src/data/bible/reading_progress_repository_impl.dart
@@ -10,28 +10,37 @@ class ReadingProgressRepositoryImpl implements ReadingProgressRepository {
   ReadingProgressRepositoryImpl();
 
   static const _storageKey = 'reading_progress_state';
-  final _controller = StreamController<ReadingPosition?>.broadcast();
-  bool _initialised = false;
+  final _controllers = <String, StreamController<ReadingPosition?>>{};
+  final _initialisedUsers = <String>{};
 
-  Future<void> _ensureInitialised() async {
-    if (_initialised) {
+  StreamController<ReadingPosition?> _controllerFor(String userId) {
+    return _controllers.putIfAbsent(
+      userId,
+      () => StreamController<ReadingPosition?>.broadcast(),
+    );
+  }
+
+  String _keyFor(String userId) => '${_storageKey}_$userId';
+
+  Future<void> _ensureInitialised(String userId) async {
+    if (_initialisedUsers.contains(userId)) {
       return;
     }
-    final position = await getLastPosition();
-    _controller.add(position);
-    _initialised = true;
+    final position = await getLastPosition(userId);
+    _controllerFor(userId).add(position);
+    _initialisedUsers.add(userId);
   }
 
   @override
-  Stream<ReadingPosition?> watch() async* {
-    await _ensureInitialised();
-    yield* _controller.stream;
+  Stream<ReadingPosition?> watch(String userId) async* {
+    await _ensureInitialised(userId);
+    yield* _controllerFor(userId).stream;
   }
 
   @override
-  Future<ReadingPosition?> getLastPosition() async {
+  Future<ReadingPosition?> getLastPosition(String userId) async {
     final prefs = await SharedPreferences.getInstance();
-    final stored = prefs.getString(_storageKey);
+    final stored = prefs.getString(_keyFor(userId));
     if (stored == null) {
       return null;
     }
@@ -50,7 +59,7 @@ class ReadingProgressRepositoryImpl implements ReadingProgressRepository {
   }
 
   @override
-  Future<void> savePosition(ReadingPosition position) async {
+  Future<void> savePosition(String userId, ReadingPosition position) async {
     final prefs = await SharedPreferences.getInstance();
     final payload = jsonEncode({
       'translationId': position.translationId,
@@ -59,12 +68,16 @@ class ReadingProgressRepositoryImpl implements ReadingProgressRepository {
       'verse': position.verse,
       'updatedAt': position.updatedAt.millisecondsSinceEpoch,
     });
-    await prefs.setString(_storageKey, payload);
-    await _ensureInitialised();
-    _controller.add(position);
+    await prefs.setString(_keyFor(userId), payload);
+    await _ensureInitialised(userId);
+    _controllerFor(userId).add(position);
   }
 
   void dispose() {
-    _controller.close();
+    for (final controller in _controllers.values) {
+      controller.close();
+    }
+    _controllers.clear();
+    _initialisedUsers.clear();
   }
 }

--- a/lib/src/data/settings/settings_repository_impl.dart
+++ b/lib/src/data/settings/settings_repository_impl.dart
@@ -6,10 +6,12 @@ import '../../domain/settings/repositories.dart';
 class SettingsRepositoryImpl implements SettingsRepository {
   static const _themeKey = 'app_theme_mode';
 
+  String _keyFor(String userId) => '${_themeKey}_$userId';
+
   @override
-  Future<AppThemeMode> getThemeMode() async {
+  Future<AppThemeMode> getThemeMode(String userId) async {
     final prefs = await SharedPreferences.getInstance();
-    final value = prefs.getString(_themeKey);
+    final value = prefs.getString(_keyFor(userId));
     switch (value) {
       case 'light':
         return AppThemeMode.light;
@@ -21,17 +23,18 @@ class SettingsRepositoryImpl implements SettingsRepository {
   }
 
   @override
-  Future<void> saveThemeMode(AppThemeMode mode) async {
+  Future<void> saveThemeMode(String userId, AppThemeMode mode) async {
     final prefs = await SharedPreferences.getInstance();
+    final key = _keyFor(userId);
     switch (mode) {
       case AppThemeMode.system:
-        await prefs.remove(_themeKey);
+        await prefs.remove(key);
         break;
       case AppThemeMode.light:
-        await prefs.setString(_themeKey, 'light');
+        await prefs.setString(key, 'light');
         break;
       case AppThemeMode.dark:
-        await prefs.setString(_themeKey, 'dark');
+        await prefs.setString(key, 'dark');
         break;
     }
   }

--- a/lib/src/domain/accounts/entities.dart
+++ b/lib/src/domain/accounts/entities.dart
@@ -2,12 +2,40 @@ class LocalAccount {
   final String id;
   final String? displayName;
   final String? avatarUrl;
+  final String? preferredCohortId;
+  final String? preferredCohortTitle;
+  final String? preferredLessonClass;
+  final bool isActive;
 
   const LocalAccount({
     required this.id,
     this.displayName,
     this.avatarUrl,
+    this.preferredCohortId,
+    this.preferredCohortTitle,
+    this.preferredLessonClass,
+    this.isActive = false,
   });
+
+  LocalAccount copyWith({
+    String? id,
+    String? displayName,
+    String? avatarUrl,
+    String? preferredCohortId,
+    String? preferredCohortTitle,
+    String? preferredLessonClass,
+    bool? isActive,
+  }) {
+    return LocalAccount(
+      id: id ?? this.id,
+      displayName: displayName ?? this.displayName,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      preferredCohortId: preferredCohortId ?? this.preferredCohortId,
+      preferredCohortTitle: preferredCohortTitle ?? this.preferredCohortTitle,
+      preferredLessonClass: preferredLessonClass ?? this.preferredLessonClass,
+      isActive: isActive ?? this.isActive,
+    );
+  }
 }
 
 abstract class AuthSession {

--- a/lib/src/domain/accounts/repositories.dart
+++ b/lib/src/domain/accounts/repositories.dart
@@ -1,8 +1,11 @@
 import 'entities.dart';
 
 abstract class AccountRepository {
+  Stream<List<LocalAccount>> watchAccounts();
+  Future<List<LocalAccount>> getAccounts();
   Future<LocalAccount?> getCurrentAccount();
   Stream<LocalAccount?> watchCurrentAccount();
+  Future<void> setActiveAccount(String id);
   Future<void> saveAccount(LocalAccount account);
   Future<void> deleteAccount(String id);
 }

--- a/lib/src/domain/accounts/usecases.dart
+++ b/lib/src/domain/accounts/usecases.dart
@@ -1,6 +1,22 @@
 import 'entities.dart';
 import 'repositories.dart';
 
+class WatchAccountsUseCase {
+  const WatchAccountsUseCase(this._repository);
+
+  final AccountRepository _repository;
+
+  Stream<List<LocalAccount>> call() => _repository.watchAccounts();
+}
+
+class GetAccountsUseCase {
+  const GetAccountsUseCase(this._repository);
+
+  final AccountRepository _repository;
+
+  Future<List<LocalAccount>> call() => _repository.getAccounts();
+}
+
 class GetCurrentAccountUseCase {
   final AccountRepository _repository;
 
@@ -15,6 +31,14 @@ class WatchAccountUseCase {
   const WatchAccountUseCase(this._repository);
 
   Stream<LocalAccount?> call() => _repository.watchCurrentAccount();
+}
+
+class SetActiveAccountUseCase {
+  final AccountRepository _repository;
+
+  const SetActiveAccountUseCase(this._repository);
+
+  Future<void> call(String id) => _repository.setActiveAccount(id);
 }
 
 class SaveAccountUseCase {

--- a/lib/src/domain/annotations/repositories.dart
+++ b/lib/src/domain/annotations/repositories.dart
@@ -2,49 +2,56 @@ import 'entities.dart';
 
 abstract class AnnotationRepository {
   Stream<List<Bookmark>> watchBookmarksForChapter(
+    String userId,
     String translationId,
     int bookId,
     int chapter,
   );
   Future<Bookmark?> findBookmark(
+    String userId,
     String translationId,
     int bookId,
     int chapter,
     int verse,
   );
-  Future<Bookmark> createBookmark(VerseLocation location);
-  Future<void> deleteBookmark(String id);
+  Future<Bookmark> createBookmark(String userId, VerseLocation location);
+  Future<void> deleteBookmark(String userId, String id);
 
   Stream<List<Highlight>> watchHighlightsForChapter(
+    String userId,
     String translationId,
     int bookId,
     int chapter,
   );
   Future<Highlight?> findHighlight(
+    String userId,
     String translationId,
     int bookId,
     int chapter,
     int verse,
   );
-  Future<Highlight> saveHighlight(Highlight highlight);
-  Future<void> deleteHighlight(String id);
+  Future<Highlight> saveHighlight(String userId, Highlight highlight);
+  Future<void> deleteHighlight(String userId, String id);
 
   Stream<List<Note>> watchNotesForChapter(
+    String userId,
     String translationId,
     int bookId,
     int chapter,
   );
   Future<Note?> findNote(
+    String userId,
     String translationId,
     int bookId,
     int chapter,
     int verse,
   );
   Future<Note> saveNote(
+    String userId,
     VerseLocation location,
     String text,
   );
-  Future<void> deleteNote(String id);
-  Future<List<NoteHistoryEntry>> getHistory(String noteId);
-  Future<Note?> revertToPreviousVersion(String noteId);
+  Future<void> deleteNote(String userId, String id);
+  Future<List<NoteHistoryEntry>> getHistory(String userId, String noteId);
+  Future<Note?> revertToPreviousVersion(String userId, String noteId);
 }

--- a/lib/src/domain/annotations/usecases.dart
+++ b/lib/src/domain/annotations/usecases.dart
@@ -6,8 +6,18 @@ class WatchBookmarksForChapterUseCase {
 
   final AnnotationRepository _repository;
 
-  Stream<List<Bookmark>> call(String translationId, int bookId, int chapter) {
-    return _repository.watchBookmarksForChapter(translationId, bookId, chapter);
+  Stream<List<Bookmark>> call(
+    String userId,
+    String translationId,
+    int bookId,
+    int chapter,
+  ) {
+    return _repository.watchBookmarksForChapter(
+      userId,
+      translationId,
+      bookId,
+      chapter,
+    );
   }
 }
 
@@ -16,18 +26,19 @@ class ToggleBookmarkUseCase {
 
   final AnnotationRepository _repository;
 
-  Future<Bookmark?> call(VerseLocation location) async {
+  Future<Bookmark?> call(String userId, VerseLocation location) async {
     final existing = await _repository.findBookmark(
+      userId,
       location.translationId,
       location.bookId,
       location.chapter,
       location.verse,
     );
     if (existing != null) {
-      await _repository.deleteBookmark(existing.id);
+      await _repository.deleteBookmark(userId, existing.id);
       return null;
     }
-    return _repository.createBookmark(location);
+    return _repository.createBookmark(userId, location);
   }
 }
 
@@ -36,8 +47,18 @@ class WatchHighlightsForChapterUseCase {
 
   final AnnotationRepository _repository;
 
-  Stream<List<Highlight>> call(String translationId, int bookId, int chapter) {
-    return _repository.watchHighlightsForChapter(translationId, bookId, chapter);
+  Stream<List<Highlight>> call(
+    String userId,
+    String translationId,
+    int bookId,
+    int chapter,
+  ) {
+    return _repository.watchHighlightsForChapter(
+      userId,
+      translationId,
+      bookId,
+      chapter,
+    );
   }
 }
 
@@ -46,8 +67,8 @@ class SaveHighlightUseCase {
 
   final AnnotationRepository _repository;
 
-  Future<Highlight> call(Highlight highlight) {
-    return _repository.saveHighlight(highlight);
+  Future<Highlight> call(String userId, Highlight highlight) {
+    return _repository.saveHighlight(userId, highlight);
   }
 }
 
@@ -56,8 +77,8 @@ class RemoveHighlightUseCase {
 
   final AnnotationRepository _repository;
 
-  Future<void> call(String id) {
-    return _repository.deleteHighlight(id);
+  Future<void> call(String userId, String id) {
+    return _repository.deleteHighlight(userId, id);
   }
 }
 
@@ -66,8 +87,18 @@ class WatchNotesForChapterUseCase {
 
   final AnnotationRepository _repository;
 
-  Stream<List<Note>> call(String translationId, int bookId, int chapter) {
-    return _repository.watchNotesForChapter(translationId, bookId, chapter);
+  Stream<List<Note>> call(
+    String userId,
+    String translationId,
+    int bookId,
+    int chapter,
+  ) {
+    return _repository.watchNotesForChapter(
+      userId,
+      translationId,
+      bookId,
+      chapter,
+    );
   }
 }
 
@@ -76,8 +107,8 @@ class SaveNoteUseCase {
 
   final AnnotationRepository _repository;
 
-  Future<Note> call(VerseLocation location, String text) {
-    return _repository.saveNote(location, text);
+  Future<Note> call(String userId, VerseLocation location, String text) {
+    return _repository.saveNote(userId, location, text);
   }
 }
 
@@ -86,8 +117,8 @@ class DeleteNoteUseCase {
 
   final AnnotationRepository _repository;
 
-  Future<void> call(String id) {
-    return _repository.deleteNote(id);
+  Future<void> call(String userId, String id) {
+    return _repository.deleteNote(userId, id);
   }
 }
 
@@ -96,8 +127,8 @@ class UndoNoteUseCase {
 
   final AnnotationRepository _repository;
 
-  Future<Note?> call(String id) {
-    return _repository.revertToPreviousVersion(id);
+  Future<Note?> call(String userId, String id) {
+    return _repository.revertToPreviousVersion(userId, id);
   }
 }
 
@@ -106,7 +137,7 @@ class GetNoteHistoryUseCase {
 
   final AnnotationRepository _repository;
 
-  Future<List<NoteHistoryEntry>> call(String noteId) {
-    return _repository.getHistory(noteId);
+  Future<List<NoteHistoryEntry>> call(String userId, String noteId) {
+    return _repository.getHistory(userId, noteId);
   }
 }

--- a/lib/src/domain/bible/reading_progress/repositories.dart
+++ b/lib/src/domain/bible/reading_progress/repositories.dart
@@ -1,7 +1,7 @@
 import 'entities.dart';
 
 abstract class ReadingProgressRepository {
-  Stream<ReadingPosition?> watch();
-  Future<ReadingPosition?> getLastPosition();
-  Future<void> savePosition(ReadingPosition position);
+  Stream<ReadingPosition?> watch(String userId);
+  Future<ReadingPosition?> getLastPosition(String userId);
+  Future<void> savePosition(String userId, ReadingPosition position);
 }

--- a/lib/src/domain/bible/reading_progress/usecases.dart
+++ b/lib/src/domain/bible/reading_progress/usecases.dart
@@ -6,7 +6,7 @@ class WatchReadingProgressUseCase {
 
   final ReadingProgressRepository _repository;
 
-  Stream<ReadingPosition?> call() => _repository.watch();
+  Stream<ReadingPosition?> call(String userId) => _repository.watch(userId);
 }
 
 class GetLastReadingPositionUseCase {
@@ -14,7 +14,8 @@ class GetLastReadingPositionUseCase {
 
   final ReadingProgressRepository _repository;
 
-  Future<ReadingPosition?> call() => _repository.getLastPosition();
+  Future<ReadingPosition?> call(String userId) =>
+      _repository.getLastPosition(userId);
 }
 
 class SaveReadingProgressUseCase {
@@ -22,6 +23,6 @@ class SaveReadingProgressUseCase {
 
   final ReadingProgressRepository _repository;
 
-  Future<void> call(ReadingPosition position) =>
-      _repository.savePosition(position);
+  Future<void> call(String userId, ReadingPosition position) =>
+      _repository.savePosition(userId, position);
 }

--- a/lib/src/domain/lessons/entities.dart
+++ b/lib/src/domain/lessons/entities.dart
@@ -149,7 +149,7 @@ class LessonQuery {
     this.classes,
     this.age,
     this.completion = LessonCompletionFilter.all,
-    this.userId = 'local-user',
+    required this.userId,
   });
 
   final Set<String>? classes;

--- a/lib/src/domain/settings/repositories.dart
+++ b/lib/src/domain/settings/repositories.dart
@@ -1,6 +1,6 @@
 import 'entities.dart';
 
 abstract class SettingsRepository {
-  Future<AppThemeMode> getThemeMode();
-  Future<void> saveThemeMode(AppThemeMode mode);
+  Future<AppThemeMode> getThemeMode(String userId);
+  Future<void> saveThemeMode(String userId, AppThemeMode mode);
 }

--- a/lib/src/domain/settings/usecases.dart
+++ b/lib/src/domain/settings/usecases.dart
@@ -6,7 +6,8 @@ class GetThemeModeUseCase {
 
   const GetThemeModeUseCase(this._repository);
 
-  Future<AppThemeMode> call() => _repository.getThemeMode();
+  Future<AppThemeMode> call(String userId) =>
+      _repository.getThemeMode(userId);
 }
 
 class SaveThemeModeUseCase {
@@ -14,6 +15,6 @@ class SaveThemeModeUseCase {
 
   const SaveThemeModeUseCase(this._repository);
 
-  Future<void> call(AppThemeMode mode) =>
-      _repository.saveThemeMode(mode);
+  Future<void> call(String userId, AppThemeMode mode) =>
+      _repository.saveThemeMode(userId, mode);
 }

--- a/lib/src/infrastructure/db/app_database.dart
+++ b/lib/src/infrastructure/db/app_database.dart
@@ -38,8 +38,24 @@ class Verses extends Table {
   Set<Column> get primaryKey => {translationId, bookId, chapter, verse};
 }
 
+class LocalUsers extends Table {
+  TextColumn get id => text()();
+  TextColumn get displayName => text().nullable()();
+  TextColumn get avatarUrl => text().nullable()();
+  TextColumn get preferredCohortId => text().nullable()();
+  TextColumn get preferredCohortTitle => text().nullable()();
+  TextColumn get preferredLessonClass => text().nullable()();
+  BoolColumn get isActive => boolean().withDefault(const Constant(false))();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
 class Bookmarks extends Table {
   TextColumn get id => text()();
+  TextColumn get userId => text()
+      .references(LocalUsers, #id, onDelete: KeyAction.cascade)
+      .withDefault(const Constant('local-user'))();
   TextColumn get translationId => text()
       .references(Translations, #id, onDelete: KeyAction.cascade)();
   IntColumn get bookId => integer()();
@@ -53,6 +69,9 @@ class Bookmarks extends Table {
 
 class Highlights extends Table {
   TextColumn get id => text()();
+  TextColumn get userId => text()
+      .references(LocalUsers, #id, onDelete: KeyAction.cascade)
+      .withDefault(const Constant('local-user'))();
   TextColumn get translationId => text()
       .references(Translations, #id, onDelete: KeyAction.cascade)();
   IntColumn get bookId => integer()();
@@ -67,6 +86,9 @@ class Highlights extends Table {
 
 class Notes extends Table {
   TextColumn get id => text()();
+  TextColumn get userId => text()
+      .references(LocalUsers, #id, onDelete: KeyAction.cascade)
+      .withDefault(const Constant('local-user'))();
   TextColumn get translationId => text()
       .references(Translations, #id, onDelete: KeyAction.cascade)();
   IntColumn get bookId => integer()();
@@ -237,15 +259,6 @@ class Progress extends Table {
   Set<Column> get primaryKey => {id};
 }
 
-class LocalUsers extends Table {
-  TextColumn get id => text()();
-  TextColumn get displayName => text().nullable()();
-  TextColumn get avatarUrl => text().nullable()();
-
-  @override
-  Set<Column> get primaryKey => {id};
-}
-
 class SyncQueue extends Table {
   TextColumn get id => text()();
   TextColumn get userId => text()();
@@ -309,7 +322,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 6;
+  int get schemaVersion => 7;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -346,6 +359,25 @@ class AppDatabase extends _$AppDatabase {
           if (from < 6) {
             await m.addColumn(progress, progress.startedAt);
             await m.addColumn(progress, progress.completedAt);
+          }
+          if (from < 7) {
+            await m.addColumn(bookmarks, bookmarks.userId);
+            await m.addColumn(highlights, highlights.userId);
+            await m.addColumn(notes, notes.userId);
+            await m.addColumn(localUsers, localUsers.preferredCohortId);
+            await m.addColumn(localUsers, localUsers.preferredCohortTitle);
+            await m.addColumn(localUsers, localUsers.preferredLessonClass);
+            await m.addColumn(localUsers, localUsers.isActive);
+            await m.customStatement(
+                "UPDATE local_users SET is_active = CASE WHEN id = 'local-user' THEN 1 ELSE 0 END");
+            await m.customStatement(
+                "INSERT INTO local_users (id, display_name, avatar_url, preferred_cohort_id, preferred_cohort_title, preferred_lesson_class, is_active) SELECT 'local-user', NULL, NULL, NULL, NULL, NULL, 1 WHERE NOT EXISTS (SELECT 1 FROM local_users WHERE id = 'local-user')");
+            await m.customStatement(
+                "UPDATE bookmarks SET user_id = 'local-user' WHERE user_id IS NULL");
+            await m.customStatement(
+                "UPDATE highlights SET user_id = 'local-user' WHERE user_id IS NULL");
+            await m.customStatement(
+                "UPDATE notes SET user_id = 'local-user' WHERE user_id IS NULL");
           }
         },
       );

--- a/lib/src/infrastructure/db/daos/account_dao.dart
+++ b/lib/src/infrastructure/db/daos/account_dao.dart
@@ -1,3 +1,5 @@
+import 'package:drift/drift.dart';
+
 import '../app_database.dart';
 
 class AccountDao {
@@ -5,16 +7,52 @@ class AccountDao {
 
   final AppDatabase _db;
 
-  Stream<LocalUser?> watchAccount() {
-    return _db.select(_db.localUsers).watchSingleOrNull();
+  Stream<List<LocalUser>> watchAccounts() {
+    final query = _db.select(_db.localUsers)
+      ..orderBy([(tbl) => OrderingTerm.asc(tbl.displayName)]);
+    return query.watch();
   }
 
-  Future<LocalUser?> getAccount() {
-    return _db.select(_db.localUsers).getSingleOrNull();
+  Future<List<LocalUser>> getAccounts() {
+    final query = _db.select(_db.localUsers)
+      ..orderBy([(tbl) => OrderingTerm.asc(tbl.displayName)]);
+    return query.get();
+  }
+
+  Stream<LocalUser?> watchActiveAccount() {
+    final query = _db.select(_db.localUsers)
+      ..where((tbl) => tbl.isActive.equals(true))
+      ..limit(1);
+    return query.watchSingleOrNull();
+  }
+
+  Future<LocalUser?> getActiveAccount() {
+    final query = _db.select(_db.localUsers)
+      ..where((tbl) => tbl.isActive.equals(true))
+      ..limit(1);
+    return query.getSingleOrNull();
+  }
+
+  Future<LocalUser?> getAccountById(String id) {
+    final query = _db.select(_db.localUsers)
+      ..where((tbl) => tbl.id.equals(id))
+      ..limit(1);
+    return query.getSingleOrNull();
   }
 
   Future<void> upsertAccount(LocalUsersCompanion companion) {
     return _db.into(_db.localUsers).insertOnConflictUpdate(companion);
+  }
+
+  Future<void> setActiveAccount(String id) async {
+    await _db.transaction(() async {
+      await _db.update(_db.localUsers).write(
+            const LocalUsersCompanion(isActive: Value(false)),
+          );
+      await (_db.update(_db.localUsers)..where((tbl) => tbl.id.equals(id))).write(
+        const LocalUsersCompanion(isActive: Value(true)),
+      );
+    });
   }
 
   Future<void> deleteAccount(String id) {

--- a/lib/src/infrastructure/db/daos/annotation_dao.dart
+++ b/lib/src/infrastructure/db/daos/annotation_dao.dart
@@ -8,12 +8,14 @@ class AnnotationDao {
   final AppDatabase _db;
 
   Stream<List<BookmarksData>> watchBookmarksForChapter(
+    String userId,
     String translationId,
     int bookId,
     int chapter,
   ) {
     final query = _db.select(_db.bookmarks)
       ..where((tbl) =>
+          tbl.userId.equals(userId) &
           tbl.translationId.equals(translationId) &
           tbl.bookId.equals(bookId) &
           tbl.chapter.equals(chapter))
@@ -24,6 +26,7 @@ class AnnotationDao {
   }
 
   Future<BookmarksData?> findBookmark(
+    String userId,
     String translationId,
     int bookId,
     int chapter,
@@ -31,6 +34,7 @@ class AnnotationDao {
   ) {
     final query = _db.select(_db.bookmarks)
       ..where((tbl) =>
+          tbl.userId.equals(userId) &
           tbl.translationId.equals(translationId) &
           tbl.bookId.equals(bookId) &
           tbl.chapter.equals(chapter) &
@@ -43,17 +47,21 @@ class AnnotationDao {
     return _db.into(_db.bookmarks).insertOnConflictUpdate(companion);
   }
 
-  Future<void> deleteBookmark(String id) {
-    return (_db.delete(_db.bookmarks)..where((tbl) => tbl.id.equals(id))).go();
+  Future<void> deleteBookmark(String userId, String id) {
+    return (_db.delete(_db.bookmarks)
+          ..where((tbl) => tbl.id.equals(id) & tbl.userId.equals(userId)))
+        .go();
   }
 
   Stream<List<HighlightsData>> watchHighlightsForChapter(
+    String userId,
     String translationId,
     int bookId,
     int chapter,
   ) {
     final query = _db.select(_db.highlights)
       ..where((tbl) =>
+          tbl.userId.equals(userId) &
           tbl.translationId.equals(translationId) &
           tbl.bookId.equals(bookId) &
           tbl.chapter.equals(chapter))
@@ -64,6 +72,7 @@ class AnnotationDao {
   }
 
   Future<HighlightsData?> findHighlight(
+    String userId,
     String translationId,
     int bookId,
     int chapter,
@@ -71,6 +80,7 @@ class AnnotationDao {
   ) {
     final query = _db.select(_db.highlights)
       ..where((tbl) =>
+          tbl.userId.equals(userId) &
           tbl.translationId.equals(translationId) &
           tbl.bookId.equals(bookId) &
           tbl.chapter.equals(chapter) &
@@ -82,6 +92,7 @@ class AnnotationDao {
   Future<void> upsertHighlight(HighlightsCompanion companion) async {
     await (_db.delete(_db.highlights)
           ..where((tbl) =>
+              tbl.userId.equals(companion.userId.value) &
               tbl.translationId.equals(companion.translationId.value) &
               tbl.bookId.equals(companion.bookId.value) &
               tbl.chapter.equals(companion.chapter.value) &
@@ -90,17 +101,21 @@ class AnnotationDao {
     await _db.into(_db.highlights).insert(companion, mode: InsertMode.insertOrReplace);
   }
 
-  Future<void> deleteHighlight(String id) {
-    return (_db.delete(_db.highlights)..where((tbl) => tbl.id.equals(id))).go();
+  Future<void> deleteHighlight(String userId, String id) {
+    return (_db.delete(_db.highlights)
+          ..where((tbl) => tbl.id.equals(id) & tbl.userId.equals(userId)))
+        .go();
   }
 
   Stream<List<NotesData>> watchNotesForChapter(
+    String userId,
     String translationId,
     int bookId,
     int chapter,
   ) {
     final query = _db.select(_db.notes)
       ..where((tbl) =>
+          tbl.userId.equals(userId) &
           tbl.translationId.equals(translationId) &
           tbl.bookId.equals(bookId) &
           tbl.chapter.equals(chapter))
@@ -110,14 +125,15 @@ class AnnotationDao {
     return query.watch();
   }
 
-  Stream<List<NotesData>> watchNotesForVerse(String noteId) {
+  Stream<List<NotesData>> watchNotesForVerse(String userId, String noteId) {
     final query = _db.select(_db.notes)
-      ..where((tbl) => tbl.id.equals(noteId))
+      ..where((tbl) => tbl.id.equals(noteId) & tbl.userId.equals(userId))
       ..limit(1);
     return query.watch();
   }
 
   Future<NotesData?> findNote(
+    String userId,
     String translationId,
     int bookId,
     int chapter,
@@ -125,6 +141,7 @@ class AnnotationDao {
   ) {
     final query = _db.select(_db.notes)
       ..where((tbl) =>
+          tbl.userId.equals(userId) &
           tbl.translationId.equals(translationId) &
           tbl.bookId.equals(bookId) &
           tbl.chapter.equals(chapter) &
@@ -133,9 +150,9 @@ class AnnotationDao {
     return query.getSingleOrNull();
   }
 
-  Future<NotesData?> findNoteById(String id) {
+  Future<NotesData?> findNoteById(String userId, String id) {
     final query = _db.select(_db.notes)
-      ..where((tbl) => tbl.id.equals(id))
+      ..where((tbl) => tbl.id.equals(id) & tbl.userId.equals(userId))
       ..limit(1);
     return query.getSingleOrNull();
   }
@@ -146,11 +163,14 @@ class AnnotationDao {
 
   Future<void> updateNote(
     String id,
+    String userId,
     String text,
     int version,
     int updatedAt,
   ) {
-    return (_db.update(_db.notes)..where((tbl) => tbl.id.equals(id))).write(
+    return (_db.update(_db.notes)
+          ..where((tbl) => tbl.id.equals(id) & tbl.userId.equals(userId)))
+        .write(
       NotesCompanion(
         text: Value(text),
         version: Value(version),
@@ -159,13 +179,23 @@ class AnnotationDao {
     );
   }
 
+  Future<void> deleteNote(String userId, String id) {
+    return (_db.delete(_db.notes)
+          ..where((tbl) => tbl.id.equals(id) & tbl.userId.equals(userId)))
+        .go();
+  }
+
   Future<void> insertRevision(NoteRevisionsCompanion companion) {
     return _db
         .into(_db.noteRevisions)
         .insert(companion, mode: InsertMode.insertOrReplace);
   }
 
-  Future<NoteRevisionsData?> findRevision(String noteId, int version) {
+  Future<NoteRevisionsData?> findRevision(
+    String userId,
+    String noteId,
+    int version,
+  ) {
     final query = _db.select(_db.noteRevisions)
       ..where((tbl) =>
           tbl.noteId.equals(noteId) & tbl.version.equals(version))
@@ -173,7 +203,7 @@ class AnnotationDao {
     return query.getSingleOrNull();
   }
 
-  Future<List<NoteRevisionsData>> getRevisions(String noteId) {
+  Future<List<NoteRevisionsData>> getRevisions(String userId, String noteId) {
     final query = _db.select(_db.noteRevisions)
       ..where((tbl) => tbl.noteId.equals(noteId))
       ..orderBy([

--- a/lib/src/presentation/accounts/profile_management_screen.dart
+++ b/lib/src/presentation/accounts/profile_management_screen.dart
@@ -1,0 +1,230 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../domain/accounts/entities.dart';
+import '../providers.dart';
+import 'profile_onboarding_screen.dart';
+
+class ProfileManagementScreen extends ConsumerWidget {
+  const ProfileManagementScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final accountsAsync = ref.watch(accountsProvider);
+    final activeAccountAsync = ref.watch(activeAccountProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Manage profiles'),
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => _createProfile(context, ref),
+        icon: const Icon(Icons.add),
+        label: const Text('Add profile'),
+      ),
+      body: accountsAsync.when(
+        data: (profiles) {
+          if (profiles.isEmpty) {
+            return const Center(child: Text('No profiles yet. Create one to get started.'));
+          }
+          final activeId = activeAccountAsync.maybeWhen(
+            data: (account) => account?.id,
+            orElse: () => null,
+          );
+          return ListView.separated(
+            padding: const EdgeInsets.all(16),
+            itemCount: profiles.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 12),
+            itemBuilder: (context, index) {
+              final profile = profiles[index];
+              final isActive = profile.id == activeId;
+              return Card(
+                child: ListTile(
+                  leading: _ProfileAvatar(avatar: profile.avatarUrl, name: profile.displayName),
+                  title: Text(profile.displayName?.isNotEmpty == true
+                      ? profile.displayName!
+                      : 'Profile ${index + 1}'),
+                  subtitle: Text(
+                    profile.preferredCohortTitle?.isNotEmpty == true
+                        ? profile.preferredCohortTitle!
+                        : profile.preferredLessonClass?.isNotEmpty == true
+                            ? profile.preferredLessonClass!
+                            : 'No cohort preference',
+                  ),
+                  trailing: Wrap(
+                    spacing: 8,
+                    children: [
+                      if (isActive)
+                        Chip(
+                          label: Text('Active', style: Theme.of(context).textTheme.labelSmall),
+                          backgroundColor: Theme.of(context).colorScheme.primary.withOpacity(0.15),
+                        )
+                      else
+                        TextButton(
+                          onPressed: () => _setActive(context, ref, profile.id),
+                          child: const Text('Set active'),
+                        ),
+                      IconButton(
+                        tooltip: 'Edit profile',
+                        icon: const Icon(Icons.edit_outlined),
+                        onPressed: () => _editProfile(context, ref, profile),
+                      ),
+                      IconButton(
+                        tooltip: 'Delete profile',
+                        icon: const Icon(Icons.delete_outline),
+                        onPressed: () => _confirmDelete(context, ref, profile),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stack) => Center(
+          child: Text('Failed to load profiles: $error'),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _createProfile(BuildContext context, WidgetRef ref) async {
+    final result = await showDialog<ProfileFormResult>(
+      context: context,
+      builder: (dialogContext) => const ProfileFormDialog(),
+    );
+    if (result == null) {
+      return;
+    }
+    final id = const Uuid().v4();
+    final account = LocalAccount(
+      id: id,
+      displayName: result.displayName,
+      avatarUrl: result.avatar,
+      preferredCohortId: result.cohortId,
+      preferredCohortTitle: result.cohortTitle,
+      preferredLessonClass: result.cohortLessonClass,
+    );
+    try {
+      await ref.read(saveAccountUseCaseProvider)(account);
+      await ref.read(setActiveAccountUseCaseProvider)(id);
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Profile created.')),
+        );
+      }
+    } catch (error) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to create profile: $error')),
+        );
+      }
+    }
+  }
+
+  Future<void> _editProfile(BuildContext context, WidgetRef ref, LocalAccount account) async {
+    final result = await showDialog<ProfileFormResult>(
+      context: context,
+      builder: (dialogContext) => ProfileFormDialog(initial: account),
+    );
+    if (result == null) {
+      return;
+    }
+    final updated = account.copyWith(
+      displayName: result.displayName,
+      avatarUrl: result.avatar,
+      preferredCohortId: result.cohortId,
+      preferredCohortTitle: result.cohortTitle,
+      preferredLessonClass: result.cohortLessonClass,
+    );
+    try {
+      await ref.read(saveAccountUseCaseProvider)(updated);
+      if (updated.isActive) {
+        await ref.read(setActiveAccountUseCaseProvider)(updated.id);
+      }
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Profile updated.')),
+        );
+      }
+    } catch (error) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to update profile: $error')),
+        );
+      }
+    }
+  }
+
+  Future<void> _setActive(BuildContext context, WidgetRef ref, String id) async {
+    try {
+      await ref.read(setActiveAccountUseCaseProvider)(id);
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Profile activated.')),
+        );
+      }
+    } catch (error) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to activate profile: $error')),
+        );
+      }
+    }
+  }
+
+  Future<void> _confirmDelete(BuildContext context, WidgetRef ref, LocalAccount account) async {
+    final shouldDelete = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Delete profile'),
+        content: Text('Are you sure you want to delete "${account.displayName ?? 'this profile'}"?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (shouldDelete != true) {
+      return;
+    }
+    try {
+      await ref.read(deleteAccountUseCaseProvider)(account.id);
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Profile deleted.')),
+        );
+      }
+    } catch (error) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to delete profile: $error')),
+        );
+      }
+    }
+  }
+}
+
+class _ProfileAvatar extends StatelessWidget {
+  const _ProfileAvatar({this.avatar, this.name});
+
+  final String? avatar;
+  final String? name;
+
+  @override
+  Widget build(BuildContext context) {
+    if (avatar != null && avatar!.isNotEmpty) {
+      return CircleAvatar(child: Text(avatar!, style: const TextStyle(fontSize: 20)));
+    }
+    final initial = (name ?? '').trim().isNotEmpty ? name!.trim()[0].toUpperCase() : '?';
+    return CircleAvatar(child: Text(initial));
+  }
+}

--- a/lib/src/presentation/accounts/profile_onboarding_screen.dart
+++ b/lib/src/presentation/accounts/profile_onboarding_screen.dart
@@ -1,0 +1,378 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../domain/accounts/entities.dart';
+import '../providers.dart';
+import 'profile_management_screen.dart';
+
+const _avatarOptions = [
+  '😀',
+  '😇',
+  '🕊️',
+  '📚',
+  '🌟',
+  '🎓',
+  '🙏',
+  '💡',
+  '🌈',
+  '❤️',
+];
+
+class ProfileOnboardingScreen extends ConsumerWidget {
+  const ProfileOnboardingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final accountsAsync = ref.watch(accountsProvider);
+
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Welcome to AFC StudyMate',
+                style: Theme.of(context).textTheme.headlineSmall,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                'Create or choose a local profile to personalise your study experience.',
+                style: Theme.of(context).textTheme.bodyMedium,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 24),
+              Expanded(
+                child: accountsAsync.when(
+                  data: (profiles) {
+                    if (profiles.isEmpty) {
+                      return _EmptyState(onCreate: () => _createProfile(context, ref));
+                    }
+                    return ListView.separated(
+                      itemCount: profiles.length,
+                      separatorBuilder: (_, __) => const SizedBox(height: 12),
+                      itemBuilder: (context, index) {
+                        final profile = profiles[index];
+                        return Card(
+                          elevation: 2,
+                          child: ListTile(
+                            leading: _ProfileAvatar(avatar: profile.avatarUrl, name: profile.displayName),
+                            title: Text(profile.displayName?.isNotEmpty == true
+                                ? profile.displayName!
+                                : 'Profile ${index + 1}'),
+                            subtitle: Text(
+                              profile.preferredCohortTitle?.isNotEmpty == true
+                                  ? profile.preferredCohortTitle!
+                                  : profile.preferredLessonClass?.isNotEmpty == true
+                                      ? profile.preferredLessonClass!
+                                      : 'No cohort preference',
+                            ),
+                            trailing: ElevatedButton(
+                              onPressed: () => _selectProfile(context, ref, profile.id),
+                              child: const Text('Use profile'),
+                            ),
+                          ),
+                        );
+                      },
+                    );
+                  },
+                  loading: () => const Center(child: CircularProgressIndicator()),
+                  error: (error, stack) => Center(
+                    child: Text('Failed to load profiles: $error'),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+              FilledButton.icon(
+                onPressed: () => _createProfile(context, ref),
+                icon: const Icon(Icons.add),
+                label: const Text('Create profile'),
+              ),
+              const SizedBox(height: 12),
+              TextButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(builder: (_) => const ProfileManagementScreen()),
+                  );
+                },
+                child: const Text('Manage existing profiles'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _createProfile(BuildContext context, WidgetRef ref) async {
+    final result = await showDialog<ProfileFormResult>(
+      context: context,
+      builder: (dialogContext) => const ProfileFormDialog(),
+    );
+    if (result == null) {
+      return;
+    }
+    final id = const Uuid().v4();
+    final account = LocalAccount(
+      id: id,
+      displayName: result.displayName,
+      avatarUrl: result.avatar,
+      preferredCohortId: result.cohortId,
+      preferredCohortTitle: result.cohortTitle,
+      preferredLessonClass: result.cohortLessonClass,
+    );
+    try {
+      await ref.read(saveAccountUseCaseProvider)(account);
+      await ref.read(setActiveAccountUseCaseProvider)(id);
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Profile created.')),
+        );
+      }
+    } catch (error) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to create profile: $error')),
+        );
+      }
+    }
+  }
+
+  Future<void> _selectProfile(BuildContext context, WidgetRef ref, String id) async {
+    try {
+      await ref.read(setActiveAccountUseCaseProvider)(id);
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Profile selected.')),
+        );
+      }
+    } catch (error) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to select profile: $error')),
+        );
+      }
+    }
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.onCreate});
+
+  final VoidCallback onCreate;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.person_add_alt_1, size: 64),
+          const SizedBox(height: 16),
+          Text(
+            'No profiles yet',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          const Text('Create your first profile to get started.'),
+          const SizedBox(height: 16),
+          FilledButton(
+            onPressed: onCreate,
+            child: const Text('Create profile'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class ProfileFormResult {
+  const ProfileFormResult({
+    required this.displayName,
+    required this.avatar,
+    required this.cohortId,
+    required this.cohortTitle,
+    required this.cohortLessonClass,
+  });
+
+  final String? displayName;
+  final String? avatar;
+  final String? cohortId;
+  final String? cohortTitle;
+  final String? cohortLessonClass;
+}
+
+class ProfileFormDialog extends ConsumerStatefulWidget {
+  const ProfileFormDialog({super.key, this.initial});
+
+  final LocalAccount? initial;
+
+  @override
+  ConsumerState<ProfileFormDialog> createState() => _ProfileFormDialogState();
+}
+
+class _ProfileFormDialogState extends ConsumerState<ProfileFormDialog> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _nameController;
+  String? _selectedAvatar;
+  String? _selectedCohortId;
+  bool _cohortInitialised = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.initial?.displayName ?? '');
+    _selectedAvatar = widget.initial?.avatarUrl;
+    _selectedCohortId = widget.initial?.preferredCohortId;
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cohortOptionsAsync = ref.watch(cohortOptionsProvider);
+    final cohortOptions = cohortOptionsAsync.maybeWhen(
+      data: (data) {
+        if (!_cohortInitialised && _selectedCohortId != null) {
+          final exists = data.any((option) => option.id == _selectedCohortId);
+          if (!exists) {
+            _selectedCohortId = null;
+          }
+          _cohortInitialised = true;
+        }
+        return data;
+      },
+      orElse: () => const <CohortOption>[],
+    );
+
+    return AlertDialog(
+      title: Text(widget.initial == null ? 'Create profile' : 'Edit profile'),
+      content: SingleChildScrollView(
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'Display name'),
+                textCapitalization: TextCapitalization.words,
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Please enter a name';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              Text('Choose an avatar', style: Theme.of(context).textTheme.titleSmall),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  for (final avatar in _avatarOptions)
+                    ChoiceChip(
+                      label: Text(avatar, style: const TextStyle(fontSize: 20)),
+                      selected: _selectedAvatar == avatar,
+                      onSelected: (_) {
+                        setState(() {
+                          _selectedAvatar = avatar;
+                        });
+                      },
+                    ),
+                  ChoiceChip(
+                    label: const Text('None'),
+                    selected: _selectedAvatar == null,
+                    onSelected: (_) {
+                      setState(() {
+                        _selectedAvatar = null;
+                      });
+                    },
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Text('Preferred cohort', style: Theme.of(context).textTheme.titleSmall),
+              const SizedBox(height: 8),
+              DropdownButtonFormField<String?>(
+                value: _selectedCohortId,
+                items: [
+                  const DropdownMenuItem<String?>(
+                    value: null,
+                    child: Text('No preference'),
+                  ),
+                  for (final option in cohortOptions)
+                    DropdownMenuItem<String?>(
+                      value: option.id,
+                      child: Text(option.displayName),
+                    ),
+                ],
+                onChanged: (value) {
+                  setState(() {
+                    _selectedCohortId = value;
+                  });
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () {
+            if (!_formKey.currentState!.validate()) {
+              return;
+            }
+            CohortOption? selectedCohort;
+            for (final option in cohortOptions) {
+              if (option.id == _selectedCohortId) {
+                selectedCohort = option;
+                break;
+              }
+            }
+            Navigator.pop(
+              context,
+              ProfileFormResult(
+                displayName: _nameController.text.trim(),
+                avatar: _selectedAvatar,
+                cohortId: selectedCohort?.id,
+                cohortTitle: selectedCohort?.title,
+                cohortLessonClass: selectedCohort?.lessonClass,
+              ),
+            );
+          },
+          child: const Text('Save'),
+        ),
+      ],
+    );
+  }
+}
+
+class _ProfileAvatar extends StatelessWidget {
+  const _ProfileAvatar({this.avatar, this.name});
+
+  final String? avatar;
+  final String? name;
+
+  @override
+  Widget build(BuildContext context) {
+    if (avatar != null && avatar!.isNotEmpty) {
+      return CircleAvatar(child: Text(avatar!, style: const TextStyle(fontSize: 20)));
+    }
+    final initial = (name ?? '').trim().isNotEmpty ? name!.trim()[0].toUpperCase() : '?';
+    return CircleAvatar(child: Text(initial));
+  }
+}

--- a/lib/src/presentation/app/app.dart
+++ b/lib/src/presentation/app/app.dart
@@ -4,6 +4,7 @@ import 'package:google_fonts/google_fonts.dart';
 
 import '../providers.dart';
 import '../home/home_screen.dart';
+import '../accounts/profile_onboarding_screen.dart';
 
 class StudyMateApp extends ConsumerWidget {
   const StudyMateApp({super.key});
@@ -89,13 +90,37 @@ class StudyMateApp extends ConsumerWidget {
       ),
     );
 
+    final accountAsync = ref.watch(activeAccountProvider);
+
     return themeMode.when(
-      data: (mode) => MaterialApp(
-        title: 'AFC StudyMate',
-        theme: lightTheme,
-        darkTheme: darkTheme,
-        themeMode: mode,
-        home: const HomeScreen(),
+      data: (mode) => accountAsync.when(
+        data: (account) => MaterialApp(
+          title: 'AFC StudyMate',
+          theme: lightTheme,
+          darkTheme: darkTheme,
+          themeMode: mode,
+          home: account == null
+              ? const ProfileOnboardingScreen()
+              : const HomeScreen(),
+        ),
+        loading: () => MaterialApp(
+          title: 'AFC StudyMate',
+          theme: lightTheme,
+          darkTheme: darkTheme,
+          home: const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          ),
+        ),
+        error: (error, stack) => MaterialApp(
+          title: 'AFC StudyMate',
+          theme: lightTheme,
+          darkTheme: darkTheme,
+          home: Scaffold(
+            body: Center(
+              child: Text('Failed to load profiles: $error'),
+            ),
+          ),
+        ),
       ),
       loading: () => MaterialApp(
         title: 'AFC StudyMate',

--- a/lib/src/presentation/bible/chapter_screen.dart
+++ b/lib/src/presentation/bible/chapter_screen.dart
@@ -39,6 +39,12 @@ class _ChapterScreenState extends ConsumerState<ChapterScreen> {
       data: (data) => {for (final translation in data) translation.id: translation},
       orElse: () => <String, BibleTranslation>{},
     );
+    final userId = ref.watch(activeUserIdProvider);
+    if (userId == null || userId.isEmpty) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
 
     final parallelAsync = ref.watch(
       parallelChapterProvider(
@@ -56,6 +62,7 @@ class _ChapterScreenState extends ConsumerState<ChapterScreen> {
 
     for (final translationId in translationIds) {
       final request = AnnotationRequest(
+        userId: userId,
         translationId: translationId,
         bookId: widget.book.id,
         chapter: widget.chapter,
@@ -146,6 +153,7 @@ class _ChapterScreenState extends ConsumerState<ChapterScreen> {
                                     bookmark,
                                     highlight,
                                     note,
+                                    userId,
                                   );
                                 },
                               ),
@@ -175,6 +183,7 @@ class _ChapterScreenState extends ConsumerState<ChapterScreen> {
     Bookmark? bookmark,
     Highlight? highlight,
     Note? note,
+    String userId,
   ) async {
     final location = VerseLocation(
       translationId: verse.translationId,
@@ -211,7 +220,8 @@ class _ChapterScreenState extends ConsumerState<ChapterScreen> {
                 title: const Text('Remove highlight'),
                 onTap: () async {
                   Navigator.pop(sheetContext);
-                  await ref.read(removeHighlightUseCaseProvider)(highlight.id);
+                  await ref
+                      .read(removeHighlightUseCaseProvider)(userId, highlight.id);
                   if (!mounted) return;
                   ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(content: Text('Highlight removed.')),
@@ -241,7 +251,11 @@ class _ChapterScreenState extends ConsumerState<ChapterScreen> {
   }
 
   Future<void> _toggleBookmark(BuildContext context, VerseLocation location) async {
-    final result = await ref.read(toggleBookmarkUseCaseProvider)(location);
+    final userId = ref.read(activeUserIdProvider);
+    if (userId == null || userId.isEmpty) {
+      return;
+    }
+    final result = await ref.read(toggleBookmarkUseCaseProvider)(userId, location);
     if (!mounted) return;
     if (result != null) {
       await _updateReadingProgress(location);
@@ -261,6 +275,10 @@ class _ChapterScreenState extends ConsumerState<ChapterScreen> {
     VerseLocation location,
     Highlight? existing,
   ) async {
+    final userId = ref.read(activeUserIdProvider);
+    if (userId == null || userId.isEmpty) {
+      return;
+    }
     final selected = await showDialog<String>(
       context: context,
       builder: (dialogContext) => SimpleDialog(
@@ -299,6 +317,7 @@ class _ChapterScreenState extends ConsumerState<ChapterScreen> {
       return;
     }
     await ref.read(saveHighlightUseCaseProvider)(
+      userId,
       Highlight(
         id: existing?.id ?? '',
         location: location,
@@ -318,6 +337,10 @@ class _ChapterScreenState extends ConsumerState<ChapterScreen> {
     VerseLocation location,
     Note? note,
   ) async {
+    final userId = ref.read(activeUserIdProvider);
+    if (userId == null || userId.isEmpty) {
+      return;
+    }
     final controller = TextEditingController(text: note?.text ?? '');
     try {
       final result = await showDialog<String>(
@@ -349,7 +372,7 @@ class _ChapterScreenState extends ConsumerState<ChapterScreen> {
       }
       if (result.isEmpty) {
         if (note != null) {
-          await ref.read(deleteNoteUseCaseProvider)(note.id);
+          await ref.read(deleteNoteUseCaseProvider)(userId, note.id);
           if (!mounted) return;
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('Note removed.')),
@@ -357,7 +380,7 @@ class _ChapterScreenState extends ConsumerState<ChapterScreen> {
         }
         return;
       }
-      await ref.read(saveNoteUseCaseProvider)(location, result);
+      await ref.read(saveNoteUseCaseProvider)(userId, location, result);
       await _updateReadingProgress(location);
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
@@ -369,8 +392,13 @@ class _ChapterScreenState extends ConsumerState<ChapterScreen> {
   }
 
   Future<void> _updateReadingProgress(VerseLocation location) {
+    final userId = ref.read(activeUserIdProvider);
+    if (userId == null || userId.isEmpty) {
+      return Future.value();
+    }
     final saveProgress = ref.read(saveReadingProgressUseCaseProvider);
     return saveProgress(
+      userId,
       ReadingPosition(
         translationId: location.translationId,
         bookId: location.bookId,
@@ -532,7 +560,12 @@ class _TranslationAnnotationSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final userId = ref.watch(activeUserIdProvider);
+    if (userId == null || userId.isEmpty) {
+      return const SizedBox.shrink();
+    }
     final request = AnnotationRequest(
+      userId: userId,
       translationId: translationId,
       bookId: book.id,
       chapter: chapter,
@@ -571,8 +604,10 @@ class _TranslationAnnotationSection extends ConsumerWidget {
               trailing: IconButton(
                 icon: const Icon(Icons.delete_outline),
                 onPressed: () async {
-                  await ref
-                      .read(toggleBookmarkUseCaseProvider)(bookmark.location);
+                  await ref.read(toggleBookmarkUseCaseProvider)(
+                    userId,
+                    bookmark.location,
+                  );
                   if (!context.mounted) return;
                   ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(
@@ -596,7 +631,8 @@ class _TranslationAnnotationSection extends ConsumerWidget {
               trailing: IconButton(
                 icon: const Icon(Icons.delete_outline),
                 onPressed: () async {
-                  await ref.read(removeHighlightUseCaseProvider)(highlight.id);
+                  await ref
+                      .read(removeHighlightUseCaseProvider)(userId, highlight.id);
                   if (!context.mounted) return;
                   ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(
@@ -625,6 +661,10 @@ class _NoteListTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final userId = ref.watch(activeUserIdProvider);
+    if (userId == null || userId.isEmpty) {
+      return const SizedBox.shrink();
+    }
     return ExpansionTile(
       title: Text('Verse ${note.location.verse} · v${note.version}'),
       subtitle: Text(note.text),
@@ -637,7 +677,7 @@ class _NoteListTile extends ConsumerWidget {
               tooltip: 'Undo to previous version',
               onPressed: note.canUndo
                   ? () async {
-                      await ref.read(undoNoteUseCaseProvider)(note.id);
+                      await ref.read(undoNoteUseCaseProvider)(userId, note.id);
                       if (!context.mounted) return;
                       ScaffoldMessenger.of(context).showSnackBar(
                         const SnackBar(content: Text('Note reverted.')),
@@ -648,7 +688,7 @@ class _NoteListTile extends ConsumerWidget {
             IconButton(
               icon: const Icon(Icons.delete_outline),
               onPressed: () async {
-                await ref.read(deleteNoteUseCaseProvider)(note.id);
+                await ref.read(deleteNoteUseCaseProvider)(userId, note.id);
                 if (!context.mounted) return;
                 ScaffoldMessenger.of(context).showSnackBar(
                   const SnackBar(content: Text('Note deleted.')),

--- a/lib/src/presentation/lessons/lesson_detail_screen.dart
+++ b/lib/src/presentation/lessons/lesson_detail_screen.dart
@@ -20,8 +20,6 @@ class LessonDetailScreen extends ConsumerStatefulWidget {
 }
 
 class _LessonDetailScreenState extends ConsumerState<LessonDetailScreen> {
-  static const _userId = 'local-user';
-
   LessonProgress? _progress;
   late LessonTimerService _timerService;
   StreamSubscription<int>? _timerSub;
@@ -29,6 +27,8 @@ class _LessonDetailScreenState extends ConsumerState<LessonDetailScreen> {
   Map<String, LessonQuizSubmission> _responses = const {};
   double? _lastQuizScore;
   bool _isPersisting = false;
+  String? _userId;
+  ProviderSubscription<AsyncValue<LessonProgress?>>? _progressSubscription;
 
   @override
   void initState() {
@@ -43,10 +43,43 @@ class _LessonDetailScreenState extends ConsumerState<LessonDetailScreen> {
         _sessionSeconds = seconds;
       });
     });
-    ref.listen<AsyncValue<LessonProgress?>>(
+    ref.listen<String?>(
+      activeUserIdProvider,
+      (previous, next) {
+        if (!mounted) {
+          return;
+        }
+        if (next == null || next.isEmpty) {
+          setState(() {
+            _userId = null;
+            _progress = null;
+          });
+          _progressSubscription?.close();
+          _progressSubscription = null;
+          return;
+        }
+        if (next != _userId) {
+          _userId = next;
+          _subscribeToProgress(next);
+        }
+      },
+      fireImmediately: true,
+    );
+  }
+
+  @override
+  void dispose() {
+    _timerSub?.cancel();
+    _progressSubscription?.close();
+    super.dispose();
+  }
+
+  void _subscribeToProgress(String userId) {
+    _progressSubscription?.close();
+    _progressSubscription = ref.listen<AsyncValue<LessonProgress?>>(
       lessonProgressProvider(
         LessonProgressRequest(
-          userId: _userId,
+          userId: userId,
           lessonId: widget.lesson.id,
         ),
       ),
@@ -60,17 +93,18 @@ class _LessonDetailScreenState extends ConsumerState<LessonDetailScreen> {
           });
         });
       },
+      fireImmediately: true,
     );
   }
 
   @override
-  void dispose() {
-    _timerSub?.cancel();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
+    final userId = ref.watch(activeUserIdProvider);
+    if (userId == null || userId.isEmpty) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
     final theme = Theme.of(context);
     final ageLabel = widget.lesson.ageRange != null
         ? '${widget.lesson.ageRange!.min}-${widget.lesson.ageRange!.max} years'
@@ -78,7 +112,7 @@ class _LessonDetailScreenState extends ConsumerState<LessonDetailScreen> {
     final progressAsync = ref.watch(
       lessonProgressProvider(
         LessonProgressRequest(
-          userId: _userId,
+          userId: userId,
           lessonId: widget.lesson.id,
         ),
       ),
@@ -385,6 +419,13 @@ class _LessonDetailScreenState extends ConsumerState<LessonDetailScreen> {
     setState(() {
       _isPersisting = true;
     });
+    final userId = _userId;
+    if (userId == null || userId.isEmpty) {
+      setState(() {
+        _isPersisting = false;
+      });
+      return;
+    }
     final elapsedSeconds = consumeTimer ? _timerService.consume() : 0;
     final now = DateTime.now();
     final existing = _progress;
@@ -395,8 +436,8 @@ class _LessonDetailScreenState extends ConsumerState<LessonDetailScreen> {
         ? now
         : (clearCompletion ? null : existing?.completedAt);
     final progress = LessonProgress(
-      id: existing?.id ?? '${_userId}_${widget.lesson.id}',
-      userId: _userId,
+      id: existing?.id ?? '${userId}_${widget.lesson.id}',
+      userId: userId,
       lessonId: widget.lesson.id,
       status: status,
       quizScore: quizScore ?? existing?.quizScore,

--- a/lib/src/presentation/providers.dart
+++ b/lib/src/presentation/providers.dart
@@ -131,6 +131,58 @@ final accountRepositoryProvider = Provider<AccountRepository>((ref) {
   return AccountRepositoryImpl(db, dao);
 });
 
+final watchAccountsUseCaseProvider = Provider((ref) {
+  return WatchAccountsUseCase(ref.watch(accountRepositoryProvider));
+});
+
+final getAccountsUseCaseProvider = Provider((ref) {
+  return GetAccountsUseCase(ref.watch(accountRepositoryProvider));
+});
+
+final setActiveAccountUseCaseProvider = Provider((ref) {
+  return SetActiveAccountUseCase(ref.watch(accountRepositoryProvider));
+});
+
+class CohortOption {
+  const CohortOption({
+    required this.id,
+    this.title,
+    this.lessonClass,
+  });
+
+  final String id;
+  final String? title;
+  final String? lessonClass;
+
+  String get displayName {
+    if (title != null && title!.isNotEmpty) {
+      return title!;
+    }
+    if (lessonClass != null && lessonClass!.isNotEmpty) {
+      return lessonClass!;
+    }
+    return id;
+  }
+}
+
+final cohortOptionsProvider = FutureProvider<List<CohortOption>>((ref) async {
+  final db = ref.watch(appDatabaseProvider);
+  final rows = await db.select(db.lessonFeeds).get();
+  final options = <String, CohortOption>{};
+  for (final row in rows) {
+    final id = row.id;
+    final title = row.cohort ?? row.id;
+    options[id] = CohortOption(
+      id: id,
+      title: title,
+      lessonClass: row.lessonClass,
+    );
+  }
+  final list = options.values.toList()
+    ..sort((a, b) => a.displayName.compareTo(b.displayName));
+  return list;
+});
+
 final syncRepositoryProvider = Provider<SyncRepository>((ref) {
   final db = ref.watch(appDatabaseProvider);
   final dao = ref.watch(syncDaoProvider);
@@ -297,9 +349,21 @@ final lessonProgressProvider = StreamProvider.autoDispose
 
 final lessonProgressDashboardProvider =
     StreamProvider.autoDispose<LessonProgressDashboardData>((ref) {
-  const userId = 'local-user';
+  final userId = ref.watch(activeUserIdProvider);
+  if (userId == null) {
+    return Stream.value(const LessonProgressDashboardData(
+      snapshots: [],
+      completedCount: 0,
+      inProgressCount: 0,
+      notStartedCount: 0,
+      totalTimeSpentSeconds: 0,
+      averageQuizScore: 0,
+      classSummaries: [],
+      completionsByDay: <DateTime, int>{},
+    ));
+  }
   final lessonsStream = ref.watch(watchLessonsUseCaseProvider)(
-    filter: const LessonQuery(),
+    filter: LessonQuery(userId: userId),
   );
   final progressStream =
       ref.watch(watchLessonProgressUseCaseProvider)(userId);
@@ -435,6 +499,22 @@ final watchAccountUseCaseProvider = Provider((ref) {
   return WatchAccountUseCase(ref.watch(accountRepositoryProvider));
 });
 
+final activeAccountProvider = StreamProvider<LocalAccount?>((ref) {
+  return ref.watch(watchAccountUseCaseProvider)();
+});
+
+final accountsProvider = StreamProvider<List<LocalAccount>>((ref) {
+  return ref.watch(watchAccountsUseCaseProvider)();
+});
+
+final activeUserIdProvider = Provider<String?>((ref) {
+  final account = ref.watch(activeAccountProvider);
+  return account.maybeWhen(
+    data: (value) => value?.id,
+    orElse: () => null,
+  );
+});
+
 final saveAccountUseCaseProvider = Provider((ref) {
   return SaveAccountUseCase(ref.watch(accountRepositoryProvider));
 });
@@ -541,7 +621,7 @@ class LessonFilterState {
     this.selectedClass,
     this.age,
     this.completion = LessonCompletionFilter.all,
-    this.userId = 'local-user',
+    required this.userId,
   });
 
   final String? selectedClass;
@@ -577,7 +657,12 @@ class LessonFilterState {
 }
 
 class LessonFiltersNotifier extends StateNotifier<LessonFilterState> {
-  LessonFiltersNotifier() : super(const LessonFilterState());
+  LessonFiltersNotifier(String userId)
+      : super(LessonFilterState(userId: userId));
+
+  void setUser(String userId) {
+    state = state.copyWith(userId: userId);
+  }
 
   void setClass(String? lessonClass) {
     state = state.copyWith(selectedClass: lessonClass, resetClass: lessonClass == null);
@@ -594,7 +679,14 @@ class LessonFiltersNotifier extends StateNotifier<LessonFilterState> {
 
 final lessonFiltersProvider =
     StateNotifierProvider<LessonFiltersNotifier, LessonFilterState>((ref) {
-  return LessonFiltersNotifier();
+  final userId = ref.watch(activeUserIdProvider) ?? '';
+  final notifier = LessonFiltersNotifier(userId);
+  ref.listen<String?>(activeUserIdProvider, (previous, next) {
+    if (next != null) {
+      notifier.setUser(next);
+    }
+  });
+  return notifier;
 });
 
 final booksProvider = FutureProvider((ref) async {
@@ -743,11 +835,13 @@ List<ParallelVerseRow> _mergeParallelVerses(
 
 class AnnotationRequest {
   const AnnotationRequest({
+    required this.userId,
     required this.translationId,
     required this.bookId,
     required this.chapter,
   });
 
+  final String userId;
   final String translationId;
   final int bookId;
   final int chapter;
@@ -756,38 +850,64 @@ class AnnotationRequest {
 final chapterBookmarksProvider = StreamProvider.autoDispose
     .family<List<Bookmark>, AnnotationRequest>((ref, request) {
   final useCase = ref.watch(watchBookmarksForChapterUseCaseProvider);
-  return useCase(request.translationId, request.bookId, request.chapter);
+  return useCase(
+    request.userId,
+    request.translationId,
+    request.bookId,
+    request.chapter,
+  );
 });
 
 final chapterHighlightsProvider = StreamProvider.autoDispose
     .family<List<Highlight>, AnnotationRequest>((ref, request) {
   final useCase = ref.watch(watchHighlightsForChapterUseCaseProvider);
-  return useCase(request.translationId, request.bookId, request.chapter);
+  return useCase(
+    request.userId,
+    request.translationId,
+    request.bookId,
+    request.chapter,
+  );
 });
 
 final chapterNotesProvider = StreamProvider.autoDispose
     .family<List<Note>, AnnotationRequest>((ref, request) {
   final useCase = ref.watch(watchNotesForChapterUseCaseProvider);
-  return useCase(request.translationId, request.bookId, request.chapter);
+  return useCase(
+    request.userId,
+    request.translationId,
+    request.bookId,
+    request.chapter,
+  );
 });
 
 final readingProgressProvider = StreamProvider<ReadingPosition?>((ref) {
+  final userId = ref.watch(activeUserIdProvider);
+  if (userId == null) {
+    return Stream.value(null);
+  }
   final useCase = ref.watch(watchReadingProgressUseCaseProvider);
-  return useCase();
+  return useCase(userId);
 });
 
 class ThemeModeController extends AsyncNotifier<ThemeMode> {
   @override
   Future<ThemeMode> build() async {
+    final userId = ref.watch(activeUserIdProvider);
+    if (userId == null) {
+      return ThemeMode.system;
+    }
     final getThemeMode = ref.read(getThemeModeUseCaseProvider);
-    final mode = await getThemeMode();
+    final mode = await getThemeMode(userId);
     return _map(mode);
   }
 
   Future<void> setThemeMode(ThemeMode mode) async {
-    final saveTheme = ref.read(saveThemeModeUseCaseProvider);
     final domainMode = _reverseMap(mode);
-    await saveTheme(domainMode);
+    final userId = ref.read(activeUserIdProvider);
+    if (userId != null) {
+      final saveTheme = ref.read(saveThemeModeUseCaseProvider);
+      await saveTheme(userId, domainMode);
+    }
     state = AsyncValue.data(mode);
   }
 

--- a/lib/src/presentation/settings/settings_screen.dart
+++ b/lib/src/presentation/settings/settings_screen.dart
@@ -13,6 +13,7 @@ import 'bible_import_controller.dart';
 import 'about_screen.dart';
 import 'lesson_sync_controller.dart';
 import 'privacy_policy_screen.dart';
+import '../accounts/profile_management_screen.dart';
 
 class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
@@ -23,6 +24,7 @@ class SettingsScreen extends ConsumerWidget {
     final translationsAsync = ref.watch(translationsProvider);
     final syncState = ref.watch(lessonSyncControllerProvider);
     final importState = ref.watch(bibleImportControllerProvider);
+    final activeAccountAsync = ref.watch(activeAccountProvider);
 
     ref.listen<BibleImportState>(bibleImportControllerProvider,
         (previous, next) {
@@ -68,6 +70,42 @@ class SettingsScreen extends ConsumerWidget {
       appBar: AppBar(title: const Text('Settings')),
       body: ListView(
         children: [
+          activeAccountAsync.when(
+            data: (account) => ListTile(
+              leading: _ProfileAvatar(avatar: account?.avatarUrl, name: account?.displayName),
+              title: Text(account?.displayName?.isNotEmpty == true
+                  ? account!.displayName!
+                  : 'No profile selected'),
+              subtitle: const Text('Current profile'),
+              trailing: TextButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const ProfileManagementScreen()),
+                  );
+                },
+                child: const Text('Manage'),
+              ),
+            ),
+            loading: () => const ListTile(
+              leading: CircularProgressIndicator(),
+              title: Text('Loading profile...'),
+            ),
+            error: (error, stack) => ListTile(
+              leading: const Icon(Icons.error_outline),
+              title: Text('Failed to load profile: $error'),
+              trailing: TextButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const ProfileManagementScreen()),
+                  );
+                },
+                child: const Text('Manage'),
+              ),
+            ),
+          ),
+          const Divider(),
           ListTile(
             leading: const Icon(Icons.info_outline),
             title: const Text('About'),
@@ -315,6 +353,22 @@ class SettingsScreen extends ConsumerWidget {
         );
       },
     );
+  }
+}
+
+class _ProfileAvatar extends StatelessWidget {
+  const _ProfileAvatar({this.avatar, this.name});
+
+  final String? avatar;
+  final String? name;
+
+  @override
+  Widget build(BuildContext context) {
+    if (avatar != null && avatar!.isNotEmpty) {
+      return CircleAvatar(child: Text(avatar!, style: const TextStyle(fontSize: 20)));
+    }
+    final initial = (name ?? '').trim().isNotEmpty ? name!.trim()[0].toUpperCase() : '?';
+    return CircleAvatar(child: Text(initial));
   }
 }
 


### PR DESCRIPTION
## Summary
- add per-user scoping across annotations, lesson progress, reading progress, and theme settings
- extend the local users schema with preferences and active flags and update migrations
- introduce profile onboarding/management flows and wire them into the app shell and settings

## Testing
- No tests were run (environment missing Flutter/Dart SDK)


------
https://chatgpt.com/codex/tasks/task_e_68df8a359d9c83209e3c349038ade6d9