### PR TITLE
Fix numeric defaults for lesson progress summaries

### DIFF
--- a/lib/src/domain/lessons/progress_dashboard.dart
+++ b/lib/src/domain/lessons/progress_dashboard.dart
@@ -55,5 +55,5 @@ class LessonProgressDashboardData {
       completedCount + inProgressCount + notStartedCount;
 
   double get completionRate =>
-      totalLessons == 0 ? 0 : completedCount / totalLessons;
+      totalLessons == 0 ? 0.0 : completedCount / totalLessons;
 }

--- a/lib/src/presentation/lessons/lesson_progress_dashboard_screen.dart
+++ b/lib/src/presentation/lessons/lesson_progress_dashboard_screen.dart
@@ -58,7 +58,7 @@ class LessonProgressDashboardScreen extends ConsumerWidget {
       final progress = snapshot.progress;
       final status = progress?.status ?? 'not_started';
       final timeSpent = progress?.timeSpentSeconds ?? 0;
-      final quizScore = progress?.quizScore ?? 0;
+      final quizScore = progress?.quizScore ?? 0.0;
       final startedAt = progress?.startedAt?.toIso8601String() ?? '';
       final completedAt = progress?.completedAt?.toIso8601String() ?? '';
       final updatedAt = progress?.updatedAt.toIso8601String() ?? '';

--- a/lib/src/presentation/providers.dart
+++ b/lib/src/presentation/providers.dart
@@ -453,7 +453,7 @@ final lessonProgressDashboardProvider =
         }
 
         final averageScore = classScores.isEmpty
-            ? 0
+            ? 0.0
             : classScores.reduce((a, b) => a + b) / classScores.length;
 
         classSummaries.add(
@@ -474,7 +474,7 @@ final lessonProgressDashboardProvider =
       );
 
       final averageQuizScore = quizScores.isEmpty
-          ? 0
+          ? 0.0
           : quizScores.reduce((a, b) => a + b) / quizScores.length;
 
       return LessonProgressDashboardData(


### PR DESCRIPTION
## Summary
- ensure lesson dashboard averages default to `0.0` so calculations stay in double precision
- export dashboard quiz scores with a double fallback value
- keep completion rate output as a double when no lessons are available

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df95380fec8320bd2977b4962c5dd3