### PR TITLE
Implement real-time class chat with moderation and notifications

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,6 +36,8 @@ class _AppBootstrap extends ConsumerWidget {
     final dataSync = ref.read(syncOrchestratorProvider);
     dataSync.ensureBackgroundScheduled();
     unawaited(dataSync.syncNow().catchError((_) {}));
+    ref.watch(notificationServiceProvider);
+    ref.watch(chatNotificationObserverProvider);
     return const StudyMateApp();
   }
 }

--- a/lib/src/data/chat/chat_remote_data_source.dart
+++ b/lib/src/data/chat/chat_remote_data_source.dart
@@ -1,0 +1,373 @@
+import 'dart:io';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+
+import '../../domain/chat/entities.dart';
+
+class RemoteChatMessage {
+  final String id;
+  final String classId;
+  final String userId;
+  final String body;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final bool deleted;
+  final bool flagged;
+  final List<ChatAttachment> attachments;
+  final String? authorName;
+
+  RemoteChatMessage({
+    required this.id,
+    required this.classId,
+    required this.userId,
+    required this.body,
+    required this.createdAt,
+    required this.updatedAt,
+    this.deleted = false,
+    this.flagged = false,
+    this.attachments = const [],
+    this.authorName,
+  });
+
+  factory RemoteChatMessage.fromDoc(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data()!;
+    return RemoteChatMessage(
+      id: doc.id,
+      classId: data['classId'] as String,
+      userId: data['userId'] as String,
+      body: data['body'] as String? ?? '',
+      createdAt: _fromTimestamp(data['createdAt']),
+      updatedAt: _fromTimestamp(data['updatedAt']),
+      deleted: data['deleted'] as bool? ?? false,
+      flagged: data['flagged'] as bool? ?? false,
+      attachments: _parseAttachments(data['attachments']),
+      authorName: data['authorName'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'classId': classId,
+        'userId': userId,
+        'body': body,
+        'createdAt': Timestamp.fromDate(createdAt.toUtc()),
+        'updatedAt': Timestamp.fromDate(updatedAt.toUtc()),
+        'deleted': deleted,
+        'flagged': flagged,
+        'attachments': attachments.map((e) => e.toJson()).toList(),
+        if (authorName != null) 'authorName': authorName,
+      };
+
+  static List<ChatAttachment> _parseAttachments(dynamic raw) {
+    if (raw == null) {
+      return const [];
+    }
+    final list = (raw as List<dynamic>)
+        .map((item) => Map<String, dynamic>.from(item as Map))
+        .toList(growable: false);
+    return list
+        .map(
+          (item) => ChatAttachment(
+            id: item['id'] as String,
+            type: item['type'] as String,
+            name: item['name'] as String? ?? '',
+            url: item['url'] as String? ?? '',
+            localPath: item['localPath'] as String?,
+            sizeBytes: item['sizeBytes'] as int?,
+          ),
+        )
+        .toList();
+  }
+}
+
+class RemoteTypingStatus {
+  final String userId;
+  final String classId;
+  final bool isTyping;
+  final DateTime updatedAt;
+
+  RemoteTypingStatus({
+    required this.userId,
+    required this.classId,
+    required this.isTyping,
+    required this.updatedAt,
+  });
+
+  factory RemoteTypingStatus.fromDoc(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data()!;
+    return RemoteTypingStatus(
+      userId: data['userId'] as String,
+      classId: data['classId'] as String,
+      isTyping: data['isTyping'] as bool? ?? false,
+      updatedAt: _fromTimestamp(data['updatedAt']),
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'userId': userId,
+        'classId': classId,
+        'isTyping': isTyping,
+        'updatedAt': Timestamp.fromDate(updatedAt.toUtc()),
+      };
+}
+
+class RemoteModerationAction {
+  final String id;
+  final String classId;
+  final String targetUserId;
+  final ModerationActionType type;
+  final String moderatorId;
+  final DateTime createdAt;
+  final DateTime? expiresAt;
+  final ModerationActionStatus status;
+  final String? reason;
+  final Map<String, dynamic> metadata;
+
+  RemoteModerationAction({
+    required this.id,
+    required this.classId,
+    required this.targetUserId,
+    required this.type,
+    required this.moderatorId,
+    required this.createdAt,
+    this.expiresAt,
+    this.status = ModerationActionStatus.pending,
+    this.reason,
+    this.metadata = const {},
+  });
+
+  factory RemoteModerationAction.fromDoc(
+    DocumentSnapshot<Map<String, dynamic>> doc,
+  ) {
+    final data = doc.data()!;
+    return RemoteModerationAction(
+      id: doc.id,
+      classId: data['classId'] as String,
+      targetUserId: data['targetUserId'] as String,
+      type: ModerationActionType.values.firstWhere(
+        (value) => value.name == (data['type'] as String? ?? 'flag'),
+        orElse: () => ModerationActionType.flag,
+      ),
+      moderatorId: data['moderatorId'] as String? ?? '',
+      createdAt: _fromTimestamp(data['createdAt']),
+      expiresAt: data['expiresAt'] != null ? _fromTimestamp(data['expiresAt']) : null,
+      status: ModerationActionStatus.values.firstWhere(
+        (value) => value.name == (data['status'] as String? ?? 'pending'),
+        orElse: () => ModerationActionStatus.pending,
+      ),
+      reason: data['reason'] as String?,
+      metadata: Map<String, dynamic>.from(data['metadata'] as Map? ?? const {}),
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'classId': classId,
+        'targetUserId': targetUserId,
+        'type': type.name,
+        'moderatorId': moderatorId,
+        'createdAt': Timestamp.fromDate(createdAt.toUtc()),
+        'expiresAt': expiresAt != null
+            ? Timestamp.fromDate(expiresAt!.toUtc())
+            : null,
+        'status': status.name,
+        if (reason != null) 'reason': reason,
+        'metadata': metadata,
+      }..removeWhere((key, value) => value == null);
+}
+
+class RemoteModerationAppeal {
+  final String id;
+  final String actionId;
+  final String userId;
+  final String message;
+  final DateTime createdAt;
+  final ModerationAppealStatus status;
+  final DateTime? resolvedAt;
+  final String? resolutionNotes;
+
+  RemoteModerationAppeal({
+    required this.id,
+    required this.actionId,
+    required this.userId,
+    required this.message,
+    required this.createdAt,
+    this.status = ModerationAppealStatus.submitted,
+    this.resolvedAt,
+    this.resolutionNotes,
+  });
+
+  factory RemoteModerationAppeal.fromDoc(
+    DocumentSnapshot<Map<String, dynamic>> doc,
+  ) {
+    final data = doc.data()!;
+    return RemoteModerationAppeal(
+      id: doc.id,
+      actionId: data['actionId'] as String,
+      userId: data['userId'] as String,
+      message: data['message'] as String? ?? '',
+      createdAt: _fromTimestamp(data['createdAt']),
+      status: ModerationAppealStatus.values.firstWhere(
+        (value) => value.name == (data['status'] as String? ?? 'submitted'),
+        orElse: () => ModerationAppealStatus.submitted,
+      ),
+      resolvedAt:
+          data['resolvedAt'] != null ? _fromTimestamp(data['resolvedAt']) : null,
+      resolutionNotes: data['resolutionNotes'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'actionId': actionId,
+        'userId': userId,
+        'message': message,
+        'createdAt': Timestamp.fromDate(createdAt.toUtc()),
+        'status': status.name,
+        if (resolvedAt != null)
+          'resolvedAt': Timestamp.fromDate(resolvedAt!.toUtc()),
+        if (resolutionNotes != null) 'resolutionNotes': resolutionNotes,
+      };
+}
+
+class ChatRemoteDataSource {
+  ChatRemoteDataSource(this._firestore, this._storage);
+
+  final FirebaseFirestore _firestore;
+  final FirebaseStorage _storage;
+
+  CollectionReference<Map<String, dynamic>> _messagesCollection(String classId) {
+    return _firestore.collection('classes').doc(classId).collection('messages');
+  }
+
+  CollectionReference<Map<String, dynamic>> _typingCollection(String classId) {
+    return _firestore.collection('classes').doc(classId).collection('typing');
+  }
+
+  CollectionReference<Map<String, dynamic>> _moderationCollection(String classId) {
+    return _firestore.collection('classes').doc(classId).collection('moderation');
+  }
+
+  CollectionReference<Map<String, dynamic>> _appealsCollection(String classId) {
+    return _firestore.collection('classes').doc(classId).collection('appeals');
+  }
+
+  Stream<List<RemoteChatMessage>> watchMessages(String classId) {
+    return _messagesCollection(classId)
+        .orderBy('createdAt')
+        .snapshots()
+        .map(
+          (snapshot) => snapshot.docs
+              .map(RemoteChatMessage.fromDoc)
+              .toList(growable: false),
+        );
+  }
+
+  Stream<List<RemoteTypingStatus>> watchTyping(String classId) {
+    return _typingCollection(classId)
+        .snapshots()
+        .map(
+          (snapshot) => snapshot.docs
+              .map(RemoteTypingStatus.fromDoc)
+              .toList(growable: false),
+        );
+  }
+
+  Stream<List<RemoteModerationAction>> watchModerationActions(String classId) {
+    return _moderationCollection(classId)
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map(
+          (snapshot) => snapshot.docs
+              .map(RemoteModerationAction.fromDoc)
+              .toList(growable: false),
+        );
+  }
+
+  Stream<List<RemoteModerationAppeal>> watchAppeals(String classId) {
+    return _appealsCollection(classId)
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map(
+          (snapshot) => snapshot.docs
+              .map(RemoteModerationAppeal.fromDoc)
+              .toList(growable: false),
+        );
+  }
+
+  Future<void> sendMessage(RemoteChatMessage message) {
+    final doc = _messagesCollection(message.classId).doc(message.id);
+    return doc.set(message.toMap(), SetOptions(merge: true));
+  }
+
+  Future<void> updateMessage(
+    String classId,
+    String messageId,
+    Map<String, dynamic> data,
+  ) {
+    final sanitized = <String, dynamic>{};
+    data.forEach((key, value) {
+      if (value is DateTime) {
+        sanitized[key] = Timestamp.fromDate(value.toUtc());
+      } else {
+        sanitized[key] = value;
+      }
+    });
+    return _messagesCollection(classId)
+        .doc(messageId)
+        .set(sanitized, SetOptions(merge: true));
+  }
+
+  Future<void> deleteMessage(String classId, String messageId) {
+    return _messagesCollection(classId).doc(messageId).update({
+      'deleted': true,
+      'updatedAt': Timestamp.fromDate(DateTime.now().toUtc()),
+    });
+  }
+
+  Future<String> uploadAttachment({
+    required String classId,
+    required String messageId,
+    required File file,
+    required String fileName,
+  }) async {
+    final ref = _storage
+        .ref()
+        .child('classes/$classId/messages/$messageId/${DateTime.now().millisecondsSinceEpoch}_$fileName');
+    final uploadTask = await ref.putFile(file);
+    return uploadTask.ref.getDownloadURL();
+  }
+
+  Future<void> setTyping(RemoteTypingStatus status) {
+    return _typingCollection(status.classId)
+        .doc(status.userId)
+        .set(status.toMap(), SetOptions(merge: true));
+  }
+
+  Future<void> removeTyping(String classId, String userId) {
+    return _typingCollection(classId).doc(userId).delete();
+  }
+
+  Future<void> recordModerationAction(RemoteModerationAction action) {
+    return _moderationCollection(action.classId)
+        .doc(action.id)
+        .set(action.toMap(), SetOptions(merge: true));
+  }
+
+  Future<void> submitAppeal(RemoteModerationAppeal appeal, String classId) {
+    return _appealsCollection(classId)
+        .doc(appeal.id)
+        .set(appeal.toMap(), SetOptions(merge: true));
+  }
+
+  static DateTime _fromTimestamp(dynamic value) {
+    if (value is Timestamp) {
+      return value.toDate().toUtc();
+    }
+    if (value is DateTime) {
+      return value.toUtc();
+    }
+    if (value is int) {
+      return DateTime.fromMillisecondsSinceEpoch(value, isUtc: true);
+    }
+    return DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
+  }
+}

--- a/lib/src/data/chat/chat_repository_impl.dart
+++ b/lib/src/data/chat/chat_repository_impl.dart
@@ -1,64 +1,392 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:drift/drift.dart';
 import 'package:uuid/uuid.dart';
 
 import '../../domain/chat/entities.dart';
+import '../../domain/chat/errors.dart';
 import '../../domain/chat/repositories.dart';
 import '../../domain/sync/entities.dart';
 import '../../domain/sync/repositories.dart';
 import '../../infrastructure/db/app_database.dart';
 import '../../infrastructure/db/daos/chat_dao.dart';
 import '../../infrastructure/db/daos/sync_dao.dart';
+import 'chat_remote_data_source.dart';
 
 class ChatRepositoryImpl implements ChatRepository {
-  ChatRepositoryImpl(this._db, this._dao, this._syncDao, this._syncRepository);
+  ChatRepositoryImpl(
+    this._db,
+    this._dao,
+    this._syncDao,
+    this._syncRepository,
+    this._remote,
+  );
 
   final AppDatabase _db;
   final ChatDao _dao;
   final SyncDao _syncDao;
   final SyncRepository _syncRepository;
+  final ChatRemoteDataSource _remote;
+
+  final _messageSubscriptions = <String, StreamSubscription>{};
+  final _typingSubscriptions = <String, StreamSubscription>{};
+  final _moderationSubscriptions = <String, StreamSubscription>{};
+  final _appealSubscriptions = <String, StreamSubscription>{};
 
   Future<void> _ensureSeeded() => _db.ensureSeeded();
+
+  Future<void> dispose() async {
+    for (final sub in _messageSubscriptions.values) {
+      await sub.cancel();
+    }
+    for (final sub in _typingSubscriptions.values) {
+      await sub.cancel();
+    }
+    for (final sub in _moderationSubscriptions.values) {
+      await sub.cancel();
+    }
+    for (final sub in _appealSubscriptions.values) {
+      await sub.cancel();
+    }
+    _messageSubscriptions.clear();
+    _typingSubscriptions.clear();
+    _moderationSubscriptions.clear();
+    _appealSubscriptions.clear();
+  }
+
+  Future<void> _ensureRemoteSubscriptions(String classId) async {
+    if (!_messageSubscriptions.containsKey(classId)) {
+      final messageSub = _remote.watchMessages(classId).listen(
+        (remoteMessages) async {
+          for (final remote in remoteMessages) {
+            final companion = MessagesCompanion(
+              id: Value(remote.id),
+              classId: Value(remote.classId),
+              userId: Value(remote.userId),
+              body: Value(remote.body),
+              createdAt: Value(remote.createdAt.millisecondsSinceEpoch),
+              updatedAt: Value(remote.updatedAt.millisecondsSinceEpoch),
+              deleted: Value(remote.deleted),
+              flagged: Value(remote.flagged),
+              attachments:
+                  Value(ChatMessage.encodeAttachments(remote.attachments)),
+              authorName: Value(remote.authorName),
+            );
+            await _dao.insertMessage(companion);
+          }
+        },
+        onError: (_) {},
+      );
+      _messageSubscriptions[classId] = messageSub;
+    }
+
+    if (!_typingSubscriptions.containsKey(classId)) {
+      final typingSub = _remote.watchTyping(classId).listen(
+        (statuses) async {
+          final activeUsers = statuses
+              .where((status) => status.isTyping)
+              .map((status) => status.userId)
+              .toList(growable: false);
+          await _db.transaction(() async {
+            if (activeUsers.isEmpty) {
+              await (_db.delete(_db.typingIndicators)
+                    ..where((tbl) => tbl.classId.equals(classId)))
+                  .go();
+            } else {
+              await (_db.delete(_db.typingIndicators)
+                    ..where(
+                      (tbl) => tbl.classId.equals(classId) &
+                          tbl.userId.isNotIn(activeUsers),
+                    ))
+                  .go();
+            }
+            for (final status in statuses) {
+              if (!status.isTyping) {
+                await _dao.removeTyping(classId, status.userId);
+                continue;
+              }
+              await _dao.upsertTyping(
+                TypingIndicatorsCompanion(
+                  classId: Value(status.classId),
+                  userId: Value(status.userId),
+                  isTyping: Value(status.isTyping),
+                  updatedAt: Value(
+                    status.updatedAt.millisecondsSinceEpoch,
+                  ),
+                ),
+              );
+            }
+          });
+        },
+        onError: (_) {},
+      );
+      _typingSubscriptions[classId] = typingSub;
+    }
+
+    if (!_moderationSubscriptions.containsKey(classId)) {
+      final moderationSub = _remote.watchModerationActions(classId).listen(
+        (actions) async {
+          for (final action in actions) {
+            await _dao.upsertModerationAction(
+              ModerationActionsTableCompanion(
+                id: Value(action.id),
+                classId: Value(action.classId),
+                targetUserId: Value(action.targetUserId),
+                moderatorId: Value(action.moderatorId),
+                type: Value(action.type.name),
+                status: Value(action.status.name),
+                reason: Value(action.reason),
+                metadata: Value(jsonEncode(action.metadata)),
+                createdAt: Value(action.createdAt.millisecondsSinceEpoch),
+                expiresAt: Value(action.expiresAt?.millisecondsSinceEpoch),
+              ),
+            );
+          }
+        },
+        onError: (_) {},
+      );
+      _moderationSubscriptions[classId] = moderationSub;
+    }
+
+    if (!_appealSubscriptions.containsKey(classId)) {
+      final appealSub = _remote.watchAppeals(classId).listen(
+        (appeals) async {
+          for (final appeal in appeals) {
+            await _dao.upsertModerationAppeal(
+              ModerationAppealsTableCompanion(
+                id: Value(appeal.id),
+                actionId: Value(appeal.actionId),
+                classId: Value(classId),
+                userId: Value(appeal.userId),
+                message: Value(appeal.message),
+                status: Value(appeal.status.name),
+                resolutionNotes: Value(appeal.resolutionNotes),
+                createdAt: Value(appeal.createdAt.millisecondsSinceEpoch),
+                resolvedAt: Value(appeal.resolvedAt?.millisecondsSinceEpoch),
+              ),
+            );
+          }
+        },
+        onError: (_) {},
+      );
+      _appealSubscriptions[classId] = appealSub;
+    }
+  }
+
+  List<ChatMessage> _mapMessages(List<Message> rows) {
+    return rows
+        .map(
+          (row) => ChatMessage(
+            id: row.id,
+            classId: row.classId,
+            userId: row.userId,
+            body: row.body,
+            createdAt: DateTime.fromMillisecondsSinceEpoch(row.createdAt),
+            updatedAt: DateTime.fromMillisecondsSinceEpoch(row.updatedAt),
+            deleted: row.deleted,
+            flagged: row.flagged,
+            attachments: ChatMessage.decodeAttachments(row.attachments),
+            authorName: row.authorName,
+          ),
+        )
+        .toList(growable: false);
+  }
 
   @override
   Stream<List<ChatMessage>> watchMessages(String classId) async* {
     await _ensureSeeded();
-    yield* _dao.watchMessages(classId).map(
-      (rows) => rows
-          .map(
-            (row) => ChatMessage(
-              id: row.id,
-              classId: row.classId,
-              userId: row.userId,
-              body: row.body,
-              createdAt: DateTime.fromMillisecondsSinceEpoch(row.createdAt),
-              deleted: row.deleted,
-              flagged: row.flagged,
-            ),
-          )
-          .toList(),
-    );
+    unawaited(_ensureRemoteSubscriptions(classId));
+    yield* _dao.watchMessages(classId).map(_mapMessages);
+  }
+
+  @override
+  Stream<List<TypingStatus>> watchTyping(String classId) async* {
+    await _ensureSeeded();
+    unawaited(_ensureRemoteSubscriptions(classId));
+    yield* _dao.watchTyping(classId).map(
+          (rows) => rows
+              .map(
+                (row) => TypingStatus(
+                  userId: row.userId,
+                  classId: row.classId,
+                  isTyping: row.isTyping,
+                  updatedAt:
+                      DateTime.fromMillisecondsSinceEpoch(row.updatedAt),
+                ),
+              )
+              .toList(growable: false),
+        );
+  }
+
+  @override
+  Stream<List<ModerationAction>> watchModerationActions(String classId) async* {
+    await _ensureSeeded();
+    unawaited(_ensureRemoteSubscriptions(classId));
+    yield* _dao.watchModerationActions(classId).map(
+          (rows) => rows
+              .map(
+                (row) => ModerationAction(
+                  id: row.id,
+                  classId: row.classId,
+                  targetUserId: row.targetUserId,
+                  type: ModerationActionType.values.firstWhere(
+                    (value) => value.name == row.type,
+                    orElse: () => ModerationActionType.flag,
+                  ),
+                  moderatorId: row.moderatorId,
+                  createdAt:
+                      DateTime.fromMillisecondsSinceEpoch(row.createdAt),
+                  expiresAt: row.expiresAt != null
+                      ? DateTime.fromMillisecondsSinceEpoch(row.expiresAt!)
+                      : null,
+                  status: ModerationActionStatus.values.firstWhere(
+                    (value) => value.name == row.status,
+                    orElse: () => ModerationActionStatus.pending,
+                  ),
+                  reason: row.reason,
+                  metadata: Map<String, Object?>.from(
+                    jsonDecode(row.metadata) as Map,
+                  ),
+                ),
+              )
+              .toList(growable: false),
+        );
   }
 
   @override
   Future<void> addMessage(ChatMessage message) async {
     await _ensureSeeded();
+    final activeActions = await _dao.getModerationActionsForUser(
+      message.classId,
+      message.userId,
+    );
+    final nowMs = DateTime.now().toUtc().millisecondsSinceEpoch;
+    ModerationActionRow? activeBan;
+    ModerationActionRow? activeMute;
+    for (final action in activeActions) {
+      if (action.status == ModerationActionStatus.resolved.name ||
+          action.status == ModerationActionStatus.expired.name) {
+        continue;
+      }
+      if (action.expiresAt != null && action.expiresAt! <= nowMs) {
+        await _dao.updateModerationActionStatus(
+          action.id,
+          ModerationActionStatus.expired.name,
+        );
+        continue;
+      }
+      if (action.type == ModerationActionType.ban.name) {
+        activeBan = action;
+        break;
+      }
+      if (action.type != ModerationActionType.mute.name) {
+        continue;
+      }
+      if (activeMute == null) {
+        activeMute = action;
+        continue;
+      }
+      if (activeMute.expiresAt == null) {
+        continue;
+      }
+      if (action.expiresAt == null) {
+        activeMute = action;
+        continue;
+      }
+      if (action.expiresAt! > (activeMute.expiresAt ?? 0)) {
+        activeMute = action;
+      }
+    }
+
+    if (activeBan != null) {
+      final banReason = activeBan.reason;
+      final banMessage = StringBuffer('You are banned from this class chat');
+      if (banReason != null && banReason.isNotEmpty) {
+        banMessage.write(': $banReason.');
+      } else {
+        banMessage.write('.');
+      }
+      throw ChatModerationException(
+        message: banMessage.toString(),
+        actionType: ModerationActionType.ban,
+        actionId: activeBan.id,
+        reason: banReason,
+      );
+    }
+
+    if (activeMute != null) {
+      final muteReason = activeMute.reason;
+      final expiresAtUtc = activeMute.expiresAt != null
+          ? DateTime.fromMillisecondsSinceEpoch(
+              activeMute.expiresAt!,
+              isUtc: true,
+            )
+          : null;
+      final buffer = StringBuffer('You are muted in this class chat');
+      if (expiresAtUtc != null) {
+        buffer.write(' until ${expiresAtUtc.toLocal()}');
+      }
+      if (muteReason != null && muteReason.isNotEmpty) {
+        buffer.write('. Reason: $muteReason.');
+      } else {
+        buffer.write('.');
+      }
+      throw ChatModerationException(
+        message: buffer.toString(),
+        actionType: ModerationActionType.mute,
+        actionId: activeMute.id,
+        expiresAt: expiresAtUtc,
+        reason: muteReason,
+      );
+    }
     final id = message.id.isEmpty ? const Uuid().v4() : message.id;
     final createdAt = message.createdAt.millisecondsSinceEpoch;
+    final uploadedAttachments = <ChatAttachment>[];
+    for (final attachment in message.attachments) {
+      if ((attachment.url.isEmpty) && attachment.localPath != null) {
+        final file = File(attachment.localPath!);
+        if (await file.exists()) {
+          final url = await _remote.uploadAttachment(
+            classId: message.classId,
+            messageId: id,
+            file: file,
+            fileName: attachment.name,
+          );
+          uploadedAttachments.add(
+            ChatAttachment(
+              id: attachment.id,
+              type: attachment.type,
+              name: attachment.name,
+              url: url,
+              localPath: attachment.localPath,
+              sizeBytes: attachment.sizeBytes ?? await file.length(),
+            ),
+          );
+        }
+      } else {
+        uploadedAttachments.add(attachment);
+      }
+    }
+
     final companion = MessagesCompanion(
       id: Value(id),
       classId: Value(message.classId),
       userId: Value(message.userId),
       body: Value(message.body),
       createdAt: Value(createdAt),
-      updatedAt: Value(createdAt),
+      updatedAt: Value(message.updatedAt.millisecondsSinceEpoch),
       deleted: Value(message.deleted),
       flagged: Value(message.flagged),
+      attachments: Value(ChatMessage.encodeAttachments(uploadedAttachments)),
+      authorName: Value(message.authorName),
     );
     await _dao.insertMessage(companion);
     await _syncDao.recordMessageChange(
       messageId: id,
       userId: message.userId,
-      localUpdatedAt: createdAt,
+      localUpdatedAt: message.updatedAt.millisecondsSinceEpoch,
       operation: 'upsert',
     );
     await _syncRepository.enqueue(
@@ -71,17 +399,38 @@ class ChatRepositoryImpl implements ChatRepository {
           'classId': message.classId,
           'body': message.body,
           'createdAt': createdAt,
-          'updatedAt': createdAt,
+          'updatedAt': message.updatedAt.millisecondsSinceEpoch,
           'deleted': message.deleted,
           'flagged': message.flagged,
+          'attachments':
+              uploadedAttachments.map((attachment) => attachment.toJson()).toList(),
+          if (message.authorName != null) 'authorName': message.authorName,
         },
         createdAt: message.createdAt,
       ),
     );
+    final remoteMessage = RemoteChatMessage(
+      id: id,
+      classId: message.classId,
+      userId: message.userId,
+      body: message.body,
+      createdAt: message.createdAt.toUtc(),
+      updatedAt: message.updatedAt.toUtc(),
+      deleted: message.deleted,
+      flagged: message.flagged,
+      attachments: uploadedAttachments,
+      authorName: message.authorName,
+    );
+    await _remote.sendMessage(remoteMessage);
   }
 
   @override
-  Future<void> flagMessage(String id, {bool flagged = true}) async {
+  Future<void> flagMessage(
+    String id, {
+    bool flagged = true,
+    String? moderatorId,
+    String? reason,
+  }) async {
     await _ensureSeeded();
     final existing = await _dao.getMessageById(id);
     if (existing == null) {
@@ -114,14 +463,37 @@ class ChatRepositoryImpl implements ChatRepository {
           'updatedAt': now.millisecondsSinceEpoch,
           'deleted': existing.deleted,
           'flagged': flagged,
+          'attachments': jsonDecode(existing.attachments),
+          if (existing.authorName != null) 'authorName': existing.authorName,
         },
         createdAt: now,
       ),
     );
+    await _remote.updateMessage(existing.classId, id, {
+      'flagged': flagged,
+      'updatedAt': DateTime.now().toUtc(),
+      if (reason != null) 'flagReason': reason,
+    });
+    if (moderatorId != null) {
+      await _logModerationAction(
+        classId: existing.classId,
+        targetUserId: existing.userId,
+        type: ModerationActionType.flag,
+        moderatorId: moderatorId,
+        reason: reason,
+        metadata: {
+          'messageId': id,
+        },
+      );
+    }
   }
 
   @override
-  Future<void> deleteMessage(String id) async {
+  Future<void> deleteMessage(
+    String id, {
+    String? moderatorId,
+    String? reason,
+  }) async {
     await _ensureSeeded();
     final existing = await _dao.getMessageById(id);
     if (existing == null) {
@@ -155,5 +527,220 @@ class ChatRepositoryImpl implements ChatRepository {
         createdAt: now,
       ),
     );
+    await _remote.deleteMessage(existing.classId, id);
+    if (moderatorId != null) {
+      await _logModerationAction(
+        classId: existing.classId,
+        targetUserId: existing.userId,
+        type: ModerationActionType.delete,
+        moderatorId: moderatorId,
+        reason: reason,
+        metadata: {
+          'messageId': id,
+        },
+      );
+    }
+  }
+
+  Future<void> _logModerationAction({
+    required String classId,
+    required String targetUserId,
+    required ModerationActionType type,
+    required String moderatorId,
+    String? reason,
+    Map<String, Object?> metadata = const {},
+    Duration? duration,
+  }) async {
+    await _ensureSeeded();
+    final id = const Uuid().v4();
+    final now = DateTime.now().toUtc();
+    final expiresAt = duration != null ? now.add(duration) : null;
+    final action = ModerationAction(
+      id: id,
+      classId: classId,
+      targetUserId: targetUserId,
+      type: type,
+      moderatorId: moderatorId,
+      createdAt: now,
+      expiresAt: expiresAt,
+      status: ModerationActionStatus.active,
+      reason: reason,
+      metadata: metadata,
+    );
+    await _dao.upsertModerationAction(
+      ModerationActionsTableCompanion(
+        id: Value(id),
+        classId: Value(classId),
+        targetUserId: Value(targetUserId),
+        moderatorId: Value(moderatorId),
+        type: Value(type.name),
+        status: Value(action.status.name),
+        reason: Value(reason),
+        metadata: Value(jsonEncode(metadata)),
+        createdAt: Value(now.millisecondsSinceEpoch),
+        expiresAt: Value(expiresAt?.millisecondsSinceEpoch),
+      ),
+    );
+    await _remote.recordModerationAction(
+      RemoteModerationAction(
+        id: id,
+        classId: classId,
+        targetUserId: targetUserId,
+        type: type,
+        moderatorId: moderatorId,
+        createdAt: now,
+        expiresAt: expiresAt,
+        status: ModerationActionStatus.active,
+        reason: reason,
+        metadata: Map<String, dynamic>.from(metadata),
+      ),
+    );
+  }
+
+  @override
+  Future<void> muteUser({
+    required String classId,
+    required String userId,
+    required Duration duration,
+    required String moderatorId,
+    String? reason,
+  }) {
+    return _logModerationAction(
+      classId: classId,
+      targetUserId: userId,
+      type: ModerationActionType.mute,
+      moderatorId: moderatorId,
+      reason: reason,
+      metadata: const {},
+      duration: duration,
+    );
+  }
+
+  @override
+  Future<void> banUser({
+    required String classId,
+    required String userId,
+    required String moderatorId,
+    String? reason,
+  }) {
+    return _logModerationAction(
+      classId: classId,
+      targetUserId: userId,
+      type: ModerationActionType.ban,
+      moderatorId: moderatorId,
+      reason: reason,
+    );
+  }
+
+  @override
+  Future<void> unbanOrUnmute({
+    required String actionId,
+    required String moderatorId,
+    String? notes,
+  }) async {
+    await _ensureSeeded();
+    final action = await _dao.getModerationAction(actionId);
+    if (action == null) {
+      return;
+    }
+    await _dao.upsertModerationAction(
+      ModerationActionsTableCompanion(
+        id: Value(actionId),
+        status: Value(ModerationActionStatus.resolved.name),
+        reason: Value(action.reason),
+        metadata: Value(action.metadata),
+        classId: Value(action.classId),
+        targetUserId: Value(action.targetUserId),
+        moderatorId: Value(moderatorId),
+        type: Value(action.type),
+        createdAt: Value(action.createdAt),
+        expiresAt: Value(action.expiresAt),
+      ),
+    );
+    await _remote.recordModerationAction(
+      RemoteModerationAction(
+        id: actionId,
+        classId: action.classId,
+        targetUserId: action.targetUserId,
+        type: ModerationActionType.values.firstWhere(
+          (value) => value.name == action.type,
+          orElse: () => ModerationActionType.flag,
+        ),
+        moderatorId: moderatorId,
+        createdAt:
+            DateTime.fromMillisecondsSinceEpoch(action.createdAt, isUtc: true),
+        expiresAt: action.expiresAt != null
+            ? DateTime.fromMillisecondsSinceEpoch(action.expiresAt!, isUtc: true)
+            : null,
+        status: ModerationActionStatus.resolved,
+        reason: action.reason,
+        metadata: Map<String, dynamic>.from(
+          jsonDecode(action.metadata) as Map,
+        )
+          ..['resolutionNotes'] = notes,
+      ),
+    );
+  }
+
+  @override
+  Future<void> submitAppeal(ModerationAppeal appeal) async {
+    await _ensureSeeded();
+    await _dao.upsertModerationAppeal(
+      ModerationAppealsTableCompanion(
+        id: Value(appeal.id),
+        actionId: Value(appeal.actionId),
+        classId: Value(appeal.classId),
+        userId: Value(appeal.userId),
+        message: Value(appeal.message),
+        status: Value(appeal.status.name),
+        createdAt: Value(appeal.createdAt.millisecondsSinceEpoch),
+        resolvedAt: Value(appeal.resolvedAt?.millisecondsSinceEpoch),
+        resolutionNotes: Value(appeal.resolutionNotes),
+      ),
+    );
+    await _remote.submitAppeal(
+      RemoteModerationAppeal(
+        id: appeal.id,
+        actionId: appeal.actionId,
+        userId: appeal.userId,
+        message: appeal.message,
+        createdAt: appeal.createdAt.toUtc(),
+        status: appeal.status,
+        resolvedAt: appeal.resolvedAt?.toUtc(),
+        resolutionNotes: appeal.resolutionNotes,
+      ),
+      appeal.classId,
+    );
+  }
+
+  @override
+  Future<void> updateTyping({
+    required String classId,
+    required String userId,
+    required bool isTyping,
+  }) async {
+    await _ensureSeeded();
+    final now = DateTime.now();
+    if (isTyping) {
+      await _dao.upsertTyping(
+        TypingIndicatorsCompanion(
+          classId: Value(classId),
+          userId: Value(userId),
+          isTyping: const Value(true),
+          updatedAt: Value(now.millisecondsSinceEpoch),
+        ),
+      );
+      await _remote.setTyping(
+        RemoteTypingStatus(
+          userId: userId,
+          classId: classId,
+          isTyping: true,
+          updatedAt: now.toUtc(),
+        ),
+      );
+    } else {
+      await _dao.removeTyping(classId, userId);
+      await _remote.removeTyping(classId, userId);
+    }
   }
 }

--- a/lib/src/data/settings/settings_repository_impl.dart
+++ b/lib/src/data/settings/settings_repository_impl.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../domain/settings/entities.dart';
@@ -5,8 +7,11 @@ import '../../domain/settings/repositories.dart';
 
 class SettingsRepositoryImpl implements SettingsRepository {
   static const _themeKey = 'app_theme_mode';
+  static const _notificationKey = 'notification_preferences';
 
   String _keyFor(String userId) => '${_themeKey}_$userId';
+  String _notificationPrefsKeyFor(String userId) =>
+      '${_notificationKey}_$userId';
 
   @override
   Future<AppThemeMode> getThemeMode(String userId) async {
@@ -37,5 +42,32 @@ class SettingsRepositoryImpl implements SettingsRepository {
         await prefs.setString(key, 'dark');
         break;
     }
+  }
+
+  @override
+  Future<NotificationPreferences> getNotificationPreferences(
+      String userId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final key = _notificationPrefsKeyFor(userId);
+    final raw = prefs.getString(key);
+    if (raw == null) {
+      return const NotificationPreferences();
+    }
+    try {
+      final json = jsonDecode(raw) as Map<String, Object?>;
+      return NotificationPreferences.fromJson(json);
+    } catch (_) {
+      return const NotificationPreferences();
+    }
+  }
+
+  @override
+  Future<void> saveNotificationPreferences(
+    String userId,
+    NotificationPreferences preferences,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    final key = _notificationPrefsKeyFor(userId);
+    await prefs.setString(key, jsonEncode(preferences.toJson()));
   }
 }

--- a/lib/src/domain/chat/entities.dart
+++ b/lib/src/domain/chat/entities.dart
@@ -1,11 +1,144 @@
+import 'dart:convert';
+
+class ChatAttachment {
+  final String id;
+  final String type;
+  final String name;
+  final String url;
+  final String? localPath;
+  final int? sizeBytes;
+
+  const ChatAttachment({
+    required this.id,
+    required this.type,
+    required this.name,
+    required this.url,
+    this.localPath,
+    this.sizeBytes,
+  });
+
+  Map<String, Object?> toJson() => {
+        'id': id,
+        'type': type,
+        'name': name,
+        'url': url,
+        if (localPath != null) 'localPath': localPath,
+        if (sizeBytes != null) 'sizeBytes': sizeBytes,
+      };
+
+  factory ChatAttachment.fromJson(Map<String, Object?> json) {
+    return ChatAttachment(
+      id: json['id'] as String,
+      type: json['type'] as String,
+      name: json['name'] as String,
+      url: json['url'] as String,
+      localPath: json['localPath'] as String?,
+      sizeBytes: json['sizeBytes'] as int?,
+    );
+  }
+}
+
+enum ModerationActionType { flag, delete, mute, ban }
+
+enum ModerationActionStatus { pending, active, resolved, expired }
+
+class ModerationAction {
+  final String id;
+  final String classId;
+  final String targetUserId;
+  final ModerationActionType type;
+  final String moderatorId;
+  final DateTime createdAt;
+  final DateTime? expiresAt;
+  final ModerationActionStatus status;
+  final String? reason;
+  final Map<String, Object?> metadata;
+
+  const ModerationAction({
+    required this.id,
+    required this.classId,
+    required this.targetUserId,
+    required this.type,
+    required this.moderatorId,
+    required this.createdAt,
+    this.expiresAt,
+    this.status = ModerationActionStatus.pending,
+    this.reason,
+    this.metadata = const {},
+  });
+
+  ModerationAction copyWith({
+    ModerationActionStatus? status,
+    DateTime? expiresAt,
+    Map<String, Object?>? metadata,
+  }) {
+    return ModerationAction(
+      id: id,
+      classId: classId,
+      targetUserId: targetUserId,
+      type: type,
+      moderatorId: moderatorId,
+      createdAt: createdAt,
+      expiresAt: expiresAt ?? this.expiresAt,
+      status: status ?? this.status,
+      reason: reason,
+      metadata: metadata ?? this.metadata,
+    );
+  }
+}
+
+enum ModerationAppealStatus { submitted, underReview, approved, rejected }
+
+class ModerationAppeal {
+  final String id;
+  final String actionId;
+  final String classId;
+  final String userId;
+  final String message;
+  final DateTime createdAt;
+  final ModerationAppealStatus status;
+  final DateTime? resolvedAt;
+  final String? resolutionNotes;
+
+  const ModerationAppeal({
+    required this.id,
+    required this.actionId,
+    required this.classId,
+    required this.userId,
+    required this.message,
+    required this.createdAt,
+    this.status = ModerationAppealStatus.submitted,
+    this.resolvedAt,
+    this.resolutionNotes,
+  });
+}
+
+class TypingStatus {
+  final String userId;
+  final String classId;
+  final bool isTyping;
+  final DateTime updatedAt;
+
+  const TypingStatus({
+    required this.userId,
+    required this.classId,
+    required this.isTyping,
+    required this.updatedAt,
+  });
+}
+
 class ChatMessage {
   final String id;
   final String classId;
   final String userId;
   final String body;
   final DateTime createdAt;
+  final DateTime updatedAt;
   final bool deleted;
   final bool flagged;
+  final List<ChatAttachment> attachments;
+  final String? authorName;
+  final bool localOnly;
 
   const ChatMessage({
     required this.id,
@@ -13,7 +146,51 @@ class ChatMessage {
     required this.userId,
     required this.body,
     required this.createdAt,
+    required this.updatedAt,
     this.deleted = false,
     this.flagged = false,
+    this.attachments = const [],
+    this.authorName,
+    this.localOnly = false,
   });
+
+  ChatMessage copyWith({
+    String? body,
+    DateTime? updatedAt,
+    bool? deleted,
+    bool? flagged,
+    List<ChatAttachment>? attachments,
+    bool? localOnly,
+  }) {
+    return ChatMessage(
+      id: id,
+      classId: classId,
+      userId: userId,
+      body: body ?? this.body,
+      createdAt: createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      deleted: deleted ?? this.deleted,
+      flagged: flagged ?? this.flagged,
+      attachments: attachments ?? this.attachments,
+      authorName: authorName,
+      localOnly: localOnly ?? this.localOnly,
+    );
+  }
+
+  static String encodeAttachments(List<ChatAttachment> attachments) {
+    if (attachments.isEmpty) {
+      return '[]';
+    }
+    return jsonEncode(attachments.map((e) => e.toJson()).toList());
+  }
+
+  static List<ChatAttachment> decodeAttachments(String? json) {
+    if (json == null || json.isEmpty) {
+      return const [];
+    }
+    final data = jsonDecode(json) as List<dynamic>;
+    return data
+        .map((e) => ChatAttachment.fromJson(Map<String, Object?>.from(e as Map)))
+        .toList();
+  }
 }

--- a/lib/src/domain/chat/errors.dart
+++ b/lib/src/domain/chat/errors.dart
@@ -1,0 +1,20 @@
+import 'entities.dart';
+
+class ChatModerationException implements Exception {
+  const ChatModerationException({
+    required this.message,
+    required this.actionType,
+    required this.actionId,
+    this.expiresAt,
+    this.reason,
+  });
+
+  final String message;
+  final ModerationActionType actionType;
+  final String actionId;
+  final DateTime? expiresAt;
+  final String? reason;
+
+  @override
+  String toString() => message;
+}

--- a/lib/src/domain/chat/repositories.dart
+++ b/lib/src/domain/chat/repositories.dart
@@ -2,7 +2,42 @@ import 'entities.dart';
 
 abstract class ChatRepository {
   Stream<List<ChatMessage>> watchMessages(String classId);
+  Stream<List<TypingStatus>> watchTyping(String classId);
+  Stream<List<ModerationAction>> watchModerationActions(String classId);
   Future<void> addMessage(ChatMessage message);
-  Future<void> flagMessage(String id, {bool flagged});
-  Future<void> deleteMessage(String id);
+  Future<void> flagMessage(
+    String id, {
+    bool flagged = true,
+    String? moderatorId,
+    String? reason,
+  });
+  Future<void> deleteMessage(
+    String id, {
+    String? moderatorId,
+    String? reason,
+  });
+  Future<void> muteUser({
+    required String classId,
+    required String userId,
+    required Duration duration,
+    required String moderatorId,
+    String? reason,
+  });
+  Future<void> banUser({
+    required String classId,
+    required String userId,
+    required String moderatorId,
+    String? reason,
+  });
+  Future<void> unbanOrUnmute({
+    required String actionId,
+    required String moderatorId,
+    String? notes,
+  });
+  Future<void> submitAppeal(ModerationAppeal appeal);
+  Future<void> updateTyping({
+    required String classId,
+    required String userId,
+    required bool isTyping,
+  });
 }

--- a/lib/src/domain/chat/usecases.dart
+++ b/lib/src/domain/chat/usecases.dart
@@ -10,6 +10,24 @@ class WatchChatMessagesUseCase {
       _repository.watchMessages(classId);
 }
 
+class WatchTypingStatusUseCase {
+  final ChatRepository _repository;
+
+  const WatchTypingStatusUseCase(this._repository);
+
+  Stream<List<TypingStatus>> call(String classId) =>
+      _repository.watchTyping(classId);
+}
+
+class WatchModerationActionsUseCase {
+  final ChatRepository _repository;
+
+  const WatchModerationActionsUseCase(this._repository);
+
+  Stream<List<ModerationAction>> call(String classId) =>
+      _repository.watchModerationActions(classId);
+}
+
 class SendChatMessageUseCase {
   final ChatRepository _repository;
 
@@ -24,8 +42,18 @@ class FlagChatMessageUseCase {
 
   const FlagChatMessageUseCase(this._repository);
 
-  Future<void> call(String id, {bool flagged = true}) =>
-      _repository.flagMessage(id, flagged: flagged);
+  Future<void> call(
+    String id, {
+    bool flagged = true,
+    String? moderatorId,
+    String? reason,
+  }) =>
+      _repository.flagMessage(
+        id,
+        flagged: flagged,
+        moderatorId: moderatorId,
+        reason: reason,
+      );
 }
 
 class DeleteChatMessageUseCase {
@@ -33,5 +61,97 @@ class DeleteChatMessageUseCase {
 
   const DeleteChatMessageUseCase(this._repository);
 
-  Future<void> call(String id) => _repository.deleteMessage(id);
+  Future<void> call(
+    String id, {
+    String? moderatorId,
+    String? reason,
+  }) =>
+      _repository.deleteMessage(
+        id,
+        moderatorId: moderatorId,
+        reason: reason,
+      );
+}
+
+class MuteUserUseCase {
+  final ChatRepository _repository;
+
+  const MuteUserUseCase(this._repository);
+
+  Future<void> call({
+    required String classId,
+    required String userId,
+    required Duration duration,
+    required String moderatorId,
+    String? reason,
+  }) =>
+      _repository.muteUser(
+        classId: classId,
+        userId: userId,
+        duration: duration,
+        moderatorId: moderatorId,
+        reason: reason,
+      );
+}
+
+class BanUserUseCase {
+  final ChatRepository _repository;
+
+  const BanUserUseCase(this._repository);
+
+  Future<void> call({
+    required String classId,
+    required String userId,
+    required String moderatorId,
+    String? reason,
+  }) =>
+      _repository.banUser(
+        classId: classId,
+        userId: userId,
+        moderatorId: moderatorId,
+        reason: reason,
+      );
+}
+
+class ResolveModerationActionUseCase {
+  final ChatRepository _repository;
+
+  const ResolveModerationActionUseCase(this._repository);
+
+  Future<void> call({
+    required String actionId,
+    required String moderatorId,
+    String? notes,
+  }) =>
+      _repository.unbanOrUnmute(
+        actionId: actionId,
+        moderatorId: moderatorId,
+        notes: notes,
+      );
+}
+
+class SubmitModerationAppealUseCase {
+  final ChatRepository _repository;
+
+  const SubmitModerationAppealUseCase(this._repository);
+
+  Future<void> call(ModerationAppeal appeal) =>
+      _repository.submitAppeal(appeal);
+}
+
+class UpdateTypingStatusUseCase {
+  final ChatRepository _repository;
+
+  const UpdateTypingStatusUseCase(this._repository);
+
+  Future<void> call({
+    required String classId,
+    required String userId,
+    required bool isTyping,
+  }) =>
+      _repository.updateTyping(
+        classId: classId,
+        userId: userId,
+        isTyping: isTyping,
+      );
 }

--- a/lib/src/domain/settings/entities.dart
+++ b/lib/src/domain/settings/entities.dart
@@ -1,1 +1,170 @@
 enum AppThemeMode { system, light, dark }
+
+class LocalTimeOfDay {
+  final int hour;
+  final int minute;
+
+  const LocalTimeOfDay({required this.hour, required this.minute})
+      : assert(hour >= 0 && hour <= 23),
+        assert(minute >= 0 && minute <= 59);
+
+  DateTime onDate(DateTime date) {
+    return DateTime(date.year, date.month, date.day, hour, minute);
+  }
+
+  Map<String, Object?> toJson() => {'hour': hour, 'minute': minute};
+
+  factory LocalTimeOfDay.fromJson(Map<String, Object?> json) {
+    return LocalTimeOfDay(
+      hour: json['hour'] as int? ?? 0,
+      minute: json['minute'] as int? ?? 0,
+    );
+  }
+}
+
+class QuietHours {
+  final bool enabled;
+  final LocalTimeOfDay start;
+  final LocalTimeOfDay end;
+
+  const QuietHours({
+    this.enabled = false,
+    this.start = const LocalTimeOfDay(hour: 22, minute: 0),
+    this.end = const LocalTimeOfDay(hour: 6, minute: 0),
+  });
+
+  bool isInQuietHours(DateTime dateTime) {
+    if (!enabled) {
+      return false;
+    }
+    final startTime = start.onDate(dateTime);
+    final endTime = end.onDate(dateTime);
+    if (startTime.isBefore(endTime) || startTime.isAtSameMomentAs(endTime)) {
+      return !dateTime.isBefore(startTime) && !dateTime.isAfter(endTime);
+    }
+    // Quiet hours span overnight.
+    return dateTime.isAfter(startTime) || dateTime.isBefore(endTime);
+  }
+
+  Map<String, Object?> toJson() => {
+        'enabled': enabled,
+        'start': start.toJson(),
+        'end': end.toJson(),
+      };
+
+  factory QuietHours.fromJson(Map<String, Object?> json) {
+    return QuietHours(
+      enabled: json['enabled'] as bool? ?? false,
+      start: json['start'] is Map
+          ? LocalTimeOfDay.fromJson(
+              Map<String, Object?>.from(json['start'] as Map),
+            )
+          : const LocalTimeOfDay(hour: 22, minute: 0),
+      end: json['end'] is Map
+          ? LocalTimeOfDay.fromJson(
+              Map<String, Object?>.from(json['end'] as Map),
+            )
+          : const LocalTimeOfDay(hour: 6, minute: 0),
+    );
+  }
+}
+
+class ParentalControlSettings {
+  final bool enabled;
+  final Set<String> allowedClassIds;
+  final Set<String> blockedClassIds;
+  final bool allowChatNotifications;
+
+  const ParentalControlSettings({
+    this.enabled = false,
+    this.allowedClassIds = const {},
+    this.blockedClassIds = const {},
+    this.allowChatNotifications = true,
+  });
+
+  bool allowsClass(String classId) {
+    if (!enabled) {
+      return true;
+    }
+    if (!allowChatNotifications) {
+      return false;
+    }
+    if (blockedClassIds.contains(classId)) {
+      return false;
+    }
+    if (allowedClassIds.isEmpty) {
+      return true;
+    }
+    return allowedClassIds.contains(classId);
+  }
+
+  Map<String, Object?> toJson() => {
+        'enabled': enabled,
+        'allowedClassIds': allowedClassIds.toList(),
+        'blockedClassIds': blockedClassIds.toList(),
+        'allowChatNotifications': allowChatNotifications,
+      };
+
+  factory ParentalControlSettings.fromJson(Map<String, Object?> json) {
+    return ParentalControlSettings(
+      enabled: json['enabled'] as bool? ?? false,
+      allowedClassIds: {
+        for (final value in (json['allowedClassIds'] as List<dynamic>? ?? const []))
+          value.toString(),
+      },
+      blockedClassIds: {
+        for (final value in (json['blockedClassIds'] as List<dynamic>? ?? const []))
+          value.toString(),
+      },
+      allowChatNotifications: json['allowChatNotifications'] as bool? ?? true,
+    );
+  }
+}
+
+class NotificationPreferences {
+  final bool pushEnabled;
+  final bool localNotificationsEnabled;
+  final QuietHours quietHours;
+  final ParentalControlSettings parentalControls;
+
+  const NotificationPreferences({
+    this.pushEnabled = true,
+    this.localNotificationsEnabled = true,
+    this.quietHours = const QuietHours(),
+    this.parentalControls = const ParentalControlSettings(),
+  });
+
+  bool shouldNotify(String classId, DateTime dateTime) {
+    if (!pushEnabled && !localNotificationsEnabled) {
+      return false;
+    }
+    if (quietHours.isInQuietHours(dateTime)) {
+      return false;
+    }
+    return parentalControls.allowsClass(classId);
+  }
+
+  Map<String, Object?> toJson() => {
+        'pushEnabled': pushEnabled,
+        'localNotificationsEnabled': localNotificationsEnabled,
+        'quietHours': quietHours.toJson(),
+        'parentalControls': parentalControls.toJson(),
+      };
+
+  factory NotificationPreferences.fromJson(Map<String, Object?> json) {
+    return NotificationPreferences(
+      pushEnabled: json['pushEnabled'] as bool? ?? true,
+      localNotificationsEnabled: json['localNotificationsEnabled'] as bool? ?? true,
+      quietHours: json['quietHours'] is Map
+          ? QuietHours.fromJson(
+              Map<String, Object?>.from(json['quietHours'] as Map),
+            )
+          : const QuietHours(),
+      parentalControls: json['parentalControls'] is Map
+          ? ParentalControlSettings.fromJson(
+              Map<String, Object?>.from(json['parentalControls'] as Map),
+            )
+          : const ParentalControlSettings(),
+    );
+  }
+}

--- a/lib/src/domain/settings/repositories.dart
+++ b/lib/src/domain/settings/repositories.dart
@@ -3,4 +3,9 @@ import 'entities.dart';
 abstract class SettingsRepository {
   Future<AppThemeMode> getThemeMode(String userId);
   Future<void> saveThemeMode(String userId, AppThemeMode mode);
+  Future<NotificationPreferences> getNotificationPreferences(String userId);
+  Future<void> saveNotificationPreferences(
+    String userId,
+    NotificationPreferences preferences,
+  );
 }

--- a/lib/src/domain/settings/usecases.dart
+++ b/lib/src/domain/settings/usecases.dart
@@ -18,3 +18,21 @@ class SaveThemeModeUseCase {
   Future<void> call(String userId, AppThemeMode mode) =>
       _repository.saveThemeMode(userId, mode);
 }
+
+class GetNotificationPreferencesUseCase {
+  final SettingsRepository _repository;
+
+  const GetNotificationPreferencesUseCase(this._repository);
+
+  Future<NotificationPreferences> call(String userId) =>
+      _repository.getNotificationPreferences(userId);
+}
+
+class SaveNotificationPreferencesUseCase {
+  final SettingsRepository _repository;
+
+  const SaveNotificationPreferencesUseCase(this._repository);
+
+  Future<void> call(String userId, NotificationPreferences preferences) =>
+      _repository.saveNotificationPreferences(userId, preferences);
+}

--- a/lib/src/infrastructure/db/app_database.dart
+++ b/lib/src/infrastructure/db/app_database.dart
@@ -282,6 +282,55 @@ class Messages extends Table {
       .withDefault(const Constant(0))();
   BoolColumn get deleted => boolean().withDefault(const Constant(false))();
   BoolColumn get flagged => boolean().withDefault(const Constant(false))();
+  TextColumn get attachments =>
+      text().withDefault(const Constant('[]'))();
+  TextColumn get authorName => text().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+@DataClassName('TypingIndicatorRow')
+class TypingIndicators extends Table {
+  TextColumn get classId => text()();
+  TextColumn get userId => text()();
+  BoolColumn get isTyping => boolean().withDefault(const Constant(false))();
+  IntColumn get updatedAt => integer().withDefault(const Constant(0))();
+
+  @override
+  Set<Column> get primaryKey => {classId, userId};
+}
+
+@DataClassName('ModerationActionRow')
+class ModerationActionsTable extends Table {
+  TextColumn get id => text()();
+  TextColumn get classId => text()();
+  TextColumn get targetUserId => text()();
+  TextColumn get moderatorId => text()();
+  TextColumn get type => text()();
+  TextColumn get status => text()();
+  TextColumn get reason => text().nullable()();
+  TextColumn get metadata =>
+      text().withDefault(const Constant('{}'))();
+  IntColumn get createdAt => integer()();
+  IntColumn get expiresAt => integer().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+@DataClassName('ModerationAppealRow')
+class ModerationAppealsTable extends Table {
+  TextColumn get id => text()();
+  TextColumn get actionId => text()()
+      .references(ModerationActionsTable, #id, onDelete: KeyAction.cascade)();
+  TextColumn get classId => text()();
+  TextColumn get userId => text()();
+  TextColumn get message => text()();
+  TextColumn get status => text()();
+  TextColumn get resolutionNotes => text().nullable()();
+  IntColumn get createdAt => integer()();
+  IntColumn get resolvedAt => integer().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};
@@ -361,6 +410,9 @@ class MessageChangeTrackers extends Table {
     LocalUsers,
     SyncQueue,
     Messages,
+    TypingIndicators,
+    ModerationActionsTable,
+    ModerationAppealsTable,
     NoteChangeTrackers,
     ProgressChangeTrackers,
     MessageChangeTrackers,
@@ -381,7 +433,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 8;
+  int get schemaVersion => 9;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -443,6 +495,13 @@ class AppDatabase extends _$AppDatabase {
             await m.createTable(noteChangeTrackers);
             await m.createTable(progressChangeTrackers);
             await m.createTable(messageChangeTrackers);
+          }
+          if (from < 9) {
+            await m.addColumn(messages, messages.attachments);
+            await m.addColumn(messages, messages.authorName);
+            await m.createTable(typingIndicators);
+            await m.createTable(moderationActionsTable);
+            await m.createTable(moderationAppealsTable);
           }
         },
       );

--- a/lib/src/infrastructure/db/app_database.g.dart
+++ b/lib/src/infrastructure/db/app_database.g.dart
@@ -45,6 +45,15 @@ class _$AppDatabase extends GeneratedDatabase {
       'Run build_runner to generate table bindings for `sync_queue`.');
   late final TableInfo<Table, dynamic> messages = throw UnimplementedError(
       'Run build_runner to generate table bindings for `messages`.');
+  late final TableInfo<Table, dynamic> typingIndicators =
+      throw UnimplementedError(
+          'Run build_runner to generate table bindings for `typing_indicators`.');
+  late final TableInfo<Table, dynamic> moderationActionsTable =
+      throw UnimplementedError(
+          'Run build_runner to generate table bindings for `moderation_actions_table`.');
+  late final TableInfo<Table, dynamic> moderationAppealsTable =
+      throw UnimplementedError(
+          'Run build_runner to generate table bindings for `moderation_appeals_table`.');
   late final TableInfo<Table, dynamic> noteChangeTrackers =
       throw UnimplementedError(
           'Run build_runner to generate table bindings for `note_change_trackers`.');
@@ -60,7 +69,7 @@ class _$AppDatabase extends GeneratedDatabase {
       throw UnimplementedError('Run build_runner to generate table bindings.');
 
   @override
-  int get schemaVersion => 8;
+  int get schemaVersion => 9;
 }
 
 /// A lightweight stand-in for the generated [LocalUser] data class.
@@ -168,4 +177,232 @@ class LocalUsersCompanion {
       isActive: isActive ?? this.isActive,
     );
   }
+}
+
+class Message {
+  const Message({
+    required this.id,
+    required this.classId,
+    required this.userId,
+    required this.body,
+    required this.createdAt,
+    required this.updatedAt,
+    this.deleted = false,
+    this.flagged = false,
+    this.attachments = '[]',
+    this.authorName,
+  });
+
+  final String id;
+  final String classId;
+  final String userId;
+  final String body;
+  final int createdAt;
+  final int updatedAt;
+  final bool deleted;
+  final bool flagged;
+  final String attachments;
+  final String? authorName;
+}
+
+class MessagesCompanion {
+  const MessagesCompanion({
+    this.id = const Value.absent(),
+    this.classId = const Value.absent(),
+    this.userId = const Value.absent(),
+    this.body = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.deleted = const Value.absent(),
+    this.flagged = const Value.absent(),
+    this.attachments = const Value.absent(),
+    this.authorName = const Value.absent(),
+  });
+
+  const MessagesCompanion.insert({
+    required String id,
+    required String classId,
+    required String userId,
+    required String body,
+    required int createdAt,
+    required int updatedAt,
+    Value<bool> deleted = const Value(false),
+    Value<bool> flagged = const Value(false),
+    Value<String> attachments = const Value('[]'),
+    Value<String?> authorName = const Value.absent(),
+  })  : id = Value(id),
+        classId = Value(classId),
+        userId = Value(userId),
+        body = Value(body),
+        createdAt = Value(createdAt),
+        updatedAt = Value(updatedAt),
+        deleted = deleted,
+        flagged = flagged,
+        attachments = attachments,
+        authorName = authorName;
+
+  final Value<String> id;
+  final Value<String> classId;
+  final Value<String> userId;
+  final Value<String> body;
+  final Value<int> createdAt;
+  final Value<int> updatedAt;
+  final Value<bool> deleted;
+  final Value<bool> flagged;
+  final Value<String> attachments;
+  final Value<String?> authorName;
+
+  MessagesCompanion copyWith({
+    Value<String>? id,
+    Value<String>? classId,
+    Value<String>? userId,
+    Value<String>? body,
+    Value<int>? createdAt,
+    Value<int>? updatedAt,
+    Value<bool>? deleted,
+    Value<bool>? flagged,
+    Value<String>? attachments,
+    Value<String?>? authorName,
+  }) {
+    return MessagesCompanion(
+      id: id ?? this.id,
+      classId: classId ?? this.classId,
+      userId: userId ?? this.userId,
+      body: body ?? this.body,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      deleted: deleted ?? this.deleted,
+      flagged: flagged ?? this.flagged,
+      attachments: attachments ?? this.attachments,
+      authorName: authorName ?? this.authorName,
+    );
+  }
+}
+
+class TypingIndicatorRow {
+  const TypingIndicatorRow({
+    required this.classId,
+    required this.userId,
+    required this.isTyping,
+    required this.updatedAt,
+  });
+
+  final String classId;
+  final String userId;
+  final bool isTyping;
+  final int updatedAt;
+}
+
+class TypingIndicatorsCompanion {
+  const TypingIndicatorsCompanion({
+    this.classId = const Value.absent(),
+    this.userId = const Value.absent(),
+    this.isTyping = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+  });
+
+  final Value<String> classId;
+  final Value<String> userId;
+  final Value<bool> isTyping;
+  final Value<int> updatedAt;
+}
+
+class ModerationActionRow {
+  const ModerationActionRow({
+    required this.id,
+    required this.classId,
+    required this.targetUserId,
+    required this.moderatorId,
+    required this.type,
+    required this.status,
+    this.reason,
+    required this.metadata,
+    required this.createdAt,
+    this.expiresAt,
+  });
+
+  final String id;
+  final String classId;
+  final String targetUserId;
+  final String moderatorId;
+  final String type;
+  final String status;
+  final String? reason;
+  final String metadata;
+  final int createdAt;
+  final int? expiresAt;
+}
+
+class ModerationActionsTableCompanion {
+  const ModerationActionsTableCompanion({
+    this.id = const Value.absent(),
+    this.classId = const Value.absent(),
+    this.targetUserId = const Value.absent(),
+    this.moderatorId = const Value.absent(),
+    this.type = const Value.absent(),
+    this.status = const Value.absent(),
+    this.reason = const Value.absent(),
+    this.metadata = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.expiresAt = const Value.absent(),
+  });
+
+  final Value<String> id;
+  final Value<String> classId;
+  final Value<String> targetUserId;
+  final Value<String> moderatorId;
+  final Value<String> type;
+  final Value<String> status;
+  final Value<String?> reason;
+  final Value<String> metadata;
+  final Value<int> createdAt;
+  final Value<int?> expiresAt;
+}
+
+class ModerationAppealRow {
+  const ModerationAppealRow({
+    required this.id,
+    required this.actionId,
+    required this.classId,
+    required this.userId,
+    required this.message,
+    required this.status,
+    this.resolutionNotes,
+    required this.createdAt,
+    this.resolvedAt,
+  });
+
+  final String id;
+  final String actionId;
+  final String classId;
+  final String userId;
+  final String message;
+  final String status;
+  final String? resolutionNotes;
+  final int createdAt;
+  final int? resolvedAt;
+}
+
+class ModerationAppealsTableCompanion {
+  const ModerationAppealsTableCompanion({
+    this.id = const Value.absent(),
+    this.actionId = const Value.absent(),
+    this.classId = const Value.absent(),
+    this.userId = const Value.absent(),
+    this.message = const Value.absent(),
+    this.status = const Value.absent(),
+    this.resolutionNotes = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.resolvedAt = const Value.absent(),
+  });
+
+  final Value<String> id;
+  final Value<String> actionId;
+  final Value<String> classId;
+  final Value<String> userId;
+  final Value<String> message;
+  final Value<String> status;
+  final Value<String?> resolutionNotes;
+  final Value<int> createdAt;
+  final Value<int?> resolvedAt;
 }

--- a/lib/src/infrastructure/db/daos/chat_dao.dart
+++ b/lib/src/infrastructure/db/daos/chat_dao.dart
@@ -27,4 +27,83 @@ class ChatDao {
     return (_db.select(_db.messages)..where((tbl) => tbl.id.equals(id)))
         .getSingleOrNull();
   }
+
+  Stream<List<TypingIndicatorRow>> watchTyping(String classId) {
+    final query = _db.select(_db.typingIndicators)
+      ..where((tbl) => tbl.classId.equals(classId));
+    return query.watch();
+  }
+
+  Future<void> upsertTyping(TypingIndicatorsCompanion companion) {
+    return _db
+        .into(_db.typingIndicators)
+        .insertOnConflictUpdate(companion);
+  }
+
+  Future<void> removeTyping(String classId, String userId) {
+    return (_db.delete(_db.typingIndicators)
+          ..where(
+            (tbl) =>
+                tbl.classId.equals(classId) & tbl.userId.equals(userId),
+          ))
+        .go();
+  }
+
+  Stream<List<ModerationActionRow>> watchModerationActions(String classId) {
+    final query = _db.select(_db.moderationActionsTable)
+      ..where((tbl) => tbl.classId.equals(classId))
+      ..orderBy([(tbl) => OrderingTerm.desc(tbl.createdAt)]);
+    return query.watch();
+  }
+
+  Stream<List<ModerationAppealRow>> watchModerationAppeals(String classId) {
+    final query = _db.select(_db.moderationAppealsTable)
+      ..where((tbl) => tbl.classId.equals(classId))
+      ..orderBy([(tbl) => OrderingTerm.desc(tbl.createdAt)]);
+    return query.watch();
+  }
+
+  Future<void> upsertModerationAction(
+    ModerationActionsTableCompanion companion,
+  ) {
+    return _db
+        .into(_db.moderationActionsTable)
+        .insertOnConflictUpdate(companion);
+  }
+
+  Future<void> upsertModerationAppeal(
+    ModerationAppealsTableCompanion companion,
+  ) {
+    return _db
+        .into(_db.moderationAppealsTable)
+        .insertOnConflictUpdate(companion);
+  }
+
+  Future<ModerationActionRow?> getModerationAction(String id) {
+    return (_db.select(_db.moderationActionsTable)
+          ..where((tbl) => tbl.id.equals(id)))
+        .getSingleOrNull();
+  }
+
+  Future<List<ModerationActionRow>> getModerationActionsForUser(
+    String classId,
+    String userId,
+  ) {
+    final query = _db.select(_db.moderationActionsTable)
+      ..where(
+        (tbl) => tbl.classId.equals(classId) & tbl.targetUserId.equals(userId),
+      )
+      ..orderBy([(tbl) => OrderingTerm.desc(tbl.createdAt)]);
+    return query.get();
+  }
+
+  Future<void> updateModerationActionStatus(String id, String status) {
+    return (_db.update(_db.moderationActionsTable)
+          ..where((tbl) => tbl.id.equals(id)))
+        .write(
+      ModerationActionsTableCompanion(
+        status: Value(status),
+      ),
+    );
+  }
 }

--- a/lib/src/infrastructure/notifications/notification_service.dart
+++ b/lib/src/infrastructure/notifications/notification_service.dart
@@ -1,0 +1,162 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+
+import '../../domain/chat/entities.dart';
+import '../../domain/settings/entities.dart';
+import '../../domain/settings/repositories.dart';
+
+class NotificationService {
+  NotificationService({
+    required FirebaseMessaging messaging,
+    required FlutterLocalNotificationsPlugin localNotifications,
+    required SettingsRepository settingsRepository,
+    required Future<String?> Function() userIdProvider,
+  })  : _messaging = messaging,
+        _localNotifications = localNotifications,
+        _settingsRepository = settingsRepository,
+        _userIdProvider = userIdProvider;
+
+  final FirebaseMessaging _messaging;
+  final FlutterLocalNotificationsPlugin _localNotifications;
+  final SettingsRepository _settingsRepository;
+  final Future<String?> Function() _userIdProvider;
+
+  static const AndroidNotificationChannel _chatChannel = AndroidNotificationChannel(
+    'chat_messages',
+    'Class chat messages',
+    description: 'Notifications for new class chat messages.',
+    importance: Importance.high,
+  );
+
+  bool _initialised = false;
+
+  Future<void> initialise() async {
+    if (_initialised) {
+      return;
+    }
+    final settings = await _messaging.requestPermission(
+      alert: true,
+      announcement: false,
+      badge: true,
+      carPlay: false,
+      criticalAlert: false,
+      provisional: false,
+      sound: true,
+    );
+    if (settings.authorizationStatus == AuthorizationStatus.authorized ||
+        settings.authorizationStatus == AuthorizationStatus.provisional) {
+      await _configureLocalNotifications();
+      _initialised = true;
+    }
+  }
+
+  Future<void> _configureLocalNotifications() async {
+    const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const darwinSettings = DarwinInitializationSettings();
+    await _localNotifications.initialize(
+      const InitializationSettings(android: androidSettings, iOS: darwinSettings),
+    );
+    final androidPlugin =
+        _localNotifications.resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>();
+    await androidPlugin?.createNotificationChannel(_chatChannel);
+  }
+
+  Future<void> handleIncomingMessage(
+    ChatMessage message,
+    String className,
+  ) async {
+    if (!_initialised) {
+      await initialise();
+    }
+    final userId = await _userIdProvider();
+    if (userId == null || userId == message.userId) {
+      return;
+    }
+    final preferences = await _settingsRepository.getNotificationPreferences(userId);
+    final now = DateTime.now();
+    if (!preferences.shouldNotify(message.classId, now)) {
+      return;
+    }
+    if (!preferences.localNotificationsEnabled) {
+      return;
+    }
+    final notificationDetails = NotificationDetails(
+      android: AndroidNotificationDetails(
+        _chatChannel.id,
+        _chatChannel.name,
+        channelDescription: _chatChannel.description,
+        importance: Importance.high,
+        priority: Priority.high,
+        styleInformation: const BigTextStyleInformation(''),
+      ),
+      iOS: const DarwinNotificationDetails(),
+    );
+    final body = message.deleted
+        ? '${message.authorName ?? 'Moderator'} removed a message.'
+        : '${message.authorName ?? 'Classmate'}: ${message.body}';
+    await _localNotifications.show(
+      message.createdAt.millisecondsSinceEpoch ~/ 1000,
+      className,
+      body,
+      notificationDetails,
+      payload: jsonEncode({
+        'classId': message.classId,
+      }),
+    );
+  }
+
+  Future<void> dispose() async {
+    if (!kIsWeb) {
+      await _localNotifications.cancelAll();
+    }
+  }
+}
+
+class ChatNotificationObserver {
+  ChatNotificationObserver(this._watchMessages, this._notificationService);
+
+  final Stream<List<ChatMessage>> Function(String classId) _watchMessages;
+  final NotificationService _notificationService;
+  final Map<String, StreamSubscription<List<ChatMessage>>> _subscriptions = {};
+  final Map<String, String?> _lastMessageIds = {};
+
+  Iterable<String> get attachedClassIds => _subscriptions.keys;
+
+  void attach(String classId, String className) {
+    if (_subscriptions.containsKey(classId)) {
+      return;
+    }
+    final subscription = _watchMessages(classId).listen((messages) {
+      if (messages.isEmpty) {
+        return;
+      }
+      final latest = messages.last;
+      final lastId = _lastMessageIds[classId];
+      if (lastId == latest.id) {
+        return;
+      }
+      _lastMessageIds[classId] = latest.id;
+      unawaited(_notificationService.handleIncomingMessage(latest, className));
+    });
+    _subscriptions[classId] = subscription;
+  }
+
+  Future<void> detach(String classId) async {
+    final subscription = _subscriptions.remove(classId);
+    await subscription?.cancel();
+    _lastMessageIds.remove(classId);
+  }
+
+  Future<void> dispose() async {
+    for (final subscription in _subscriptions.values) {
+      await subscription.cancel();
+    }
+    _subscriptions.clear();
+    _lastMessageIds.clear();
+    await _notificationService.dispose();
+  }
+}

--- a/lib/src/presentation/chat/chat_controller.dart
+++ b/lib/src/presentation/chat/chat_controller.dart
@@ -1,0 +1,198 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../domain/chat/entities.dart';
+import '../../domain/chat/errors.dart';
+import '../../domain/chat/usecases.dart';
+import '../../domain/accounts/entities.dart';
+import '../providers.dart';
+
+class ChatComposerState {
+  final String text;
+  final List<ChatAttachment> attachments;
+  final bool isSending;
+  final String? errorMessage;
+  final bool isTyping;
+
+  const ChatComposerState({
+    this.text = '',
+    this.attachments = const [],
+    this.isSending = false,
+    this.errorMessage,
+    this.isTyping = false,
+  });
+
+  bool get canSend => text.trim().isNotEmpty || attachments.isNotEmpty;
+
+  ChatComposerState copyWith({
+    String? text,
+    List<ChatAttachment>? attachments,
+    bool? isSending,
+    String? errorMessage,
+    bool? isTyping,
+  }) {
+    return ChatComposerState(
+      text: text ?? this.text,
+      attachments: attachments ?? this.attachments,
+      isSending: isSending ?? this.isSending,
+      errorMessage: errorMessage,
+      isTyping: isTyping ?? this.isTyping,
+    );
+  }
+}
+
+class ChatController extends StateNotifier<ChatComposerState> {
+  ChatController(this._ref, this.classId)
+      : super(const ChatComposerState()) {
+    _activeAccountSub = _ref.listen<AsyncValue<LocalAccount?>>(activeAccountProvider,
+        (_, next) {
+      next.whenData((account) {
+        _currentAccount = account;
+      });
+    });
+  }
+
+  final Ref _ref;
+  final String classId;
+  LocalAccount? _currentAccount;
+  late final ProviderSubscription<AsyncValue<LocalAccount?>> _activeAccountSub;
+  Timer? _typingDebounce;
+
+  SendChatMessageUseCase get _sendMessage =>
+      _ref.read(sendChatMessageUseCaseProvider);
+  UpdateTypingStatusUseCase get _updateTyping =>
+      _ref.read(updateTypingStatusUseCaseProvider);
+
+  void setText(String value) {
+    state = state.copyWith(text: value, errorMessage: null);
+    _markTyping(value.trim().isNotEmpty);
+  }
+
+  void addAttachment(ChatAttachment attachment) {
+    final next = [...state.attachments, attachment];
+    state = state.copyWith(attachments: next, errorMessage: null);
+    _markTyping(true);
+  }
+
+  void removeAttachment(String attachmentId) {
+    final next = state.attachments
+        .where((attachment) => attachment.id != attachmentId)
+        .toList(growable: false);
+    state = state.copyWith(attachments: next, errorMessage: null);
+  }
+
+  Future<void> send() async {
+    final account = _currentAccount;
+    if (account == null) {
+      state = state.copyWith(
+        errorMessage: 'You need an active profile to send messages.',
+      );
+      return;
+    }
+    if (!state.canSend) {
+      return;
+    }
+    final now = DateTime.now();
+    final message = ChatMessage(
+      id: const Uuid().v4(),
+      classId: classId,
+      userId: account.id,
+      body: state.text.trim(),
+      createdAt: now,
+      updatedAt: now,
+      attachments: state.attachments,
+      authorName: account.displayName,
+    );
+    state = state.copyWith(isSending: true, errorMessage: null);
+    try {
+      await _sendMessage(message);
+      state = const ChatComposerState();
+      await _updateTyping(
+        classId: classId,
+        userId: account.id,
+        isTyping: false,
+      );
+    } catch (error) {
+      final errorMessage = error is ChatModerationException
+          ? error.message
+          : 'Failed to send message: $error';
+      state = state.copyWith(
+        isSending: false,
+        errorMessage: errorMessage,
+      );
+    }
+  }
+
+  void _markTyping(bool typing) {
+    if (_currentAccount == null) {
+      return;
+    }
+    final userId = _currentAccount!.id;
+    _typingDebounce?.cancel();
+    if (typing) {
+      if (!state.isTyping) {
+        state = state.copyWith(isTyping: true);
+        unawaited(
+          _updateTyping(
+            classId: classId,
+            userId: userId,
+            isTyping: true,
+          ),
+        );
+      }
+      _typingDebounce = Timer(const Duration(seconds: 4), () {
+        _markTyping(false);
+      });
+    } else {
+      state = state.copyWith(isTyping: false);
+      unawaited(
+        _updateTyping(
+          classId: classId,
+          userId: userId,
+          isTyping: false,
+        ),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _typingDebounce?.cancel();
+    if (_currentAccount != null) {
+      unawaited(
+        _updateTyping(
+          classId: classId,
+          userId: _currentAccount!.id,
+          isTyping: false,
+        ),
+      );
+    }
+    _activeAccountSub.close();
+    super.dispose();
+  }
+}
+
+final chatComposerControllerProvider = StateNotifierProvider.autoDispose
+    .family<ChatController, ChatComposerState, String>((ref, classId) {
+  return ChatController(ref, classId);
+});
+
+final chatMessagesProvider = StreamProvider.autoDispose
+    .family<List<ChatMessage>, String>((ref, classId) {
+  final useCase = ref.watch(watchChatMessagesUseCaseProvider);
+  return useCase(classId);
+});
+
+final typingStatusProvider = StreamProvider.autoDispose
+    .family<List<TypingStatus>, String>((ref, classId) {
+  final useCase = ref.watch(watchTypingStatusUseCaseProvider);
+  return useCase(classId);
+});
+
+final moderationActionsProvider = StreamProvider.autoDispose
+    .family<List<ModerationAction>, String>((ref, classId) {
+  final useCase = ref.watch(watchModerationActionsUseCaseProvider);
+  return useCase(classId);
+});

--- a/lib/src/presentation/chat/chat_room_screen.dart
+++ b/lib/src/presentation/chat/chat_room_screen.dart
@@ -1,0 +1,693 @@
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:path/path.dart' as p;
+import 'package:url_launcher/url_launcher.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../domain/chat/entities.dart';
+import '../../domain/chat/usecases.dart';
+import '../../domain/accounts/entities.dart';
+import '../providers.dart';
+import 'chat_controller.dart';
+
+class ChatRoomScreen extends ConsumerWidget {
+  const ChatRoomScreen({
+    super.key,
+    required this.classId,
+    required this.className,
+  });
+
+  final String classId;
+  final String className;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final messagesAsync = ref.watch(chatMessagesProvider(classId));
+    final typingAsync = ref.watch(typingStatusProvider(classId));
+    final composerState = ref.watch(chatComposerControllerProvider(classId));
+    final controller = ref.read(chatComposerControllerProvider(classId).notifier);
+    final accountAsync = ref.watch(activeAccountProvider);
+
+    final messages = messagesAsync.value ?? const <ChatMessage>[];
+    final typingUsers = typingAsync.value ?? const <TypingStatus>[];
+
+    final Map<String, String> userDisplayNames = {
+      for (final message in messages)
+        if (message.authorName != null && message.authorName!.isNotEmpty)
+          message.userId: message.authorName!,
+    };
+
+    final typingNames = typingUsers
+        .where((status) => status.isTyping)
+        .map((status) {
+          if (status.userId == accountAsync.asData?.value?.id) {
+            return 'You';
+          }
+          return userDisplayNames[status.userId] ?? 'Someone';
+        })
+        .toList();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Class Chat · $className'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.report),
+            tooltip: 'Submit appeal',
+            onPressed: () async {
+              final account = accountAsync.asData?.value;
+              if (account == null) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Create a profile to submit appeals.')),
+                );
+                return;
+              }
+              await showDialog<void>(
+                context: context,
+                builder: (context) {
+                  final idController = TextEditingController();
+                  final reasonController = TextEditingController();
+                  return AlertDialog(
+                    title: const Text('Appeal moderation action'),
+                    content: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        TextField(
+                          controller: idController,
+                          decoration: const InputDecoration(
+                            labelText: 'Action ID',
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        TextField(
+                          controller: reasonController,
+                          decoration: const InputDecoration(
+                            labelText: 'Why should this be reviewed?'
+                                ' (shared with moderators)',
+                          ),
+                          maxLines: 4,
+                        ),
+                      ],
+                    ),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: const Text('Cancel'),
+                      ),
+                      TextButton(
+                        onPressed: () async {
+                          if (idController.text.trim().isEmpty ||
+                              reasonController.text.trim().isEmpty) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text('Provide an action ID and your message.'),
+                              ),
+                            );
+                            return;
+                          }
+                          final appeal = ModerationAppeal(
+                            id: const Uuid().v4(),
+                            actionId: idController.text.trim(),
+                            classId: classId,
+                            userId: account.id,
+                            message: reasonController.text.trim(),
+                            createdAt: DateTime.now(),
+                          );
+                          await ref
+                              .read(submitModerationAppealUseCaseProvider)
+                              .call(appeal);
+                          if (context.mounted) {
+                            Navigator.of(context).pop();
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content:
+                                    Text('Appeal submitted. Moderators will review it.'),
+                              ),
+                            );
+                          }
+                        },
+                        child: const Text('Submit'),
+                      ),
+                    ],
+                  );
+                },
+              );
+            },
+          )
+        ],
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: messagesAsync.when(
+                data: (messages) {
+                  if (messages.isEmpty) {
+                    return const Center(
+                      child: Text('No messages yet. Start the conversation!'),
+                    );
+                  }
+                  return _MessageList(
+                    messages: messages,
+                    classId: classId,
+                    accountAsync: accountAsync,
+                  );
+                },
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (error, stack) => Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text('Failed to load messages: $error'),
+                  ),
+                ),
+              ),
+            ),
+            if (typingNames.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '${typingNames.join(', ')} is typing…',
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodySmall
+                        ?.copyWith(fontStyle: FontStyle.italic),
+                  ),
+                ),
+              ),
+            _ComposerBar(
+              state: composerState,
+              controller: controller,
+              onPickAttachments: () => _pickAttachments(context, controller),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _pickAttachments(
+    BuildContext context,
+    ChatController controller,
+  ) async {
+    try {
+      final result = await FilePicker.platform.pickFiles(allowMultiple: true);
+      if (result == null || result.files.isEmpty) {
+        return;
+      }
+      for (final file in result.files) {
+        final path = file.path;
+        if (path == null) {
+          continue;
+        }
+        final extension = p.extension(path).toLowerCase();
+        final type = _attachmentType(extension);
+        final attachment = ChatAttachment(
+          id: const Uuid().v4(),
+          type: type,
+          name: file.name,
+          url: '',
+          localPath: path,
+          sizeBytes: file.size,
+        );
+        controller.addAttachment(attachment);
+      }
+    } catch (error) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Unable to add attachment: $error')),
+        );
+      }
+    }
+  }
+
+  String _attachmentType(String extension) {
+    switch (extension) {
+      case '.png':
+      case '.jpg':
+      case '.jpeg':
+      case '.gif':
+      case '.bmp':
+        return 'image';
+      case '.pdf':
+        return 'document';
+      case '.mp3':
+      case '.m4a':
+      case '.wav':
+        return 'audio';
+      case '.mp4':
+      case '.mov':
+      case '.avi':
+        return 'video';
+      default:
+        return 'file';
+    }
+  }
+}
+
+class _MessageList extends ConsumerWidget {
+  const _MessageList({
+    required this.messages,
+    required this.classId,
+    required this.accountAsync,
+  });
+
+  final List<ChatMessage> messages;
+  final String classId;
+  final AsyncValue<LocalAccount?> accountAsync;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final account = accountAsync.asData?.value;
+    return ListView.builder(
+      reverse: false,
+      padding: const EdgeInsets.all(16.0),
+      itemCount: messages.length,
+      itemBuilder: (context, index) {
+        final message = messages[index];
+        final isMine = account?.id == message.userId;
+        return Align(
+          alignment: isMine ? Alignment.centerRight : Alignment.centerLeft,
+          child: _MessageBubble(
+            message: message,
+            isMine: isMine,
+            classId: classId,
+            account: account,
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _MessageBubble extends ConsumerWidget {
+  const _MessageBubble({
+    required this.message,
+    required this.isMine,
+    required this.classId,
+    required this.account,
+  });
+
+  final ChatMessage message;
+  final bool isMine;
+  final String classId;
+  final LocalAccount? account;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final bubbleColor = isMine
+        ? theme.colorScheme.primary.withOpacity(0.12)
+        : theme.colorScheme.surfaceVariant;
+    final textColor = isMine ? theme.colorScheme.onPrimaryContainer : null;
+
+    final children = <Widget>[
+      if (message.authorName != null && message.authorName!.isNotEmpty)
+        Text(
+          message.authorName!,
+          style: theme.textTheme.bodySmall
+              ?.copyWith(color: theme.colorScheme.primary, fontWeight: FontWeight.bold),
+        ),
+      if (message.deleted)
+        Text(
+          'This message was removed',
+          style: theme.textTheme.bodyMedium?.copyWith(
+            fontStyle: FontStyle.italic,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        )
+      else
+        Text(
+          message.body,
+          style: theme.textTheme.bodyMedium?.copyWith(color: textColor),
+        ),
+      if (message.attachments.isNotEmpty)
+        Padding(
+          padding: const EdgeInsets.only(top: 8),
+          child: Wrap(
+            spacing: 8,
+            runSpacing: 4,
+            children: message.attachments
+                .map((attachment) => ActionChip(
+                      avatar: Icon(_attachmentIcon(attachment.type), size: 18),
+                      label: Text(attachment.name),
+                      onPressed: attachment.url.isEmpty
+                          ? null
+                          : () async {
+                              final uri = Uri.parse(attachment.url);
+                              if (await canLaunchUrl(uri)) {
+                                await launchUrl(uri, mode: LaunchMode.externalApplication);
+                              }
+                            },
+                    ))
+                .toList(),
+          ),
+        ),
+      Padding(
+        padding: const EdgeInsets.only(top: 4),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              _formatTimestamp(message.createdAt),
+              style: theme.textTheme.bodySmall?.copyWith(
+                fontStyle: FontStyle.italic,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            if (message.flagged)
+              Padding(
+                padding: const EdgeInsets.only(left: 8),
+                child: Icon(Icons.flag, color: theme.colorScheme.error, size: 16),
+              ),
+          ],
+        ),
+      ),
+    ];
+
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 6),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: bubbleColor,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ...children,
+          Align(
+            alignment: Alignment.centerRight,
+            child: PopupMenuButton<_MessageAction>(
+              tooltip: 'Moderation tools',
+              icon: const Icon(Icons.more_horiz, size: 18),
+              onSelected: (value) => _handleAction(context, ref, value),
+              itemBuilder: (context) => [
+                const PopupMenuItem(
+                  value: _MessageAction.flag,
+                  child: Text('Flag message'),
+                ),
+                const PopupMenuItem(
+                  value: _MessageAction.delete,
+                  child: Text('Delete message'),
+                ),
+                const PopupMenuDivider(),
+                const PopupMenuItem(
+                  value: _MessageAction.mute,
+                  child: Text('Mute user (15 min)'),
+                ),
+                const PopupMenuItem(
+                  value: _MessageAction.ban,
+                  child: Text('Ban user'),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  IconData _attachmentIcon(String type) {
+    switch (type) {
+      case 'image':
+        return Icons.image_outlined;
+      case 'document':
+        return Icons.description_outlined;
+      case 'audio':
+        return Icons.audiotrack;
+      case 'video':
+        return Icons.videocam_outlined;
+      default:
+        return Icons.attach_file;
+    }
+  }
+
+  String _formatTimestamp(DateTime timestamp) {
+    final timeOfDay = TimeOfDay.fromDateTime(timestamp.toLocal());
+    final hour = timeOfDay.hourOfPeriod == 0 ? 12 : timeOfDay.hourOfPeriod;
+    final minute = timeOfDay.minute.toString().padLeft(2, '0');
+    final suffix = timeOfDay.period == DayPeriod.am ? 'AM' : 'PM';
+    return '${hour.toString().padLeft(2, '0')}:$minute $suffix';
+  }
+
+  Future<void> _handleAction(
+    BuildContext context,
+    WidgetRef ref,
+    _MessageAction action,
+  ) async {
+    final accountId = account?.id;
+    if (accountId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Moderation tools require an active profile.')),
+      );
+      return;
+    }
+    switch (action) {
+      case _MessageAction.flag:
+        final reason = await _promptModerationReason(context, 'Flag reason');
+        if (reason == null) {
+          return;
+        }
+        await ref.read(flagChatMessageUseCaseProvider).call(
+              message.id,
+              flagged: true,
+              moderatorId: accountId,
+              reason: reason,
+            );
+        break;
+      case _MessageAction.delete:
+        final reason = await _promptModerationReason(context, 'Delete reason');
+        if (reason == null) {
+          return;
+        }
+        await ref.read(deleteChatMessageUseCaseProvider).call(
+              message.id,
+              moderatorId: accountId,
+              reason: reason,
+            );
+        break;
+      case _MessageAction.mute:
+        await ref.read(muteUserUseCaseProvider).call(
+              classId: classId,
+              userId: message.userId,
+              duration: const Duration(minutes: 15),
+              moderatorId: accountId,
+              reason: 'Muted via chat UI',
+            );
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Muted ${message.authorName ?? message.userId}.')),
+        );
+        break;
+      case _MessageAction.ban:
+        final confirm = await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('Ban user?'),
+            content: Text(
+              'Ban ${message.authorName ?? message.userId} from this class chat?'
+              ' This action can be appealed.',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('Cancel'),
+              ),
+              ElevatedButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('Ban'),
+              ),
+            ],
+          ),
+        );
+        if (confirm == true) {
+          await ref.read(banUserUseCaseProvider).call(
+                classId: classId,
+                userId: message.userId,
+                moderatorId: accountId,
+                reason: 'Banned via chat UI',
+              );
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Banned ${message.authorName ?? message.userId}.')),
+          );
+        }
+        break;
+    }
+  }
+
+  Future<String?> _promptModerationReason(
+    BuildContext context,
+    String label,
+  ) async {
+    final controller = TextEditingController();
+    return showDialog<String?>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(label),
+        content: TextField(
+          controller: controller,
+          decoration: const InputDecoration(
+            hintText: 'Provide context for the action',
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(null),
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.of(context).pop(controller.text.trim()),
+            child: const Text('Submit'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ComposerBar extends StatefulWidget {
+  const _ComposerBar({
+    required this.state,
+    required this.controller,
+    required this.onPickAttachments,
+  });
+
+  final ChatComposerState state;
+  final ChatController controller;
+  final VoidCallback onPickAttachments;
+
+  @override
+  State<_ComposerBar> createState() => _ComposerBarState();
+}
+
+class _ComposerBarState extends State<_ComposerBar> {
+  late final TextEditingController _textController;
+
+  @override
+  void initState() {
+    super.initState();
+    _textController = TextEditingController(text: widget.state.text);
+  }
+
+  @override
+  void didUpdateWidget(covariant _ComposerBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.state.text != _textController.text) {
+      _textController.value = TextEditingValue(
+        text: widget.state.text,
+        selection: TextSelection.collapsed(offset: widget.state.text.length),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = widget.state;
+    return SafeArea(
+      top: false,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surface,
+          boxShadow: const [
+            BoxShadow(blurRadius: 4, color: Colors.black12, offset: Offset(0, -2)),
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (state.attachments.isNotEmpty)
+              SizedBox(
+                height: 72,
+                child: ListView(
+                  scrollDirection: Axis.horizontal,
+                  children: state.attachments
+                      .map(
+                        (attachment) => Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 4),
+                          child: Chip(
+                            label: Text(attachment.name),
+                            avatar: Icon(_attachmentPreviewIcon(attachment.type)),
+                            onDeleted: () => widget.controller.removeAttachment(attachment.id),
+                          ),
+                        ),
+                      )
+                      .toList(),
+                ),
+              ),
+            Row(
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.attach_file),
+                  onPressed: widget.onPickAttachments,
+                ),
+                Expanded(
+                  child: TextField(
+                    controller: _textController,
+                    onChanged: widget.controller.setText,
+                    maxLines: null,
+                    decoration: const InputDecoration(
+                      hintText: 'Write a message…',
+                      border: InputBorder.none,
+                    ),
+                  ),
+                ),
+                state.isSending
+                    ? const Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 12),
+                        child: SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        ),
+                      )
+                    : IconButton(
+                        icon: const Icon(Icons.send),
+                        color: Theme.of(context).colorScheme.primary,
+                        onPressed: state.canSend ? widget.controller.send : null,
+                      ),
+              ],
+            ),
+            if (state.errorMessage != null)
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Text(
+                    state.errorMessage!,
+                    style: TextStyle(color: Theme.of(context).colorScheme.error),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  IconData _attachmentPreviewIcon(String type) {
+    switch (type) {
+      case 'image':
+        return Icons.image;
+      case 'document':
+        return Icons.picture_as_pdf;
+      case 'audio':
+        return Icons.audiotrack;
+      case 'video':
+        return Icons.videocam;
+      default:
+        return Icons.insert_drive_file;
+    }
+  }
+}
+
+enum _MessageAction { flag, delete, mute, ban }

--- a/lib/src/presentation/lessons/lesson_detail_screen.dart
+++ b/lib/src/presentation/lessons/lesson_detail_screen.dart
@@ -8,6 +8,7 @@ import '../../domain/lessons/entities.dart';
 import '../../domain/lessons/services/lesson_quiz_grader.dart';
 import '../../domain/lessons/services/lesson_timer_service.dart';
 import '../providers.dart';
+import '../chat/chat_room_screen.dart';
 
 class LessonDetailScreen extends ConsumerStatefulWidget {
   const LessonDetailScreen({super.key, required this.lesson});
@@ -106,6 +107,7 @@ class _LessonDetailScreenState extends ConsumerState<LessonDetailScreen> {
       );
     }
     final theme = Theme.of(context);
+    final chatClassId = normaliseClassId(widget.lesson.lessonClass);
     final ageLabel = widget.lesson.ageRange != null
         ? '${widget.lesson.ageRange!.min}-${widget.lesson.ageRange!.max} years'
         : 'All ages';
@@ -164,6 +166,25 @@ class _LessonDetailScreenState extends ConsumerState<LessonDetailScreen> {
               onComplete: _isPersisting || status == 'completed'
                   ? null
                   : _handleComplete,
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                icon: const Icon(Icons.forum_outlined),
+                label: const Text('Open class chat'),
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => ChatRoomScreen(
+                        classId: chatClassId,
+                        className: widget.lesson.lessonClass,
+                      ),
+                    ),
+                  );
+                },
+              ),
             ),
             if (widget.lesson.objectives.isNotEmpty) ...[
               const SizedBox(height: 24),

--- a/lib/src/presentation/providers.dart
+++ b/lib/src/presentation/providers.dart
@@ -1,12 +1,15 @@
 import 'dart:async';
 
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_storage/firebase_storage.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -14,6 +17,7 @@ import '../data/accounts/account_repository_impl.dart';
 import '../data/bible/annotation_repository_impl.dart';
 import '../data/bible/bible_repository_impl.dart';
 import '../data/bible/reading_progress_repository_impl.dart';
+import '../data/chat/chat_remote_data_source.dart';
 import '../data/chat/chat_repository_impl.dart';
 import '../data/lessons/lesson_repository_impl.dart';
 import '../data/settings/settings_repository_impl.dart';
@@ -59,6 +63,7 @@ import '../infrastructure/lessons/lesson_sync_service.dart';
 import '../infrastructure/sync/sync_orchestrator.dart';
 import '../infrastructure/accounts/cloud_account_coordinator.dart';
 import '../infrastructure/accounts/firebase_auth_service.dart';
+import '../infrastructure/notifications/notification_service.dart';
 import '../utils/iterable_extensions.dart';
 import 'settings/bible_import_controller.dart';
 import 'settings/data_sync_controller.dart';
@@ -77,6 +82,19 @@ final firebaseAuthProvider = Provider<FirebaseAuth>((ref) {
 
 final firebaseStorageProvider = Provider<FirebaseStorage>((ref) {
   return FirebaseStorage.instance;
+});
+
+final firebaseFirestoreProvider = Provider<FirebaseFirestore>((ref) {
+  return FirebaseFirestore.instance;
+});
+
+final firebaseMessagingProvider = Provider<FirebaseMessaging>((ref) {
+  return FirebaseMessaging.instance;
+});
+
+final flutterLocalNotificationsProvider =
+    Provider<FlutterLocalNotificationsPlugin>((ref) {
+  return FlutterLocalNotificationsPlugin();
 });
 
 final googleSignInProvider = Provider<GoogleSignIn>((ref) {
@@ -122,6 +140,13 @@ final lessonDaoProvider = Provider((ref) => LessonDao(ref.watch(appDatabaseProvi
 final accountDaoProvider = Provider((ref) => AccountDao(ref.watch(appDatabaseProvider)));
 final syncDaoProvider = Provider((ref) => SyncDao(ref.watch(appDatabaseProvider)));
 final chatDaoProvider = Provider((ref) => ChatDao(ref.watch(appDatabaseProvider)));
+final chatRemoteDataSourceProvider =
+    Provider<ChatRemoteDataSource>((ref) {
+  return ChatRemoteDataSource(
+    ref.watch(firebaseFirestoreProvider),
+    ref.watch(firebaseStorageProvider),
+  );
+});
 final annotationDaoProvider =
     Provider((ref) => AnnotationDao(ref.watch(appDatabaseProvider)));
 
@@ -300,7 +325,11 @@ final chatRepositoryProvider = Provider<ChatRepository>((ref) {
   final dao = ref.watch(chatDaoProvider);
   final syncDao = ref.watch(syncDaoProvider);
   final syncRepository = ref.watch(syncRepositoryProvider);
-  return ChatRepositoryImpl(db, dao, syncDao, syncRepository);
+  final remote = ref.watch(chatRemoteDataSourceProvider);
+  final repository =
+      ChatRepositoryImpl(db, dao, syncDao, syncRepository, remote);
+  ref.onDispose(repository.dispose);
+  return repository;
 });
 final annotationRepositoryProvider = Provider<AnnotationRepository>((ref) {
   final db = ref.watch(appDatabaseProvider);
@@ -318,6 +347,18 @@ final readingProgressRepositoryProvider =
 
 final settingsRepositoryProvider = Provider<SettingsRepository>((ref) {
   return SettingsRepositoryImpl();
+});
+
+final notificationServiceProvider = Provider<NotificationService>((ref) {
+  final service = NotificationService(
+    messaging: ref.watch(firebaseMessagingProvider),
+    localNotifications: ref.watch(flutterLocalNotificationsProvider),
+    settingsRepository: ref.watch(settingsRepositoryProvider),
+    userIdProvider: () async => ref.read(activeUserIdProvider),
+  );
+  unawaited(service.initialise());
+  ref.onDispose(service.dispose);
+  return service;
 });
 
 final getTranslationsUseCaseProvider = Provider((ref) {
@@ -665,12 +706,96 @@ final deleteChatMessageUseCaseProvider = Provider((ref) {
   return DeleteChatMessageUseCase(ref.watch(chatRepositoryProvider));
 });
 
+final chatNotificationObserverProvider = Provider<ChatNotificationObserver>((ref) {
+  final watchMessages = ref.watch(watchChatMessagesUseCaseProvider);
+  final observer = ChatNotificationObserver(
+    (classId) => watchMessages(classId),
+    ref.watch(notificationServiceProvider),
+  );
+  ref.onDispose(observer.dispose);
+  ref.listen(lessonsProvider, (previous, next) {
+    next.whenData((lessons) {
+      final targets = <String, String>{};
+      for (final lesson in lessons) {
+        final classId = _normaliseClassId(lesson.lessonClass);
+        targets[classId] = lesson.lessonClass;
+      }
+      final current = observer.attachedClassIds.toSet();
+      for (final entry in targets.entries) {
+        observer.attach(entry.key, entry.value);
+      }
+      for (final id in current) {
+        if (!targets.containsKey(id)) {
+          unawaited(observer.detach(id));
+        }
+      }
+    });
+  });
+  return observer;
+});
+
+final watchTypingStatusUseCaseProvider = Provider((ref) {
+  return WatchTypingStatusUseCase(ref.watch(chatRepositoryProvider));
+});
+
+final watchModerationActionsUseCaseProvider = Provider((ref) {
+  return WatchModerationActionsUseCase(ref.watch(chatRepositoryProvider));
+});
+
+final muteUserUseCaseProvider = Provider((ref) {
+  return MuteUserUseCase(ref.watch(chatRepositoryProvider));
+});
+
+final banUserUseCaseProvider = Provider((ref) {
+  return BanUserUseCase(ref.watch(chatRepositoryProvider));
+});
+
+final resolveModerationActionUseCaseProvider = Provider((ref) {
+  return ResolveModerationActionUseCase(ref.watch(chatRepositoryProvider));
+});
+
+final submitModerationAppealUseCaseProvider = Provider((ref) {
+  return SubmitModerationAppealUseCase(ref.watch(chatRepositoryProvider));
+});
+
+final updateTypingStatusUseCaseProvider = Provider((ref) {
+  return UpdateTypingStatusUseCase(ref.watch(chatRepositoryProvider));
+});
+
+String normaliseClassId(String value) {
+  var classId = value.toLowerCase();
+  classId = classId
+      .replaceAll(RegExp(r'[^a-z0-9]+'), '-')
+      .replaceAll(RegExp(r'-+'), '-')
+      .trim();
+  if (classId.startsWith('-')) {
+    classId = classId.substring(1);
+  }
+  if (classId.endsWith('-')) {
+    classId = classId.substring(0, classId.length - 1);
+  }
+  if (classId.isEmpty) {
+    classId = 'general';
+  }
+  return classId;
+}
+
+String _normaliseClassId(String value) => normaliseClassId(value);
+
 final getThemeModeUseCaseProvider = Provider((ref) {
   return GetThemeModeUseCase(ref.watch(settingsRepositoryProvider));
 });
 
 final saveThemeModeUseCaseProvider = Provider((ref) {
   return SaveThemeModeUseCase(ref.watch(settingsRepositoryProvider));
+});
+
+final getNotificationPreferencesUseCaseProvider = Provider((ref) {
+  return GetNotificationPreferencesUseCase(ref.watch(settingsRepositoryProvider));
+});
+
+final saveNotificationPreferencesUseCaseProvider = Provider((ref) {
+  return SaveNotificationPreferencesUseCase(ref.watch(settingsRepositoryProvider));
 });
 
 final translationsProvider = FutureProvider((ref) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,10 @@ dependencies:
   firebase_storage: ^11.7.3
   google_sign_in: ^6.2.1
   sign_in_with_apple: ^6.1.0
+  cloud_firestore: ^5.4.4
+  firebase_messaging: ^14.7.10
+  flutter_local_notifications: ^17.2.2
+  timezone: ^0.9.4
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- integrate a Firestore-backed chat remote data source with Drift caching, attachments, typing indicators, and moderation actions
- add chat room UI per lesson class including composer, attachment picker, moderation tools, and appeals entry point
- introduce notification preferences, quiet hours, and parental control storage with a notification service coordinating local alerts
- extend the local database schema to persist chat attachments, typing indicators, and moderation logs while wiring observers into app startup

## Testing
- unable to run `flutter pub get` (Flutter SDK not available in container)
- unable to run automated tests (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfd6fab9bc8320b296e411de54fed5