### PR TITLE
Add teacher tools for lesson drafts, roundtables, and forums

### DIFF
--- a/lib/src/data/accounts/account_repository_impl.dart
+++ b/lib/src/data/accounts/account_repository_impl.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:drift/drift.dart';
 
 import '../../domain/accounts/entities.dart';
@@ -59,6 +61,7 @@ class AccountRepositoryImpl implements AccountRepository {
       preferredCohortId: Value(account.preferredCohortId),
       preferredCohortTitle: Value(account.preferredCohortTitle),
       preferredLessonClass: Value(account.preferredLessonClass),
+      roles: Value(json.encode(account.roles)),
       isActive: Value(account.isActive),
     );
     return _dao.upsertAccount(companion);
@@ -95,7 +98,23 @@ class AccountRepositoryImpl implements AccountRepository {
       preferredCohortId: row.preferredCohortId,
       preferredCohortTitle: row.preferredCohortTitle,
       preferredLessonClass: row.preferredLessonClass,
+      roles: _decodeRoles(row.roles),
       isActive: row.isActive,
     );
+  }
+
+  List<String> _decodeRoles(String? roles) {
+    if (roles == null || roles.isEmpty) {
+      return const [];
+    }
+    try {
+      final decoded = json.decode(roles);
+      if (decoded is List) {
+        return decoded.map((e) => e.toString()).toList();
+      }
+    } catch (_) {
+      // ignore
+    }
+    return const [];
   }
 }

--- a/lib/src/data/lessons/discussion_forum_repository_impl.dart
+++ b/lib/src/data/lessons/discussion_forum_repository_impl.dart
@@ -1,0 +1,172 @@
+import '../../domain/lessons/entities.dart';
+import '../../domain/lessons/repositories.dart';
+import '../../domain/sync/entities.dart';
+import '../../domain/sync/repositories.dart';
+import '../../infrastructure/db/app_database.dart';
+import '../../infrastructure/db/daos/forum_dao.dart';
+
+class DiscussionForumRepositoryImpl implements DiscussionForumRepository {
+  DiscussionForumRepositoryImpl(
+    this._db,
+    this._dao,
+    this._syncRepository,
+  );
+
+  final AppDatabase _db;
+  final ForumDao _dao;
+  final SyncRepository _syncRepository;
+
+  Future<void> _ensureSeeded() => _db.ensureSeeded();
+
+  @override
+  Stream<List<DiscussionThread>> watchThreads(String classId) async* {
+    await _ensureSeeded();
+    yield* _dao.watchThreads(classId).map(_mapThreads);
+  }
+
+  @override
+  Stream<List<DiscussionPost>> watchPosts(String threadId) async* {
+    await _ensureSeeded();
+    yield* _dao.watchPosts(threadId).map(_mapPosts);
+  }
+
+  @override
+  Future<void> upsertThread(DiscussionThread thread) async {
+    await _ensureSeeded();
+    await _dao.upsertThread(
+      DiscussionThreadsCompanion(
+        id: Value(thread.id),
+        classId: Value(thread.classId),
+        title: Value(thread.title),
+        createdBy: Value(thread.createdBy),
+        status: Value(thread.status),
+        createdAt: Value(thread.createdAt.millisecondsSinceEpoch),
+        updatedAt: Value(thread.updatedAt.millisecondsSinceEpoch),
+      ),
+    );
+    await _syncRepository.enqueue(
+      SyncOperation(
+        id: 'forum-thread:${thread.id}',
+        userId: thread.createdBy,
+        opType: 'forum.thread.upsert',
+        payload: {
+          'id': thread.id,
+          'classId': thread.classId,
+          'title': thread.title,
+          'status': thread.status,
+          'createdAt': thread.createdAt.toIso8601String(),
+          'updatedAt': thread.updatedAt.toIso8601String(),
+        },
+        createdAt: thread.updatedAt,
+      ),
+    );
+  }
+
+  @override
+  Future<void> upsertPost(DiscussionPost post) async {
+    await _ensureSeeded();
+    await _dao.upsertPost(
+      DiscussionPostsCompanion(
+        id: Value(post.id),
+        threadId: Value(post.threadId),
+        authorId: Value(post.authorId),
+        role: Value(post.role),
+        body: Value(post.body),
+        status: Value(_statusToString(post.status)),
+        createdAt: Value(post.createdAt.millisecondsSinceEpoch),
+        updatedAt: Value(post.updatedAt.millisecondsSinceEpoch),
+      ),
+    );
+    await _syncRepository.enqueue(
+      SyncOperation(
+        id: 'forum-post:${post.id}',
+        userId: post.authorId,
+        opType: 'forum.post.upsert',
+        payload: {
+          'id': post.id,
+          'threadId': post.threadId,
+          'authorId': post.authorId,
+          'role': post.role,
+          'body': post.body,
+          'status': _statusToString(post.status),
+          'createdAt': post.createdAt.toIso8601String(),
+          'updatedAt': post.updatedAt.toIso8601String(),
+        },
+        createdAt: post.updatedAt,
+      ),
+    );
+  }
+
+  @override
+  Future<void> deletePost(String postId) async {
+    await _ensureSeeded();
+    await _dao.deletePost(postId);
+    await _syncRepository.enqueue(
+      SyncOperation(
+        id: 'forum-post:$postId:delete',
+        userId: 'system',
+        opType: 'forum.post.delete',
+        payload: {
+          'id': postId,
+        },
+        createdAt: DateTime.now(),
+      ),
+    );
+  }
+
+  List<DiscussionThread> _mapThreads(List<DiscussionThreadRow> rows) {
+    return rows
+        .map(
+          (row) => DiscussionThread(
+            id: row.id,
+            classId: row.classId,
+            title: row.title,
+            createdBy: row.createdBy,
+            status: row.status,
+            createdAt: DateTime.fromMillisecondsSinceEpoch(row.createdAt),
+            updatedAt: DateTime.fromMillisecondsSinceEpoch(row.updatedAt),
+          ),
+        )
+        .toList();
+  }
+
+  List<DiscussionPost> _mapPosts(List<DiscussionPostRow> rows) {
+    return rows
+        .map(
+          (row) => DiscussionPost(
+            id: row.id,
+            threadId: row.threadId,
+            authorId: row.authorId,
+            role: row.role,
+            body: row.body,
+            status: _statusFromString(row.status),
+            createdAt: DateTime.fromMillisecondsSinceEpoch(row.createdAt),
+            updatedAt: DateTime.fromMillisecondsSinceEpoch(row.updatedAt),
+          ),
+        )
+        .toList();
+  }
+
+  DiscussionPostStatus _statusFromString(String value) {
+    switch (value) {
+      case 'published':
+        return DiscussionPostStatus.published;
+      case 'rejected':
+        return DiscussionPostStatus.rejected;
+      case 'pending':
+      default:
+        return DiscussionPostStatus.pending;
+    }
+  }
+
+  String _statusToString(DiscussionPostStatus status) {
+    switch (status) {
+      case DiscussionPostStatus.pending:
+        return 'pending';
+      case DiscussionPostStatus.published:
+        return 'published';
+      case DiscussionPostStatus.rejected:
+        return 'rejected';
+    }
+  }
+}

--- a/lib/src/data/lessons/lesson_draft_repository_impl.dart
+++ b/lib/src/data/lessons/lesson_draft_repository_impl.dart
@@ -1,0 +1,132 @@
+import 'package:drift/drift.dart';
+
+import '../../domain/lessons/entities.dart';
+import '../../domain/lessons/repositories.dart';
+import '../../domain/sync/entities.dart';
+import '../../domain/sync/repositories.dart';
+import '../../infrastructure/db/app_database.dart';
+import '../../infrastructure/db/daos/lesson_draft_dao.dart';
+
+class LessonDraftRepositoryImpl implements LessonDraftRepository {
+  LessonDraftRepositoryImpl(
+    this._db,
+    this._dao,
+    this._syncRepository,
+  );
+
+  final AppDatabase _db;
+  final LessonDraftDao _dao;
+  final SyncRepository _syncRepository;
+
+  Future<void> _ensureSeeded() => _db.ensureSeeded();
+
+  @override
+  Stream<List<LessonDraft>> watchDrafts(String authorId) async* {
+    await _ensureSeeded();
+    yield* _dao.watchDrafts(authorId).map(_mapDrafts);
+  }
+
+  @override
+  Stream<List<LessonDraft>> watchPendingApprovals() async* {
+    await _ensureSeeded();
+    yield* _dao.watchPendingApprovals().map(_mapDrafts);
+  }
+
+  @override
+  Future<LessonDraft?> getDraftById(String id) async {
+    await _ensureSeeded();
+    final row = await _dao.getDraftById(id);
+    return row == null ? null : _mapDraft(row);
+  }
+
+  @override
+  Future<void> saveDraft(LessonDraft draft) async {
+    await _ensureSeeded();
+    final companion = LessonDraftsCompanion(
+      id: Value(draft.id),
+      lessonId: Value(draft.lessonId),
+      authorId: Value(draft.authorId),
+      title: Value(draft.title),
+      deltaJson: Value(draft.deltaJson),
+      status: Value(_statusToString(draft.status)),
+      approverId: Value(draft.approverId),
+      reviewerComment: Value(draft.reviewerComment),
+      createdAt: Value(draft.createdAt.millisecondsSinceEpoch),
+      updatedAt: Value(draft.updatedAt.millisecondsSinceEpoch),
+    );
+    await _dao.upsertDraft(companion);
+    if (draft.status == LessonDraftStatus.submitted ||
+        draft.status == LessonDraftStatus.approved ||
+        draft.status == LessonDraftStatus.rejected) {
+      await _syncRepository.enqueue(
+        SyncOperation(
+          id: 'lesson-draft:${draft.id}',
+          userId: draft.authorId,
+          opType: 'lessonDraft.${_statusToString(draft.status)}',
+          payload: {
+            'draftId': draft.id,
+            'lessonId': draft.lessonId,
+            'title': draft.title,
+            'delta': draft.deltaJson,
+            'status': _statusToString(draft.status),
+            'approverId': draft.approverId,
+            'reviewerComment': draft.reviewerComment,
+            'updatedAt': draft.updatedAt.millisecondsSinceEpoch,
+          },
+          createdAt: draft.updatedAt,
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<void> deleteDraft(String id) async {
+    await _ensureSeeded();
+    await _dao.deleteDraft(id);
+  }
+
+  List<LessonDraft> _mapDrafts(List<LessonDraftRow> rows) =>
+      rows.map(_mapDraft).toList();
+
+  LessonDraft _mapDraft(LessonDraftRow row) {
+    return LessonDraft(
+      id: row.id,
+      lessonId: row.lessonId,
+      authorId: row.authorId,
+      title: row.title,
+      deltaJson: row.deltaJson,
+      status: _statusFromString(row.status),
+      approverId: row.approverId,
+      reviewerComment: row.reviewerComment,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(row.createdAt),
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(row.updatedAt),
+    );
+  }
+
+  LessonDraftStatus _statusFromString(String status) {
+    switch (status) {
+      case 'submitted':
+        return LessonDraftStatus.submitted;
+      case 'approved':
+        return LessonDraftStatus.approved;
+      case 'rejected':
+        return LessonDraftStatus.rejected;
+      case 'draft':
+      default:
+        return LessonDraftStatus.draft;
+    }
+  }
+
+  String _statusToString(LessonDraftStatus status) {
+    switch (status) {
+      case LessonDraftStatus.draft:
+        return 'draft';
+      case LessonDraftStatus.submitted:
+        return 'submitted';
+      case LessonDraftStatus.approved:
+        return 'approved';
+      case LessonDraftStatus.rejected:
+        return 'rejected';
+    }
+  }
+}

--- a/lib/src/data/lessons/roundtable_repository_impl.dart
+++ b/lib/src/data/lessons/roundtable_repository_impl.dart
@@ -1,0 +1,100 @@
+import '../../domain/lessons/entities.dart';
+import '../../domain/lessons/repositories.dart';
+import '../../domain/sync/entities.dart';
+import '../../domain/sync/repositories.dart';
+import '../../infrastructure/db/app_database.dart';
+import '../../infrastructure/db/daos/roundtable_dao.dart';
+
+class RoundtableRepositoryImpl implements RoundtableRepository {
+  RoundtableRepositoryImpl(
+    this._db,
+    this._dao,
+    this._syncRepository,
+  );
+
+  final AppDatabase _db;
+  final RoundtableDao _dao;
+  final SyncRepository _syncRepository;
+
+  Future<void> _ensureSeeded() => _db.ensureSeeded();
+
+  @override
+  Stream<List<RoundtableSession>> watchUpcoming(String? classId) async* {
+    await _ensureSeeded();
+    yield* _dao.watchUpcoming(classId).map(_mapSessions);
+  }
+
+  @override
+  Future<void> saveSession(RoundtableSession session) async {
+    await _ensureSeeded();
+    await _dao.upsertEvent(
+      RoundtableEventsCompanion(
+        id: Value(session.id),
+        title: Value(session.title),
+        description: Value(session.description),
+        classId: Value(session.classId),
+        startTime: Value(session.startTime.millisecondsSinceEpoch),
+        endTime: Value(session.endTime.millisecondsSinceEpoch),
+        conferencingUrl: Value(session.conferencingUrl),
+        reminderMinutesBefore: Value(session.reminderMinutesBefore),
+        createdBy: Value(session.createdBy),
+        updatedAt: Value(session.updatedAt.millisecondsSinceEpoch),
+      ),
+    );
+    await _syncRepository.enqueue(
+      SyncOperation(
+        id: 'roundtable:${session.id}',
+        userId: session.createdBy,
+        opType: 'roundtable.upsert',
+        payload: {
+          'id': session.id,
+          'title': session.title,
+          'description': session.description,
+          'classId': session.classId,
+          'startTime': session.startTime.toIso8601String(),
+          'endTime': session.endTime.toIso8601String(),
+          'conferencingUrl': session.conferencingUrl,
+          'reminderMinutesBefore': session.reminderMinutesBefore,
+          'updatedAt': session.updatedAt.millisecondsSinceEpoch,
+        },
+        createdAt: session.updatedAt,
+      ),
+    );
+  }
+
+  @override
+  Future<void> cancelSession(String id) async {
+    await _ensureSeeded();
+    await _dao.deleteEvent(id);
+    await _syncRepository.enqueue(
+      SyncOperation(
+        id: 'roundtable:$id:cancel',
+        userId: 'system',
+        opType: 'roundtable.cancel',
+        payload: {
+          'id': id,
+        },
+        createdAt: DateTime.now(),
+      ),
+    );
+  }
+
+  List<RoundtableSession> _mapSessions(List<RoundtableRow> rows) {
+    return rows
+        .map(
+          (row) => RoundtableSession(
+            id: row.id,
+            title: row.title,
+            description: row.description,
+            classId: row.classId,
+            startTime: DateTime.fromMillisecondsSinceEpoch(row.startTime),
+            endTime: DateTime.fromMillisecondsSinceEpoch(row.endTime),
+            conferencingUrl: row.conferencingUrl,
+            reminderMinutesBefore: row.reminderMinutesBefore,
+            createdBy: row.createdBy,
+            updatedAt: DateTime.fromMillisecondsSinceEpoch(row.updatedAt),
+          ),
+        )
+        .toList();
+  }
+}

--- a/lib/src/domain/accounts/entities.dart
+++ b/lib/src/domain/accounts/entities.dart
@@ -5,6 +5,7 @@ class LocalAccount {
   final String? preferredCohortId;
   final String? preferredCohortTitle;
   final String? preferredLessonClass;
+  final List<String> roles;
   final bool isActive;
 
   const LocalAccount({
@@ -14,6 +15,7 @@ class LocalAccount {
     this.preferredCohortId,
     this.preferredCohortTitle,
     this.preferredLessonClass,
+    this.roles = const [],
     this.isActive = false,
   });
 
@@ -24,6 +26,7 @@ class LocalAccount {
     String? preferredCohortId,
     String? preferredCohortTitle,
     String? preferredLessonClass,
+    List<String>? roles,
     bool? isActive,
   }) {
     return LocalAccount(
@@ -33,6 +36,7 @@ class LocalAccount {
       preferredCohortId: preferredCohortId ?? this.preferredCohortId,
       preferredCohortTitle: preferredCohortTitle ?? this.preferredCohortTitle,
       preferredLessonClass: preferredLessonClass ?? this.preferredLessonClass,
+      roles: roles ?? this.roles,
       isActive: isActive ?? this.isActive,
     );
   }

--- a/lib/src/domain/lessons/entities.dart
+++ b/lib/src/domain/lessons/entities.dart
@@ -157,3 +157,130 @@ class LessonQuery {
   final LessonCompletionFilter completion;
   final String userId;
 }
+
+enum LessonDraftStatus { draft, submitted, approved, rejected }
+
+class LessonDraft {
+  const LessonDraft({
+    required this.id,
+    this.lessonId,
+    required this.authorId,
+    required this.title,
+    required this.deltaJson,
+    required this.status,
+    this.approverId,
+    this.reviewerComment,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String? lessonId;
+  final String authorId;
+  final String title;
+  final String deltaJson;
+  final LessonDraftStatus status;
+  final String? approverId;
+  final String? reviewerComment;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  LessonDraft copyWith({
+    String? id,
+    String? lessonId,
+    String? authorId,
+    String? title,
+    String? deltaJson,
+    LessonDraftStatus? status,
+    String? approverId,
+    bool removeApprover = false,
+    String? reviewerComment,
+    bool removeComment = false,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return LessonDraft(
+      id: id ?? this.id,
+      lessonId: lessonId ?? this.lessonId,
+      authorId: authorId ?? this.authorId,
+      title: title ?? this.title,
+      deltaJson: deltaJson ?? this.deltaJson,
+      status: status ?? this.status,
+      approverId: removeApprover ? null : approverId ?? this.approverId,
+      reviewerComment:
+          removeComment ? null : reviewerComment ?? this.reviewerComment,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+}
+
+class RoundtableSession {
+  const RoundtableSession({
+    required this.id,
+    required this.title,
+    this.description,
+    this.classId,
+    required this.startTime,
+    required this.endTime,
+    this.conferencingUrl,
+    required this.reminderMinutesBefore,
+    required this.createdBy,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String title;
+  final String? description;
+  final String? classId;
+  final DateTime startTime;
+  final DateTime endTime;
+  final String? conferencingUrl;
+  final int reminderMinutesBefore;
+  final String createdBy;
+  final DateTime updatedAt;
+}
+
+enum DiscussionPostStatus { pending, published, rejected }
+
+class DiscussionThread {
+  const DiscussionThread({
+    required this.id,
+    required this.classId,
+    required this.title,
+    required this.createdBy,
+    required this.status,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String classId;
+  final String title;
+  final String createdBy;
+  final String status;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+}
+
+class DiscussionPost {
+  const DiscussionPost({
+    required this.id,
+    required this.threadId,
+    required this.authorId,
+    this.role,
+    required this.body,
+    required this.status,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String threadId;
+  final String authorId;
+  final String? role;
+  final String body;
+  final DiscussionPostStatus status;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+}

--- a/lib/src/domain/lessons/repositories.dart
+++ b/lib/src/domain/lessons/repositories.dart
@@ -7,3 +7,25 @@ abstract class LessonRepository {
   Stream<List<LessonProgress>> watchProgress(String userId);
   Future<void> upsertProgress(LessonProgress progress);
 }
+
+abstract class LessonDraftRepository {
+  Stream<List<LessonDraft>> watchDrafts(String authorId);
+  Stream<List<LessonDraft>> watchPendingApprovals();
+  Future<LessonDraft?> getDraftById(String id);
+  Future<void> saveDraft(LessonDraft draft);
+  Future<void> deleteDraft(String id);
+}
+
+abstract class RoundtableRepository {
+  Stream<List<RoundtableSession>> watchUpcoming(String? classId);
+  Future<void> saveSession(RoundtableSession session);
+  Future<void> cancelSession(String id);
+}
+
+abstract class DiscussionForumRepository {
+  Stream<List<DiscussionThread>> watchThreads(String classId);
+  Stream<List<DiscussionPost>> watchPosts(String threadId);
+  Future<void> upsertThread(DiscussionThread thread);
+  Future<void> upsertPost(DiscussionPost post);
+  Future<void> deletePost(String postId);
+}

--- a/lib/src/domain/lessons/usecases.dart
+++ b/lib/src/domain/lessons/usecases.dart
@@ -44,3 +44,106 @@ class UpdateProgressUseCase {
   Future<void> call(LessonProgress progress) =>
       _repository.upsertProgress(progress);
 }
+
+class WatchLessonDraftsUseCase {
+  const WatchLessonDraftsUseCase(this._repository);
+
+  final LessonDraftRepository _repository;
+
+  Stream<List<LessonDraft>> call(String authorId) =>
+      _repository.watchDrafts(authorId);
+}
+
+class WatchPendingDraftApprovalsUseCase {
+  const WatchPendingDraftApprovalsUseCase(this._repository);
+
+  final LessonDraftRepository _repository;
+
+  Stream<List<LessonDraft>> call() => _repository.watchPendingApprovals();
+}
+
+class SaveLessonDraftUseCase {
+  const SaveLessonDraftUseCase(this._repository);
+
+  final LessonDraftRepository _repository;
+
+  Future<void> call(LessonDraft draft) => _repository.saveDraft(draft);
+}
+
+class DeleteLessonDraftUseCase {
+  const DeleteLessonDraftUseCase(this._repository);
+
+  final LessonDraftRepository _repository;
+
+  Future<void> call(String id) => _repository.deleteDraft(id);
+}
+
+class WatchRoundtablesUseCase {
+  const WatchRoundtablesUseCase(this._repository);
+
+  final RoundtableRepository _repository;
+
+  Stream<List<RoundtableSession>> call(String? classId) =>
+      _repository.watchUpcoming(classId);
+}
+
+class SaveRoundtableUseCase {
+  const SaveRoundtableUseCase(this._repository);
+
+  final RoundtableRepository _repository;
+
+  Future<void> call(RoundtableSession session) =>
+      _repository.saveSession(session);
+}
+
+class CancelRoundtableUseCase {
+  const CancelRoundtableUseCase(this._repository);
+
+  final RoundtableRepository _repository;
+
+  Future<void> call(String id) => _repository.cancelSession(id);
+}
+
+class WatchForumThreadsUseCase {
+  const WatchForumThreadsUseCase(this._repository);
+
+  final DiscussionForumRepository _repository;
+
+  Stream<List<DiscussionThread>> call(String classId) =>
+      _repository.watchThreads(classId);
+}
+
+class WatchForumPostsUseCase {
+  const WatchForumPostsUseCase(this._repository);
+
+  final DiscussionForumRepository _repository;
+
+  Stream<List<DiscussionPost>> call(String threadId) =>
+      _repository.watchPosts(threadId);
+}
+
+class UpsertForumThreadUseCase {
+  const UpsertForumThreadUseCase(this._repository);
+
+  final DiscussionForumRepository _repository;
+
+  Future<void> call(DiscussionThread thread) =>
+      _repository.upsertThread(thread);
+}
+
+class UpsertForumPostUseCase {
+  const UpsertForumPostUseCase(this._repository);
+
+  final DiscussionForumRepository _repository;
+
+  Future<void> call(DiscussionPost post) =>
+      _repository.upsertPost(post);
+}
+
+class DeleteForumPostUseCase {
+  const DeleteForumPostUseCase(this._repository);
+
+  final DiscussionForumRepository _repository;
+
+  Future<void> call(String id) => _repository.deletePost(id);
+}

--- a/lib/src/infrastructure/db/app_database.dart
+++ b/lib/src/infrastructure/db/app_database.dart
@@ -47,6 +47,7 @@ class LocalUsers extends Table {
   TextColumn get preferredCohortId => text().nullable()();
   TextColumn get preferredCohortTitle => text().nullable()();
   TextColumn get preferredLessonClass => text().nullable()();
+  TextColumn get roles => text().withDefault(const Constant('[]'))();
   BoolColumn get isActive => boolean().withDefault(const Constant(false))();
 
   @override
@@ -203,6 +204,24 @@ class LessonQuizOptions extends Table {
   Set<Column> get primaryKey => {quizId, position};
 }
 
+@DataClassName('LessonDraftRow')
+class LessonDrafts extends Table {
+  TextColumn get id => text()();
+  TextColumn get lessonId => text().nullable()();
+  TextColumn get authorId => text()();
+  TextColumn get title => text()();
+  TextColumn get deltaJson => text()();
+  TextColumn get status => text()
+      .withDefault(const Constant('draft'))();
+  TextColumn get approverId => text().nullable()();
+  TextColumn get reviewerComment => text().nullable()();
+  IntColumn get createdAt => integer()();
+  IntColumn get updatedAt => integer()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
 @DataClassName('LessonFeedRow')
 class LessonFeeds extends Table {
   TextColumn get id => text()();
@@ -240,6 +259,56 @@ class LessonSources extends Table {
   IntColumn get lessonCount => integer().withDefault(const Constant(0))();
   IntColumn get attachmentBytes => integer().withDefault(const Constant(0))();
   IntColumn get quotaBytes => integer().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+@DataClassName('RoundtableRow')
+class RoundtableEvents extends Table {
+  TextColumn get id => text()();
+  TextColumn get title => text()();
+  TextColumn get description => text().nullable()();
+  TextColumn get classId => text().nullable()();
+  IntColumn get startTime => integer()();
+  IntColumn get endTime => integer()();
+  TextColumn get conferencingUrl => text().nullable()();
+  IntColumn get reminderMinutesBefore =>
+      integer().withDefault(const Constant(30))();
+  TextColumn get createdBy => text()();
+  IntColumn get updatedAt => integer()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+@DataClassName('DiscussionThreadRow')
+class DiscussionThreads extends Table {
+  TextColumn get id => text()();
+  TextColumn get classId => text()();
+  TextColumn get title => text()();
+  TextColumn get createdBy => text()();
+  TextColumn get status =>
+      text().withDefault(const Constant('open'))();
+  IntColumn get createdAt => integer()();
+  IntColumn get updatedAt => integer()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+@DataClassName('DiscussionPostRow')
+class DiscussionPosts extends Table {
+  TextColumn get id => text()();
+  TextColumn get threadId => text()
+      .references(DiscussionThreads, #id, onDelete: KeyAction.cascade)();
+  TextColumn get authorId => text()();
+  TextColumn get role => text().nullable()();
+  TextColumn get body => text()();
+  TextColumn get status =>
+      text().withDefault(const Constant('pending'))();
+  IntColumn get createdAt => integer()();
+  IntColumn get updatedAt => integer()();
 
   @override
   Set<Column> get primaryKey => {id};
@@ -406,8 +475,12 @@ class MessageChangeTrackers extends Table {
     LessonAttachments,
     LessonQuizzes,
     LessonQuizOptions,
+    LessonDrafts,
     LessonFeeds,
     LessonSources,
+    RoundtableEvents,
+    DiscussionThreads,
+    DiscussionPosts,
     Progress,
     LocalUsers,
     SyncQueue,
@@ -448,7 +521,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 9;
+  int get schemaVersion => 10;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -517,6 +590,13 @@ class AppDatabase extends _$AppDatabase {
             await m.createTable(typingIndicators);
             await m.createTable(moderationActionsTable);
             await m.createTable(moderationAppealsTable);
+          }
+          if (from < 10) {
+            await m.addColumn(localUsers, localUsers.roles);
+            await m.createTable(lessonDrafts);
+            await m.createTable(roundtableEvents);
+            await m.createTable(discussionThreads);
+            await m.createTable(discussionPosts);
           }
         },
       );
@@ -608,6 +688,7 @@ class AppDatabase extends _$AppDatabase {
           id: 'local-user',
           displayName: const Value('You'),
           avatarUrl: const Value(null),
+          roles: const Value('["teacher"]'),
         ),
         mode: InsertMode.insertOrIgnore,
       );

--- a/lib/src/infrastructure/db/app_database.g.dart
+++ b/lib/src/infrastructure/db/app_database.g.dart
@@ -37,6 +37,14 @@ class _$AppDatabase extends GeneratedDatabase {
       'Run build_runner to generate table bindings for `lesson_feeds`.');
   late final TableInfo<Table, dynamic> lessonSources = throw UnimplementedError(
       'Run build_runner to generate table bindings for `lesson_sources`.');
+  late final TableInfo<Table, dynamic> lessonDrafts = throw UnimplementedError(
+      'Run build_runner to generate table bindings for `lesson_drafts`.');
+  late final TableInfo<Table, dynamic> roundtableEvents = throw UnimplementedError(
+      'Run build_runner to generate table bindings for `roundtable_events`.');
+  late final TableInfo<Table, dynamic> discussionThreads = throw UnimplementedError(
+      'Run build_runner to generate table bindings for `discussion_threads`.');
+  late final TableInfo<Table, dynamic> discussionPosts = throw UnimplementedError(
+      'Run build_runner to generate table bindings for `discussion_posts`.');
   late final TableInfo<Table, dynamic> progress = throw UnimplementedError(
       'Run build_runner to generate table bindings for `progress`.');
   late final TableInfo<Table, dynamic> localUsers = throw UnimplementedError(
@@ -69,7 +77,7 @@ class _$AppDatabase extends GeneratedDatabase {
       throw UnimplementedError('Run build_runner to generate table bindings.');
 
   @override
-  int get schemaVersion => 9;
+  int get schemaVersion => 10;
 }
 
 /// A lightweight stand-in for the generated [LocalUser] data class.
@@ -87,6 +95,7 @@ class LocalUser {
     this.preferredCohortId,
     this.preferredCohortTitle,
     this.preferredLessonClass,
+    this.roles = const <String>[],
     this.isActive = false,
   });
 
@@ -96,6 +105,7 @@ class LocalUser {
   final String? preferredCohortId;
   final String? preferredCohortTitle;
   final String? preferredLessonClass;
+  final List<String> roles;
   final bool isActive;
 
   LocalUser copyWith({
@@ -105,6 +115,7 @@ class LocalUser {
     String? preferredCohortId,
     String? preferredCohortTitle,
     String? preferredLessonClass,
+    List<String>? roles,
     bool? isActive,
   }) {
     return LocalUser(
@@ -115,6 +126,7 @@ class LocalUser {
       preferredCohortTitle: preferredCohortTitle ?? this.preferredCohortTitle,
       preferredLessonClass:
           preferredLessonClass ?? this.preferredLessonClass,
+      roles: roles ?? this.roles,
       isActive: isActive ?? this.isActive,
     );
   }
@@ -129,6 +141,7 @@ class LocalUsersCompanion {
     this.preferredCohortId = const Value.absent(),
     this.preferredCohortTitle = const Value.absent(),
     this.preferredLessonClass = const Value.absent(),
+    this.roles = const Value.absent(),
     this.isActive = const Value.absent(),
   });
 
@@ -139,6 +152,7 @@ class LocalUsersCompanion {
     Value<String?> preferredCohortId = const Value.absent(),
     Value<String?> preferredCohortTitle = const Value.absent(),
     Value<String?> preferredLessonClass = const Value.absent(),
+    Value<String> roles = const Value.absent(),
     Value<bool> isActive = const Value.absent(),
   })  : id = Value(id),
         displayName = displayName,
@@ -146,6 +160,7 @@ class LocalUsersCompanion {
         preferredCohortId = preferredCohortId,
         preferredCohortTitle = preferredCohortTitle,
         preferredLessonClass = preferredLessonClass,
+        roles = roles,
         isActive = isActive;
 
   final Value<String> id;
@@ -154,6 +169,7 @@ class LocalUsersCompanion {
   final Value<String?> preferredCohortId;
   final Value<String?> preferredCohortTitle;
   final Value<String?> preferredLessonClass;
+  final Value<String> roles;
   final Value<bool> isActive;
 
   LocalUsersCompanion copyWith({
@@ -163,6 +179,7 @@ class LocalUsersCompanion {
     Value<String?>? preferredCohortId,
     Value<String?>? preferredCohortTitle,
     Value<String?>? preferredLessonClass,
+    Value<String>? roles,
     Value<bool>? isActive,
   }) {
     return LocalUsersCompanion(
@@ -174,6 +191,7 @@ class LocalUsersCompanion {
           preferredCohortTitle ?? this.preferredCohortTitle,
       preferredLessonClass:
           preferredLessonClass ?? this.preferredLessonClass,
+      roles: roles ?? this.roles,
       isActive: isActive ?? this.isActive,
     );
   }

--- a/lib/src/infrastructure/db/daos/forum_dao.dart
+++ b/lib/src/infrastructure/db/daos/forum_dao.dart
@@ -1,0 +1,42 @@
+import 'package:drift/drift.dart';
+
+import '../app_database.dart';
+
+class ForumDao {
+  ForumDao(this._db);
+
+  final AppDatabase _db;
+
+  Stream<List<DiscussionThreadRow>> watchThreads(String classId) {
+    final query = _db.select(_db.discussionThreads)
+      ..where((tbl) => tbl.classId.equals(classId))
+      ..orderBy([(tbl) => OrderingTerm.desc(tbl.updatedAt)]);
+    return query.watch();
+  }
+
+  Future<List<DiscussionThreadRow>> fetchThreads(String classId) {
+    final query = _db.select(_db.discussionThreads)
+      ..where((tbl) => tbl.classId.equals(classId))
+      ..orderBy([(tbl) => OrderingTerm.desc(tbl.updatedAt)]);
+    return query.get();
+  }
+
+  Stream<List<DiscussionPostRow>> watchPosts(String threadId) {
+    final query = _db.select(_db.discussionPosts)
+      ..where((tbl) => tbl.threadId.equals(threadId))
+      ..orderBy([(tbl) => OrderingTerm.asc(tbl.createdAt)]);
+    return query.watch();
+  }
+
+  Future<void> upsertThread(DiscussionThreadsCompanion companion) {
+    return _db.into(_db.discussionThreads).insertOnConflictUpdate(companion);
+  }
+
+  Future<void> upsertPost(DiscussionPostsCompanion companion) {
+    return _db.into(_db.discussionPosts).insertOnConflictUpdate(companion);
+  }
+
+  Future<void> deletePost(String id) {
+    return (_db.delete(_db.discussionPosts)..where((tbl) => tbl.id.equals(id))).go();
+  }
+}

--- a/lib/src/infrastructure/db/daos/lesson_draft_dao.dart
+++ b/lib/src/infrastructure/db/daos/lesson_draft_dao.dart
@@ -1,0 +1,42 @@
+import 'package:drift/drift.dart';
+
+import '../app_database.dart';
+
+class LessonDraftDao {
+  LessonDraftDao(this._db);
+
+  final AppDatabase _db;
+
+  Stream<List<LessonDraftRow>> watchDrafts(String authorId) {
+    final query = _db.select(_db.lessonDrafts)
+      ..where((tbl) => tbl.authorId.equals(authorId))
+      ..orderBy([(tbl) => OrderingTerm.desc(tbl.updatedAt)]);
+    return query.watch();
+  }
+
+  Future<List<LessonDraftRow>> fetchDrafts(String authorId) {
+    final query = _db.select(_db.lessonDrafts)
+      ..where((tbl) => tbl.authorId.equals(authorId))
+      ..orderBy([(tbl) => OrderingTerm.desc(tbl.updatedAt)]);
+    return query.get();
+  }
+
+  Stream<List<LessonDraftRow>> watchPendingApprovals() {
+    final query = _db.select(_db.lessonDrafts)
+      ..where((tbl) => tbl.status.equals('submitted'))
+      ..orderBy([(tbl) => OrderingTerm.asc(tbl.updatedAt)]);
+    return query.watch();
+  }
+
+  Future<LessonDraftRow?> getDraftById(String id) {
+    return (_db.select(_db.lessonDrafts)..where((tbl) => tbl.id.equals(id))).getSingleOrNull();
+  }
+
+  Future<void> upsertDraft(LessonDraftsCompanion companion) {
+    return _db.into(_db.lessonDrafts).insertOnConflictUpdate(companion);
+  }
+
+  Future<void> deleteDraft(String id) {
+    return (_db.delete(_db.lessonDrafts)..where((tbl) => tbl.id.equals(id))).go();
+  }
+}

--- a/lib/src/infrastructure/db/daos/roundtable_dao.dart
+++ b/lib/src/infrastructure/db/daos/roundtable_dao.dart
@@ -1,0 +1,37 @@
+import 'package:drift/drift.dart';
+
+import '../app_database.dart';
+
+class RoundtableDao {
+  RoundtableDao(this._db);
+
+  final AppDatabase _db;
+
+  Stream<List<RoundtableRow>> watchUpcoming(String? classId) {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final query = _db.select(_db.roundtableEvents)
+      ..where((tbl) => tbl.endTime.isBiggerOrEqualValue(now));
+    if (classId != null) {
+      query.where((tbl) => tbl.classId.equals(classId) | tbl.classId.isNull());
+    }
+    query.orderBy([(tbl) => OrderingTerm.asc(tbl.startTime)]);
+    return query.watch();
+  }
+
+  Future<List<RoundtableRow>> fetchAll(String? classId) {
+    final query = _db.select(_db.roundtableEvents);
+    if (classId != null) {
+      query.where((tbl) => tbl.classId.equals(classId) | tbl.classId.isNull());
+    }
+    query.orderBy([(tbl) => OrderingTerm.asc(tbl.startTime)]);
+    return query.get();
+  }
+
+  Future<void> upsertEvent(RoundtableEventsCompanion companion) {
+    return _db.into(_db.roundtableEvents).insertOnConflictUpdate(companion);
+  }
+
+  Future<void> deleteEvent(String id) {
+    return (_db.delete(_db.roundtableEvents)..where((tbl) => tbl.id.equals(id))).go();
+  }
+}

--- a/lib/src/infrastructure/notifications/notification_service.dart
+++ b/lib/src/infrastructure/notifications/notification_service.dart
@@ -4,6 +4,8 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
 
 import '../../domain/chat/entities.dart';
 import '../../domain/settings/entities.dart';
@@ -33,6 +35,7 @@ class NotificationService {
   );
 
   bool _initialised = false;
+  bool _timeZoneInitialised = false;
 
   Future<void> initialise() async {
     if (_initialised) {
@@ -63,6 +66,19 @@ class NotificationService {
     final androidPlugin =
         _localNotifications.resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>();
     await androidPlugin?.createNotificationChannel(_chatChannel);
+  }
+
+  Future<void> _ensureTimezoneInitialised() async {
+    if (_timeZoneInitialised) {
+      return;
+    }
+    tz.initializeTimeZones();
+    try {
+      tz.setLocalLocation(tz.getLocation(DateTime.now().timeZoneName));
+    } catch (_) {
+      tz.setLocalLocation(tz.getLocation('UTC'));
+    }
+    _timeZoneInitialised = true;
   }
 
   Future<void> handleIncomingMessage(
@@ -114,6 +130,49 @@ class NotificationService {
       await _localNotifications.cancelAll();
     }
   }
+
+  Future<void> scheduleRoundtableReminder(
+    String sessionId,
+    String title,
+    DateTime startTime,
+    int minutesBefore,
+  ) async {
+    if (!_initialised) {
+      await initialise();
+    }
+    await _ensureTimezoneInitialised();
+    final reminderTime = startTime.subtract(Duration(minutes: minutesBefore));
+    if (reminderTime.isBefore(DateTime.now())) {
+      return;
+    }
+    final notificationDetails = NotificationDetails(
+      android: AndroidNotificationDetails(
+        'roundtable_reminders',
+        'Roundtable reminders',
+        channelDescription: 'Reminders for upcoming roundtable sessions.',
+        importance: Importance.high,
+        priority: Priority.high,
+      ),
+      iOS: const DarwinNotificationDetails(),
+    );
+    await _localNotifications.zonedSchedule(
+      _scheduleId(sessionId),
+      'Upcoming roundtable',
+      '$title starts at ${startTime.toLocal()}.',
+      tz.TZDateTime.from(reminderTime, tz.local),
+      notificationDetails,
+      androidAllowWhileIdle: true,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: DateTimeComponents.dateAndTime,
+    );
+  }
+
+  Future<void> cancelRoundtableReminder(String sessionId) async {
+    await _localNotifications.cancel(_scheduleId(sessionId));
+  }
+
+  int _scheduleId(String id) => id.hashCode & 0x7fffffff;
 }
 
 class ChatNotificationObserver {

--- a/lib/src/presentation/home/home_screen.dart
+++ b/lib/src/presentation/home/home_screen.dart
@@ -6,6 +6,7 @@ import '../bible/bible_screen.dart';
 import '../bible/chapter_screen.dart';
 import '../../domain/bible/entities.dart';
 import '../lessons/lessons_screen.dart';
+import '../teacher/teacher_tools_screen.dart';
 import '../settings/settings_screen.dart';
 import '../providers.dart';
 
@@ -24,6 +25,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final pages = [
       const _HomeDashboard(),
       const LessonsScreen(),
+      const TeacherToolsScreen(),
     ];
 
     return Scaffold(
@@ -48,6 +50,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
           BottomNavigationBarItem(icon: Icon(Icons.school), label: 'Lessons'),
+          BottomNavigationBarItem(icon: Icon(Icons.manage_accounts), label: 'Teacher'),
         ],
       ),
     );

--- a/lib/src/presentation/providers.dart
+++ b/lib/src/presentation/providers.dart
@@ -19,7 +19,10 @@ import '../data/bible/bible_repository_impl.dart';
 import '../data/bible/reading_progress_repository_impl.dart';
 import '../data/chat/chat_remote_data_source.dart';
 import '../data/chat/chat_repository_impl.dart';
+import '../data/lessons/discussion_forum_repository_impl.dart';
+import '../data/lessons/lesson_draft_repository_impl.dart';
 import '../data/lessons/lesson_repository_impl.dart';
+import '../data/lessons/roundtable_repository_impl.dart';
 import '../data/settings/settings_repository_impl.dart';
 import '../data/sync/sync_repository_impl.dart';
 import '../data/bible/verse_of_the_day_service.dart';
@@ -53,8 +56,11 @@ import '../infrastructure/db/daos/account_dao.dart';
 import '../infrastructure/db/daos/annotation_dao.dart';
 import '../infrastructure/db/daos/bible_dao.dart';
 import '../infrastructure/db/daos/chat_dao.dart';
+import '../infrastructure/db/daos/forum_dao.dart';
 import '../infrastructure/db/daos/lesson_dao.dart';
+import '../infrastructure/db/daos/lesson_draft_dao.dart';
 import '../infrastructure/db/daos/sync_dao.dart';
+import '../infrastructure/db/daos/roundtable_dao.dart';
 import '../infrastructure/lessons/lesson_attachment_cache.dart';
 import '../infrastructure/lessons/lesson_cache_invalidator.dart';
 import '../infrastructure/lessons/lesson_ingestion_pipeline.dart';
@@ -127,9 +133,14 @@ final firebaseAuthUserProvider = StreamProvider<User?>((ref) {
 
 final bibleDaoProvider = Provider((ref) => BibleDao(ref.watch(appDatabaseProvider)));
 final lessonDaoProvider = Provider((ref) => LessonDao(ref.watch(appDatabaseProvider)));
+final lessonDraftDaoProvider =
+    Provider((ref) => LessonDraftDao(ref.watch(appDatabaseProvider)));
 final accountDaoProvider = Provider((ref) => AccountDao(ref.watch(appDatabaseProvider)));
 final syncDaoProvider = Provider((ref) => SyncDao(ref.watch(appDatabaseProvider)));
 final chatDaoProvider = Provider((ref) => ChatDao(ref.watch(appDatabaseProvider)));
+final roundtableDaoProvider =
+    Provider((ref) => RoundtableDao(ref.watch(appDatabaseProvider)));
+final forumDaoProvider = Provider((ref) => ForumDao(ref.watch(appDatabaseProvider)));
 final chatRemoteDataSourceProvider =
     Provider<ChatRemoteDataSource>((ref) {
   return ChatRemoteDataSource(
@@ -199,6 +210,28 @@ final lessonRepositoryProvider = Provider<LessonRepository>((ref) {
   final syncDao = ref.watch(syncDaoProvider);
   final syncRepository = ref.watch(syncRepositoryProvider);
   return LessonRepositoryImpl(db, dao, pipeline, syncDao, syncRepository);
+});
+
+final lessonDraftRepositoryProvider = Provider<LessonDraftRepository>((ref) {
+  final db = ref.watch(appDatabaseProvider);
+  final dao = ref.watch(lessonDraftDaoProvider);
+  final syncRepository = ref.watch(syncRepositoryProvider);
+  return LessonDraftRepositoryImpl(db, dao, syncRepository);
+});
+
+final roundtableRepositoryProvider = Provider<RoundtableRepository>((ref) {
+  final db = ref.watch(appDatabaseProvider);
+  final dao = ref.watch(roundtableDaoProvider);
+  final syncRepository = ref.watch(syncRepositoryProvider);
+  return RoundtableRepositoryImpl(db, dao, syncRepository);
+});
+
+final discussionForumRepositoryProvider =
+    Provider<DiscussionForumRepository>((ref) {
+  final db = ref.watch(appDatabaseProvider);
+  final dao = ref.watch(forumDaoProvider);
+  final syncRepository = ref.watch(syncRepositoryProvider);
+  return DiscussionForumRepositoryImpl(db, dao, syncRepository);
 });
 
 final lessonCacheInvalidatorProvider = Provider<LessonCacheInvalidator>((ref) {
@@ -491,6 +524,56 @@ final updateProgressUseCaseProvider = Provider((ref) {
   return UpdateProgressUseCase(ref.watch(lessonRepositoryProvider));
 });
 
+final watchLessonDraftsUseCaseProvider = Provider((ref) {
+  return WatchLessonDraftsUseCase(ref.watch(lessonDraftRepositoryProvider));
+});
+
+final watchPendingDraftApprovalsUseCaseProvider = Provider((ref) {
+  return WatchPendingDraftApprovalsUseCase(
+    ref.watch(lessonDraftRepositoryProvider),
+  );
+});
+
+final saveLessonDraftUseCaseProvider = Provider((ref) {
+  return SaveLessonDraftUseCase(ref.watch(lessonDraftRepositoryProvider));
+});
+
+final deleteLessonDraftUseCaseProvider = Provider((ref) {
+  return DeleteLessonDraftUseCase(ref.watch(lessonDraftRepositoryProvider));
+});
+
+final watchRoundtablesUseCaseProvider = Provider((ref) {
+  return WatchRoundtablesUseCase(ref.watch(roundtableRepositoryProvider));
+});
+
+final saveRoundtableUseCaseProvider = Provider((ref) {
+  return SaveRoundtableUseCase(ref.watch(roundtableRepositoryProvider));
+});
+
+final cancelRoundtableUseCaseProvider = Provider((ref) {
+  return CancelRoundtableUseCase(ref.watch(roundtableRepositoryProvider));
+});
+
+final watchForumThreadsUseCaseProvider = Provider((ref) {
+  return WatchForumThreadsUseCase(ref.watch(discussionForumRepositoryProvider));
+});
+
+final watchForumPostsUseCaseProvider = Provider((ref) {
+  return WatchForumPostsUseCase(ref.watch(discussionForumRepositoryProvider));
+});
+
+final upsertForumThreadUseCaseProvider = Provider((ref) {
+  return UpsertForumThreadUseCase(ref.watch(discussionForumRepositoryProvider));
+});
+
+final upsertForumPostUseCaseProvider = Provider((ref) {
+  return UpsertForumPostUseCase(ref.watch(discussionForumRepositoryProvider));
+});
+
+final deleteForumPostUseCaseProvider = Provider((ref) {
+  return DeleteForumPostUseCase(ref.watch(discussionForumRepositoryProvider));
+});
+
 final lessonTimerServiceProvider =
     Provider.autoDispose.family<LessonTimerService, String>((ref, lessonId) {
   final service = LessonTimerService();
@@ -687,6 +770,14 @@ final activeUserIdProvider = Provider<String?>((ref) {
   return account.maybeWhen(
     data: (value) => value?.id,
     orElse: () => null,
+  );
+});
+
+final userRolesProvider = Provider<Set<String>>((ref) {
+  final account = ref.watch(activeAccountProvider);
+  return account.maybeWhen(
+    data: (value) => value == null ? <String>{} : value.roles.toSet(),
+    orElse: () => <String>{},
   );
 });
 

--- a/lib/src/presentation/teacher/teacher_tools_screen.dart
+++ b/lib/src/presentation/teacher/teacher_tools_screen.dart
@@ -1,0 +1,889 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_quill/flutter_quill.dart' hide Text;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../domain/lessons/entities.dart';
+import '../providers.dart';
+
+final _lessonDraftsProvider =
+    StreamProvider.autoDispose<List<LessonDraft>>((ref) {
+  final userId = ref.watch(activeUserIdProvider);
+  if (userId == null) {
+    return Stream<List<LessonDraft>>.empty();
+  }
+  return ref.watch(watchLessonDraftsUseCaseProvider)(userId);
+});
+
+final _pendingDraftsProvider =
+    StreamProvider.autoDispose<List<LessonDraft>>((ref) {
+  return ref.watch(watchPendingDraftApprovalsUseCaseProvider)();
+});
+
+final _roundtableSessionsProvider =
+    StreamProvider.autoDispose<List<RoundtableSession>>((ref) {
+  final account = ref.watch(activeAccountProvider);
+  final classId = account.maybeWhen(
+    data: (value) => value?.preferredCohortId,
+    orElse: () => null,
+  );
+  return ref.watch(watchRoundtablesUseCaseProvider)(classId);
+});
+
+final _forumThreadsProvider = StreamProvider.autoDispose<List<DiscussionThread>>((ref) {
+  final account = ref.watch(activeAccountProvider);
+  final classId = account.maybeWhen(
+    data: (value) => value?.preferredCohortId,
+    orElse: () => null,
+  );
+  if (classId == null) {
+    return Stream<List<DiscussionThread>>.empty();
+  }
+  return ref.watch(watchForumThreadsUseCaseProvider)(classId);
+});
+
+final _forumPostsProvider = StreamProvider.autoDispose
+    .family<List<DiscussionPost>, String>((ref, threadId) {
+  return ref.watch(watchForumPostsUseCaseProvider)(threadId);
+});
+
+class TeacherToolsScreen extends ConsumerWidget {
+  const TeacherToolsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final roles = ref.watch(userRolesProvider);
+    if (!roles.contains('teacher')) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24.0),
+          child: Text(
+            'You need teacher permissions to access these tools. '
+            'Please contact an administrator.',
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+    return DefaultTabController(
+      length: 3,
+      child: Scaffold(
+        appBar: AppBar(
+          automaticallyImplyLeading: false,
+          title: const Text('Teacher Tools'),
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Lesson Editor'),
+              Tab(text: 'Roundtables'),
+              Tab(text: 'Forums'),
+            ],
+          ),
+        ),
+        body: const TabBarView(
+          children: [
+            _LessonEditorTab(),
+            _RoundtableSchedulerTab(),
+            _DiscussionForumTab(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _LessonEditorTab extends ConsumerStatefulWidget {
+  const _LessonEditorTab();
+
+  @override
+  ConsumerState<_LessonEditorTab> createState() => _LessonEditorTabState();
+}
+
+class _LessonEditorTabState extends ConsumerState<_LessonEditorTab> {
+  final _titleController = TextEditingController();
+  late QuillController _controller;
+  LessonDraft? _selectedDraft;
+  bool _dirty = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = QuillController.basic();
+    _controller.addListener(_markDirty);
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _controller.removeListener(_markDirty);
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _loadDraft(LessonDraft? draft) {
+    _controller.removeListener(_markDirty);
+    _controller.dispose();
+    _selectedDraft = draft;
+    _titleController.text = draft?.title ?? '';
+    final delta =
+        draft == null ? Document() : Document.fromJson(jsonDecode(draft.deltaJson) as List);
+    _controller = QuillController(
+      document: delta,
+      selection: const TextSelection.collapsed(offset: 0),
+    );
+    _controller.addListener(_markDirty);
+    setState(() {
+      _dirty = false;
+    });
+  }
+
+  void _markDirty() {
+    if (mounted) {
+      setState(() {
+        _dirty = true;
+      });
+    }
+  }
+
+  Future<void> _saveDraft(BuildContext context, LessonDraftStatus status) async {
+    final userId = ref.read(activeUserIdProvider);
+    if (userId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Sign in to manage drafts.')),
+      );
+      return;
+    }
+    final title = _titleController.text.trim();
+    if (title.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Title cannot be empty.')),
+      );
+      return;
+    }
+    final deltaJson = jsonEncode(_controller.document.toDelta().toJson());
+    final now = DateTime.now();
+    final draftId = _selectedDraft?.id ?? const Uuid().v4();
+    final draft = LessonDraft(
+      id: draftId,
+      lessonId: _selectedDraft?.lessonId,
+      authorId: userId,
+      title: title,
+      deltaJson: deltaJson,
+      status: status,
+      approverId: status == LessonDraftStatus.draft
+          ? _selectedDraft?.approverId
+          : null,
+      reviewerComment: status == LessonDraftStatus.draft
+          ? _selectedDraft?.reviewerComment
+          : null,
+      createdAt: _selectedDraft?.createdAt ?? now,
+      updatedAt: now,
+    );
+    await ref.read(saveLessonDraftUseCaseProvider)(draft);
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(status == LessonDraftStatus.submitted
+              ? 'Draft submitted for approval.'
+              : 'Draft saved locally.'),
+        ),
+      );
+      setState(() {
+        _selectedDraft = draft;
+        _dirty = false;
+      });
+    }
+  }
+
+  Future<void> _approveDraft(
+    BuildContext context,
+    LessonDraft draft,
+    LessonDraftStatus status,
+  ) async {
+    final userId = ref.read(activeUserIdProvider);
+    if (userId == null) {
+      return;
+    }
+    String? comment;
+    if (status == LessonDraftStatus.rejected) {
+      comment = await showDialog<String?>(
+        context: context,
+        builder: (context) {
+          final controller = TextEditingController();
+          return AlertDialog(
+            title: const Text('Provide feedback'),
+            content: TextField(
+              controller: controller,
+              maxLines: 3,
+              decoration: const InputDecoration(
+                hintText: 'Let the author know what to change.',
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context, null),
+                child: const Text('Cancel'),
+              ),
+              ElevatedButton(
+                onPressed: () => Navigator.pop(context, controller.text.trim()),
+                child: const Text('Submit'),
+              ),
+            ],
+          );
+        },
+      );
+      if (comment == null) {
+        return;
+      }
+    }
+    final updated = draft.copyWith(
+      status: status,
+      approverId: userId,
+      reviewerComment: status == LessonDraftStatus.rejected ? comment : null,
+      updatedAt: DateTime.now(),
+    );
+    await ref.read(saveLessonDraftUseCaseProvider)(updated);
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(status == LessonDraftStatus.approved
+              ? 'Draft approved and synced.'
+              : 'Draft rejected and feedback sent.'),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final draftsAsync = ref.watch(_lessonDraftsProvider);
+    final pendingAsync = ref.watch(_pendingDraftsProvider);
+    return Row(
+      children: [
+        Expanded(
+          flex: 2,
+          child: draftsAsync.when(
+            data: (drafts) => ListView(
+              children: [
+                ListTile(
+                  title: const Text('New draft'),
+                  leading: const Icon(Icons.create),
+                  onTap: () => _loadDraft(null),
+                ),
+                for (final draft in drafts)
+                  ListTile(
+                    selected: _selectedDraft?.id == draft.id,
+                    title: Text(draft.title),
+                    subtitle: Text(
+                      '${draft.status.name} • '
+                      '${draft.updatedAt.toLocal()}',
+                    ),
+                    onTap: () => _loadDraft(draft),
+                  ),
+                const Divider(),
+                const Padding(
+                  padding: EdgeInsets.all(12.0),
+                  child: Text(
+                    'Pending approvals',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                ),
+                pendingAsync.when(
+                  data: (pending) => Column(
+                    children: pending.isEmpty
+                        ? [
+                            const ListTile(
+                              title: Text('No drafts awaiting review.'),
+                            ),
+                          ]
+                        : pending
+                            .map(
+                              (draft) => ListTile(
+                                title: Text(draft.title),
+                                subtitle: Text('Author: ${draft.authorId}'),
+                                trailing: Wrap(
+                                  spacing: 8,
+                                  children: [
+                                    IconButton(
+                                      icon: const Icon(Icons.check_circle,
+                                          color: Colors.green),
+                                      tooltip: 'Approve draft',
+                                      onPressed: () =>
+                                          _approveDraft(context, draft,
+                                              LessonDraftStatus.approved),
+                                    ),
+                                    IconButton(
+                                      icon: const Icon(Icons.cancel,
+                                          color: Colors.redAccent),
+                                      tooltip: 'Reject draft',
+                                      onPressed: () => _approveDraft(
+                                        context,
+                                        draft,
+                                        LessonDraftStatus.rejected,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            )
+                            .toList(),
+                  ),
+                  error: (error, stackTrace) => ListTile(
+                    title: Text('Failed to load approvals: $error'),
+                  ),
+                  loading: () => const ListTile(
+                    title: Text('Loading approvals…'),
+                  ),
+                ),
+              ],
+            ),
+            error: (error, stackTrace) => Center(
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Text('Failed to load drafts: $error'),
+              ),
+            ),
+            loading: () => const Center(child: CircularProgressIndicator()),
+          ),
+        ),
+        VerticalDivider(color: Theme.of(context).dividerColor),
+        Expanded(
+          flex: 3,
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                TextField(
+                  controller: _titleController,
+                  decoration: const InputDecoration(
+                    labelText: 'Lesson title',
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Expanded(
+                  child: Column(
+                    children: [
+                      QuillToolbar.simple(controller: _controller),
+                      const SizedBox(height: 12),
+                      Expanded(
+                        child: Container(
+                          decoration: BoxDecoration(
+                            border: Border.all(
+                              color: Theme.of(context).dividerColor,
+                            ),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: QuillEditor.basic(
+                            controller: _controller,
+                            configurations: const QuillEditorConfigurations(
+                              expands: true,
+                              padding: EdgeInsets.all(12),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    ElevatedButton.icon(
+                      onPressed: _dirty
+                          ? () =>
+                              _saveDraft(context, LessonDraftStatus.draft)
+                          : null,
+                      icon: const Icon(Icons.save_outlined),
+                      label: const Text('Save Draft'),
+                    ),
+                    const SizedBox(width: 12),
+                    FilledButton.icon(
+                      onPressed: () =>
+                          _saveDraft(context, LessonDraftStatus.submitted),
+                      icon: const Icon(Icons.send),
+                      label: const Text('Submit for approval'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _RoundtableSchedulerTab extends ConsumerStatefulWidget {
+  const _RoundtableSchedulerTab();
+
+  @override
+  ConsumerState<_RoundtableSchedulerTab> createState() =>
+      _RoundtableSchedulerTabState();
+}
+
+class _RoundtableSchedulerTabState
+    extends ConsumerState<_RoundtableSchedulerTab> {
+  final _titleController = TextEditingController();
+  final _descriptionController = TextEditingController();
+  final _urlController = TextEditingController();
+  int _reminderMinutes = 30;
+  late DateTime _startTime;
+  late DateTime _endTime;
+
+  @override
+  void initState() {
+    super.initState();
+    final now = DateTime.now();
+    _startTime = now.add(const Duration(hours: 1));
+    _endTime = _startTime.add(const Duration(hours: 1));
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _descriptionController.dispose();
+    _urlController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickDateTime(BuildContext context, bool isStart) async {
+    final initial = isStart ? _startTime : _endTime;
+    final pickedDate = await showDatePicker(
+      context: context,
+      initialDate: initial,
+      firstDate: DateTime.now().subtract(const Duration(days: 1)),
+      lastDate: DateTime.now().add(const Duration(days: 365)),
+    );
+    if (pickedDate == null) {
+      return;
+    }
+    final pickedTime = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(initial),
+    );
+    if (pickedTime == null) {
+      return;
+    }
+    final combined = DateTime(
+      pickedDate.year,
+      pickedDate.month,
+      pickedDate.day,
+      pickedTime.hour,
+      pickedTime.minute,
+    );
+    setState(() {
+      if (isStart) {
+        _startTime = combined;
+        if (_endTime.isBefore(_startTime)) {
+          _endTime = _startTime.add(const Duration(hours: 1));
+        }
+      } else {
+        _endTime = combined;
+      }
+    });
+  }
+
+  Future<void> _createRoundtable(BuildContext context) async {
+    final userId = ref.read(activeUserIdProvider);
+    final account = ref.read(activeAccountProvider).asData?.value;
+    if (userId == null || account == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Select an active account to schedule.')),
+      );
+      return;
+    }
+    final title = _titleController.text.trim();
+    if (title.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Title is required.')),
+      );
+      return;
+    }
+    final session = RoundtableSession(
+      id: const Uuid().v4(),
+      title: title,
+      description: _descriptionController.text.trim().isEmpty
+          ? null
+          : _descriptionController.text.trim(),
+      classId: account.preferredCohortId,
+      startTime: _startTime,
+      endTime: _endTime,
+      conferencingUrl: _urlController.text.trim().isEmpty
+          ? null
+          : _urlController.text.trim(),
+      reminderMinutesBefore: _reminderMinutes,
+      createdBy: userId,
+      updatedAt: DateTime.now(),
+    );
+    await ref.read(saveRoundtableUseCaseProvider)(session);
+    await ref
+        .read(notificationServiceProvider)
+        .scheduleRoundtableReminder(
+          session.id,
+          session.title,
+          session.startTime,
+          session.reminderMinutesBefore,
+        );
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Roundtable scheduled and synced.')),
+      );
+      _titleController.clear();
+      _descriptionController.clear();
+      _urlController.clear();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final sessionsAsync = ref.watch(_roundtableSessionsProvider);
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TextField(
+            controller: _titleController,
+            decoration: const InputDecoration(labelText: 'Session title'),
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: _descriptionController,
+            maxLines: 2,
+            decoration:
+                const InputDecoration(labelText: 'Description (optional)'),
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: _urlController,
+            decoration: const InputDecoration(
+              labelText: 'Conferencing URL (optional)',
+            ),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 16,
+            runSpacing: 12,
+            children: [
+              OutlinedButton.icon(
+                icon: const Icon(Icons.schedule),
+                label: Text('Start: ${_startTime.toLocal()}'),
+                onPressed: () => _pickDateTime(context, true),
+              ),
+              OutlinedButton.icon(
+                icon: const Icon(Icons.event),
+                label: Text('End: ${_endTime.toLocal()}'),
+                onPressed: () => _pickDateTime(context, false),
+              ),
+              DropdownButton<int>(
+                value: _reminderMinutes,
+                items: const [
+                  DropdownMenuItem(value: 15, child: Text('15 min reminder')),
+                  DropdownMenuItem(value: 30, child: Text('30 min reminder')),
+                  DropdownMenuItem(value: 60, child: Text('1 hour reminder')),
+                ],
+                onChanged: (value) {
+                  if (value != null) {
+                    setState(() => _reminderMinutes = value);
+                  }
+                },
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: FilledButton.icon(
+              onPressed: () => _createRoundtable(context),
+              icon: const Icon(Icons.add_circle),
+              label: const Text('Schedule Roundtable'),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: sessionsAsync.when(
+              data: (sessions) => ListView.builder(
+                itemCount: sessions.length,
+                itemBuilder: (context, index) {
+                  final session = sessions[index];
+                  return Card(
+                    child: ListTile(
+                      title: Text(session.title),
+                      subtitle: Text(
+                        '${session.startTime.toLocal()} — '
+                        '${session.endTime.toLocal()}\n'
+                        'Reminder: ${session.reminderMinutesBefore} minutes before',
+                      ),
+                      isThreeLine: true,
+                      trailing: IconButton(
+                        icon: const Icon(Icons.cancel),
+                        onPressed: () async {
+                          await ref
+                              .read(cancelRoundtableUseCaseProvider)(session.id);
+                          await ref
+                              .read(notificationServiceProvider)
+                              .cancelRoundtableReminder(session.id);
+                        },
+                      ),
+                    ),
+                  );
+                },
+              ),
+              error: (error, stackTrace) => Center(
+                child: Text('Failed to load sessions: $error'),
+              ),
+              loading: () => const Center(child: CircularProgressIndicator()),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DiscussionForumTab extends ConsumerStatefulWidget {
+  const _DiscussionForumTab();
+
+  @override
+  ConsumerState<_DiscussionForumTab> createState() =>
+      _DiscussionForumTabState();
+}
+
+class _DiscussionForumTabState extends ConsumerState<_DiscussionForumTab> {
+  String? _selectedThreadId;
+  final _threadTitleController = TextEditingController();
+  final _postBodyController = TextEditingController();
+
+  @override
+  void dispose() {
+    _threadTitleController.dispose();
+    _postBodyController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _createThread(BuildContext context) async {
+    final classId = ref.read(activeAccountProvider).asData?.value?.preferredCohortId;
+    final userId = ref.read(activeUserIdProvider);
+    if (classId == null || userId == null) {
+      return;
+    }
+    final title = _threadTitleController.text.trim();
+    if (title.isEmpty) {
+      return;
+    }
+    final thread = DiscussionThread(
+      id: const Uuid().v4(),
+      classId: classId,
+      title: title,
+      createdBy: userId,
+      status: 'open',
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
+    await ref.read(upsertForumThreadUseCaseProvider)(thread);
+    setState(() => _selectedThreadId = thread.id);
+    _threadTitleController.clear();
+  }
+
+  Future<void> _submitPost(BuildContext context) async {
+    final threadId = _selectedThreadId;
+    if (threadId == null) {
+      return;
+    }
+    final userId = ref.read(activeUserIdProvider);
+    if (userId == null) {
+      return;
+    }
+    final roles = ref.read(userRolesProvider);
+    final canPublish = roles.contains('teacher') || roles.contains('moderator');
+    final body = _postBodyController.text.trim();
+    if (body.isEmpty) {
+      return;
+    }
+    final post = DiscussionPost(
+      id: const Uuid().v4(),
+      threadId: threadId,
+      authorId: userId,
+      role: roles.isEmpty ? 'member' : roles.first,
+      body: body,
+      status:
+          canPublish ? DiscussionPostStatus.published : DiscussionPostStatus.pending,
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
+    await ref.read(upsertForumPostUseCaseProvider)(post);
+    _postBodyController.clear();
+    if (mounted && !canPublish) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Post submitted for moderator approval.'),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final roles = ref.watch(userRolesProvider);
+    final threadsAsync = ref.watch(_forumThreadsProvider);
+    final postsAsync = _selectedThreadId == null
+        ? const AsyncValue<List<DiscussionPost>>.data(<DiscussionPost>[])
+        : ref.watch(_forumPostsProvider(_selectedThreadId!));
+    final canModerate = roles.contains('teacher') || roles.contains('moderator');
+    final canPost = roles.contains('teacher') || roles.contains('moderator') || roles.contains('student');
+
+    return Row(
+      children: [
+        Expanded(
+          flex: 2,
+          child: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(12.0),
+                child: TextField(
+                  controller: _threadTitleController,
+                  decoration: InputDecoration(
+                    labelText: 'New thread title',
+                    suffixIcon: IconButton(
+                      icon: const Icon(Icons.add_comment),
+                      onPressed: roles.contains('teacher')
+                          ? () => _createThread(context)
+                          : null,
+                    ),
+                  ),
+                ),
+              ),
+              Expanded(
+                child: threadsAsync.when(
+                  data: (threads) => ListView.builder(
+                    itemCount: threads.length,
+                    itemBuilder: (context, index) {
+                      final thread = threads[index];
+                      return ListTile(
+                        selected: _selectedThreadId == thread.id,
+                        title: Text(thread.title),
+                        subtitle: Text('Opened by ${thread.createdBy}'),
+                        onTap: () => setState(() {
+                          _selectedThreadId = thread.id;
+                        }),
+                      );
+                    },
+                  ),
+                  error: (error, stackTrace) => Center(
+                    child: Text('Failed to load threads: $error'),
+                  ),
+                  loading: () => const Center(
+                    child: CircularProgressIndicator(),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        VerticalDivider(color: Theme.of(context).dividerColor),
+        Expanded(
+          flex: 3,
+          child: Column(
+            children: [
+              if (!canPost)
+                const Padding(
+                  padding: EdgeInsets.all(16.0),
+                  child: Text(
+                    'Your current role does not allow posting. '
+                    'You can still review discussions.',
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              Expanded(
+                child: postsAsync.when(
+                  data: (posts) => ListView.builder(
+                    itemCount: posts.length,
+                    itemBuilder: (context, index) {
+                      final post = posts[index];
+                      return Card(
+                        margin: const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 6,
+                        ),
+                        child: ListTile(
+                          title: Text(post.body),
+                          subtitle: Text(
+                            '${post.authorId} • ${post.status.name}',
+                          ),
+                          trailing: canModerate &&
+                                  post.status == DiscussionPostStatus.pending
+                              ? PopupMenuButton<DiscussionPostStatus>(
+                                  onSelected: (status) {
+                                    final updated = DiscussionPost(
+                                      id: post.id,
+                                      threadId: post.threadId,
+                                      authorId: post.authorId,
+                                      role: post.role,
+                                      body: post.body,
+                                      status: status,
+                                      createdAt: post.createdAt,
+                                      updatedAt: DateTime.now(),
+                                    );
+                                    ref
+                                        .read(upsertForumPostUseCaseProvider)(
+                                            updated);
+                                  },
+                                  itemBuilder: (context) => const [
+                                    PopupMenuItem(
+                                      value: DiscussionPostStatus.published,
+                                      child: Text('Approve'),
+                                    ),
+                                    PopupMenuItem(
+                                      value: DiscussionPostStatus.rejected,
+                                      child: Text('Reject'),
+                                    ),
+                                  ],
+                                )
+                              : null,
+                        ),
+                      );
+                    },
+                  ),
+                  error: (error, stackTrace) => Center(
+                    child: Text('Failed to load posts: $error'),
+                  ),
+                  loading: () => const Center(
+                    child: CircularProgressIndicator(),
+                  ),
+                ),
+              ),
+              if (canPost)
+                Padding(
+                  padding: const EdgeInsets.all(12.0),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: TextField(
+                          controller: _postBodyController,
+                          maxLines: 3,
+                          decoration: const InputDecoration(
+                            labelText: 'Share a reply',
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      ElevatedButton(
+                        onPressed: _selectedThreadId == null
+                            ? null
+                            : () => _submitPost(context),
+                        child: const Text('Post'),
+                      ),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,8 @@ dependencies:
   firebase_storage: ^11.7.3
   google_sign_in: ^6.2.1
   sign_in_with_apple: ^6.1.0
+  flutter_quill: ^9.3.0
+  timezone: ^0.9.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add Drift tables, DAOs, and repositories for lesson drafts, roundtables, and class discussion forums with sync integration
- introduce a Flutter Quill-powered teacher tools screen for drafting lessons, scheduling roundtables with reminders, and moderating class forums with role-aware controls
- extend account roles, notification scheduling, and navigation/providers to honour teacher permissions and offline queues

## Testing
- Not run (flutter is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfe29dc2848320a952b8f0ba6c0170