### PR TITLE
feat: add age cohort theme profiles and accessibility updates

### DIFF
--- a/lib/src/data/settings/settings_repository_impl.dart
+++ b/lib/src/data/settings/settings_repository_impl.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 
 import '../../domain/settings/entities.dart';
 import '../../domain/settings/repositories.dart';
@@ -8,15 +9,17 @@ class SettingsRepositoryImpl implements SettingsRepository {
 
   final SecureStorageService _storage;
   static const _themeKey = 'app_theme_mode';
+  static const _themeProfileKey = 'theme_profile';
   static const _notificationKey = 'notification_preferences';
 
-  String _keyFor(String userId) => '${_themeKey}_$userId';
+  String _themeModeKeyFor(String userId) => '${_themeKey}_$userId';
+  String _themeProfileKeyFor(String userId) => '${_themeProfileKey}_$userId';
   String _notificationPrefsKeyFor(String userId) =>
       '${_notificationKey}_$userId';
 
   @override
   Future<AppThemeMode> getThemeMode(String userId) async {
-    final value = await _storage.read(_keyFor(userId));
+    final value = await _storage.read(_themeModeKeyFor(userId));
     switch (value) {
       case 'light':
         return AppThemeMode.light;
@@ -29,7 +32,7 @@ class SettingsRepositoryImpl implements SettingsRepository {
 
   @override
   Future<void> saveThemeMode(String userId, AppThemeMode mode) async {
-    final key = _keyFor(userId);
+    final key = _themeModeKeyFor(userId);
     switch (mode) {
       case AppThemeMode.system:
         await _storage.delete(key);
@@ -44,5 +47,48 @@ class SettingsRepositoryImpl implements SettingsRepository {
   }
 
   @override
+  Future<String?> getThemeProfileId(String userId) async {
+    final value = await _storage.read(_themeProfileKeyFor(userId));
+    if (value == null || value.isEmpty) {
+      return null;
+    }
+    return value;
+  }
+
+  @override
+  Future<void> saveThemeProfileId(String userId, String profileId) async {
+    final key = _themeProfileKeyFor(userId);
+    if (profileId.isEmpty) {
+      await _storage.delete(key);
+      return;
+    }
+    await _storage.write(key, profileId);
+  }
+
+  @override
+  Future<NotificationPreferences> getNotificationPreferences(
+      String userId) async {
+    final key = _notificationPrefsKeyFor(userId);
+    final raw = await _storage.read(key);
+    if (raw == null || raw.isEmpty) {
+      return const NotificationPreferences();
+    }
+    try {
+      final decoded = jsonDecode(raw) as Map<String, dynamic>;
+      return NotificationPreferences.fromJson(decoded);
+    } catch (_) {
+      await _storage.delete(key);
+      return const NotificationPreferences();
+    }
+  }
+
+  @override
+  Future<void> saveNotificationPreferences(
+    String userId,
+    NotificationPreferences preferences,
+  ) async {
+    final key = _notificationPrefsKeyFor(userId);
+    final payload = jsonEncode(preferences.toJson());
+    await _storage.write(key, payload);
   }
 }

--- a/lib/src/domain/settings/repositories.dart
+++ b/lib/src/domain/settings/repositories.dart
@@ -3,5 +3,9 @@ import 'entities.dart';
 abstract class SettingsRepository {
   Future<AppThemeMode> getThemeMode(String userId);
   Future<void> saveThemeMode(String userId, AppThemeMode mode);
-
+  Future<String?> getThemeProfileId(String userId);
+  Future<void> saveThemeProfileId(String userId, String profileId);
+  Future<NotificationPreferences> getNotificationPreferences(String userId);
+  Future<void> saveNotificationPreferences(
+      String userId, NotificationPreferences preferences);
 }

--- a/lib/src/domain/settings/usecases.dart
+++ b/lib/src/domain/settings/usecases.dart
@@ -19,6 +19,24 @@ class SaveThemeModeUseCase {
       _repository.saveThemeMode(userId, mode);
 }
 
+class GetThemeProfileUseCase {
+  final SettingsRepository _repository;
+
+  const GetThemeProfileUseCase(this._repository);
+
+  Future<String?> call(String userId) =>
+      _repository.getThemeProfileId(userId);
+}
+
+class SaveThemeProfileUseCase {
+  final SettingsRepository _repository;
+
+  const SaveThemeProfileUseCase(this._repository);
+
+  Future<void> call(String userId, String profileId) =>
+      _repository.saveThemeProfileId(userId, profileId);
+}
+
 class GetNotificationPreferencesUseCase {
   final SettingsRepository _repository;
 

--- a/lib/src/presentation/app/app.dart
+++ b/lib/src/presentation/app/app.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:google_fonts/google_fonts.dart';
 
+import '../../domain/accounts/entities.dart';
 import '../providers.dart';
 import '../home/home_screen.dart';
 import '../accounts/profile_onboarding_screen.dart';
+import '../theme/age_cohort_theme_profiles.dart';
 
 class StudyMateApp extends ConsumerWidget {
   const StudyMateApp({super.key});
@@ -12,133 +13,75 @@ class StudyMateApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final themeMode = ref.watch(themeModeControllerProvider);
+    final themeProfileAsync = ref.watch(themeProfileControllerProvider);
     ref.watch(meetingReminderCoordinatorProvider);
-
-    const Color primarySeedColor = Color(0xFF3F51B5);
-
-    final TextTheme appTextTheme = TextTheme(
-      displayLarge: GoogleFonts.playfairDisplay(
-        fontSize: 57,
-        fontWeight: FontWeight.bold,
-      ),
-      titleLarge: GoogleFonts.playfairDisplay(
-        fontSize: 22,
-        fontWeight: FontWeight.w500,
-      ),
-      bodyMedium: GoogleFonts.ptSans(fontSize: 14),
-    );
-
-    final ThemeData lightTheme = ThemeData(
-      useMaterial3: true,
-      colorScheme: ColorScheme.fromSeed(
-        seedColor: primarySeedColor,
-        brightness: Brightness.light,
-        surface: const Color(0xFFE8EAF6),
-      ),
-      textTheme: appTextTheme,
-      appBarTheme: AppBarTheme(
-        backgroundColor: primarySeedColor,
-        foregroundColor: Colors.white,
-        titleTextStyle: GoogleFonts.playfairDisplay(
-          fontSize: 24,
-          fontWeight: FontWeight.bold,
-        ),
-      ),
-      elevatedButtonTheme: ElevatedButtonThemeData(
-        style: ElevatedButton.styleFrom(
-          foregroundColor: Colors.white,
-          backgroundColor: const Color(0xFFFFAB40),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8),
-          ),
-          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-          textStyle: GoogleFonts.ptSans(
-            fontSize: 16,
-            fontWeight: FontWeight.w500,
-          ),
-        ),
-      ),
-    );
-
-    final ThemeData darkTheme = ThemeData(
-      useMaterial3: true,
-      colorScheme: ColorScheme.fromSeed(
-        seedColor: primarySeedColor,
-        brightness: Brightness.dark,
-      ),
-      textTheme: appTextTheme,
-      appBarTheme: AppBarTheme(
-        backgroundColor: Colors.grey[900],
-        foregroundColor: Colors.white,
-        titleTextStyle: GoogleFonts.playfairDisplay(
-          fontSize: 24,
-          fontWeight: FontWeight.bold,
-        ),
-      ),
-      elevatedButtonTheme: ElevatedButtonThemeData(
-        style: ElevatedButton.styleFrom(
-          foregroundColor: Colors.black,
-          backgroundColor: const Color(0xFFFFAB40),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8),
-          ),
-          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-          textStyle: GoogleFonts.ptSans(
-            fontSize: 16,
-            fontWeight: FontWeight.w500,
-          ),
-        ),
-      ),
-    );
 
     final accountAsync = ref.watch(activeAccountProvider);
 
     return themeMode.when(
-      data: (mode) => accountAsync.when(
-        data: (account) => MaterialApp(
-          title: 'AFC StudyMate',
-          theme: lightTheme,
-          darkTheme: darkTheme,
-          themeMode: mode,
-          home: account == null
-              ? const ProfileOnboardingScreen()
-              : const HomeScreen(),
-        ),
-        loading: () => MaterialApp(
-          title: 'AFC StudyMate',
-          theme: lightTheme,
-          darkTheme: darkTheme,
-          home: const Scaffold(
-            body: Center(child: CircularProgressIndicator()),
+      data: (mode) => themeProfileAsync.when(
+        data: (profile) => accountAsync.when(
+          data: (account) => _buildApp(
+            themeMode: mode,
+            profile: profile,
+            account: account,
           ),
+          loading: () => _buildLoadingApp(mode, profile),
+          error: (error, stack) => _buildErrorApp(mode, profile, error),
         ),
-        error: (error, stack) => MaterialApp(
-          title: 'AFC StudyMate',
-          theme: lightTheme,
-          darkTheme: darkTheme,
-          home: Scaffold(
-            body: Center(
-              child: Text('Failed to load profiles: $error'),
-            ),
-          ),
-        ),
+        loading: () => _buildLoadingApp(mode, defaultThemeProfile()),
+        error: (error, stack) => _buildErrorApp(mode, defaultThemeProfile(), error),
       ),
-      loading: () => MaterialApp(
-        title: 'AFC StudyMate',
-        theme: lightTheme,
-        darkTheme: darkTheme,
-        home: const Scaffold(
-          body: Center(child: CircularProgressIndicator()),
-        ),
+      loading: () => _buildLoadingApp(ThemeMode.system, defaultThemeProfile()),
+      error: (error, stack) =>
+          _buildErrorApp(ThemeMode.system, defaultThemeProfile(), error),
+    );
+  }
+
+  Widget _buildApp({
+    required ThemeMode themeMode,
+    required AgeCohortThemeProfile profile,
+    required LocalAccount? account,
+  }) {
+    return MaterialApp(
+      title: 'AFC StudyMate',
+      theme: profile.toThemeData(Brightness.light),
+      darkTheme: profile.toThemeData(Brightness.dark),
+      themeMode: themeMode,
+      home: account == null
+          ? const ProfileOnboardingScreen()
+          : const HomeScreen(),
+    );
+  }
+
+  Widget _buildLoadingApp(
+    ThemeMode themeMode,
+    AgeCohortThemeProfile profile,
+  ) {
+    return MaterialApp(
+      title: 'AFC StudyMate',
+      theme: profile.toThemeData(Brightness.light),
+      darkTheme: profile.toThemeData(Brightness.dark),
+      themeMode: themeMode,
+      home: const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
       ),
-      error: (error, stack) => MaterialApp(
-        title: 'AFC StudyMate',
-        theme: lightTheme,
-        darkTheme: darkTheme,
-        home: Scaffold(
-          body: Center(
-            child: Text('Failed to load theme: $error'),
-          ),
+    );
+  }
+
+  Widget _buildErrorApp(
+    ThemeMode themeMode,
+    AgeCohortThemeProfile profile,
+    Object error,
+  ) {
+    return MaterialApp(
+      title: 'AFC StudyMate',
+      theme: profile.toThemeData(Brightness.light),
+      darkTheme: profile.toThemeData(Brightness.dark),
+      themeMode: themeMode,
+      home: Scaffold(
+        body: Center(
+          child: Text('Failed to load theme: $error'),
         ),
       ),
     );

--- a/lib/src/presentation/home/home_screen.dart
+++ b/lib/src/presentation/home/home_screen.dart
@@ -34,6 +34,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         actions: [
           IconButton(
             icon: const Icon(Icons.settings_outlined),
+            tooltip: 'Open settings',
             onPressed: () {
               Navigator.push(
                 context,
@@ -75,84 +76,93 @@ class _HomeDashboard extends ConsumerWidget {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Image.asset('assets/images/logo.png', height: 120),
+              Image.asset(
+                'assets/images/logo.png',
+                height: 120,
+                semanticLabel: 'AFC StudyMate logo',
+              ),
               const SizedBox(height: 30),
-              Card(
-                elevation: 4.0,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12.0),
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: verseAsync.when(
-                    loading: () => const Center(
-                      child: CircularProgressIndicator(),
-                    ),
-                    error: (error, stack) => Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        const Text('Failed to load verse of the day'),
-                        const SizedBox(height: 8),
-                        Text(error.toString()),
-                      ],
-                    ),
-                    data: (verse) => Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        Text(
-                          'Verse of the Day',
-                          style: Theme.of(context)
-                              .textTheme
-                              .headlineSmall
-                              ?.copyWith(fontWeight: FontWeight.bold),
-                          textAlign: TextAlign.center,
-                        ),
-                        const SizedBox(height: 12),
-                        Text(
-                          verse.text,
-                          style: Theme.of(context)
-                              .textTheme
-                              .bodyLarge
-                              ?.copyWith(fontSize: 16, height: 1.6),
-                          textAlign: TextAlign.center,
-                        ),
-                        const SizedBox(height: 12),
-                        Text(
-                          verse.reference,
-                          style: Theme.of(context)
-                              .textTheme
-                              .titleMedium
-                              ?.copyWith(
-                                fontStyle: FontStyle.italic,
-                                color: Theme.of(context).colorScheme.primary,
-                              ),
-                          textAlign: TextAlign.center,
-                        ),
-                        const SizedBox(height: 8),
-                        IconButton(
-                          icon: const Icon(Icons.share_outlined),
-                          onPressed: () {
-                            Share.share(
-                              '"${verse.text}" - ${verse.reference}',
-                              subject: 'Verse of the Day',
-                            );
-                          },
-                          tooltip: 'Share Verse',
-                        ),
-                      ],
+              Semantics(
+                container: true,
+                label: 'Verse of the day card',
+                child: Card(
+                  elevation: 4.0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12.0),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: verseAsync.when(
+                      loading: () => const Center(
+                        child: CircularProgressIndicator(),
+                      ),
+                      error: (error, stack) => Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Text('Failed to load verse of the day'),
+                          const SizedBox(height: 8),
+                          Text(error.toString()),
+                        ],
+                      ),
+                      data: (verse) => Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Text(
+                            'Verse of the Day',
+                            style: Theme.of(context)
+                                .textTheme
+                                .headlineSmall
+                                ?.copyWith(fontWeight: FontWeight.bold),
+                            textAlign: TextAlign.center,
+                          ),
+                          const SizedBox(height: 12),
+                          Text(
+                            verse.text,
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyLarge
+                                ?.copyWith(fontSize: 16, height: 1.6),
+                            textAlign: TextAlign.center,
+                          ),
+                          const SizedBox(height: 12),
+                          Text(
+                            verse.reference,
+                            style: Theme.of(context)
+                                .textTheme
+                                .titleMedium
+                                ?.copyWith(
+                                  fontStyle: FontStyle.italic,
+                                  color: Theme.of(context).colorScheme.primary,
+                                ),
+                            textAlign: TextAlign.center,
+                          ),
+                          const SizedBox(height: 8),
+                          IconButton(
+                            icon: const Icon(Icons.share_outlined),
+                            onPressed: () {
+                              Share.share(
+                                '"${verse.text}" - ${verse.reference}',
+                                subject: 'Verse of the Day',
+                              );
+                            },
+                            tooltip: 'Share Verse',
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ),
               ),
               const SizedBox(height: 30),
-              Wrap(
-                spacing: 16,
-                runSpacing: 16,
-                alignment: WrapAlignment.center,
-                children: [
-                  ElevatedButton.icon(
-                    icon: const Icon(Icons.menu_book_outlined),
-                    label: const Text('Read Bible'),
+              FocusTraversalGroup(
+                child: Wrap(
+                  spacing: 16,
+                  runSpacing: 16,
+                  alignment: WrapAlignment.center,
+                  children: [
+                    ElevatedButton.icon(
+                      icon: const Icon(Icons.menu_book_outlined),
+                      label: const Text('Read Bible'),
                     onPressed: () {
                       Navigator.push(
                         context,
@@ -211,7 +221,8 @@ class _HomeDashboard extends ConsumerWidget {
                       );
                     },
                   ),
-                ],
+                  ],
+                ),
               ),
             ],
           ),

--- a/lib/src/presentation/lessons/lessons_screen.dart
+++ b/lib/src/presentation/lessons/lessons_screen.dart
@@ -66,21 +66,26 @@ class LessonsScreen extends ConsumerWidget {
                       if (lesson.quizzes.isNotEmpty)
                         '${lesson.quizzes.length} quiz${lesson.quizzes.length == 1 ? '' : 'zes'}',
                     ].join(' · ');
-                    return Card(
-                      margin:
-                          const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                      child: ListTile(
-                        title: Text(lesson.title),
-                        subtitle: Text(secondary),
-                        trailing: const Icon(Icons.chevron_right),
-                        onTap: () {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (_) => LessonDetailScreen(lesson: lesson),
-                            ),
-                          );
-                        },
+                    return Semantics(
+                      container: true,
+                      label: 'Lesson ${lesson.title}',
+                      hint: 'Opens lesson details',
+                      child: Card(
+                        margin: const EdgeInsets.symmetric(
+                            horizontal: 16, vertical: 8),
+                        child: ListTile(
+                          title: Text(lesson.title),
+                          subtitle: Text(secondary),
+                          trailing: const Icon(Icons.chevron_right),
+                          onTap: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (_) => LessonDetailScreen(lesson: lesson),
+                              ),
+                            );
+                          },
+                        ),
                       ),
                     );
                   },
@@ -129,50 +134,61 @@ class _LessonFilterBar extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-      child: Wrap(
-        spacing: 16,
-        runSpacing: 8,
-        crossAxisAlignment: WrapCrossAlignment.center,
-        children: [
-          DropdownButton<String?>(
-            value: state.selectedClass,
-            hint: const Text('Class'),
-            onChanged: onClassChanged,
-            items: _classOptions
-                .map(
-                  (option) => DropdownMenuItem<String?>(
-                    value: option,
-                    child: Text(option ?? 'All classes'),
-                  ),
-                )
-                .toList(),
-          ),
-          DropdownButton<int?>(
-            value: state.age,
-            hint: const Text('Age'),
-            onChanged: onAgeChanged,
-            items: _ageOptions
-                .map(
-                  (option) => DropdownMenuItem<int?>(
-                    value: option,
-                    child: Text(option == null ? 'Any age' : '$option yrs'),
-                  ),
-                )
-                .toList(),
-          ),
-          DropdownButton<LessonCompletionFilter>(
-            value: state.completion,
-            onChanged: onCompletionChanged,
-            items: LessonCompletionFilter.values
-                .map(
-                  (value) => DropdownMenuItem<LessonCompletionFilter>(
-                    value: value,
-                    child: Text(_completionLabel(value)),
-                  ),
-                )
-                .toList(),
-          ),
-        ],
+      child: FocusTraversalGroup(
+        child: Wrap(
+          spacing: 16,
+          runSpacing: 8,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            Semantics(
+              label: 'Filter by class',
+              child: DropdownButton<String?>(
+                value: state.selectedClass,
+                hint: const Text('Class'),
+                onChanged: onClassChanged,
+                items: _classOptions
+                    .map(
+                      (option) => DropdownMenuItem<String?>(
+                        value: option,
+                        child: Text(option ?? 'All classes'),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
+            Semantics(
+              label: 'Filter by age',
+              child: DropdownButton<int?>(
+                value: state.age,
+                hint: const Text('Age'),
+                onChanged: onAgeChanged,
+                items: _ageOptions
+                    .map(
+                      (option) => DropdownMenuItem<int?>(
+                        value: option,
+                        child: Text(option == null ? 'Any age' : '$option yrs'),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
+            Semantics(
+              label: 'Filter by completion status',
+              child: DropdownButton<LessonCompletionFilter>(
+                value: state.completion,
+                onChanged: onCompletionChanged,
+                items: LessonCompletionFilter.values
+                    .map(
+                      (value) => DropdownMenuItem<LessonCompletionFilter>(
+                        value: value,
+                        child: Text(_completionLabel(value)),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/presentation/providers.dart
+++ b/lib/src/presentation/providers.dart
@@ -26,6 +26,7 @@ import '../data/lessons/roundtable_repository_impl.dart';
 import '../data/settings/settings_repository_impl.dart';
 import '../data/sync/sync_repository_impl.dart';
 import '../data/bible/verse_of_the_day_service.dart';
+import '../domain/accounts/entities.dart';
 import '../domain/accounts/repositories.dart';
 import '../domain/accounts/usecases.dart';
 import '../domain/annotations/entities.dart';
@@ -81,6 +82,7 @@ import 'settings/data_sync_controller.dart';
 import 'settings/lesson_sync_controller.dart';
 import 'settings/privacy_controller.dart';
 import 'accounts/cloud_auth_controller.dart';
+import 'theme/age_cohort_theme_profiles.dart';
 
 final appDatabaseProvider = Provider<AppDatabase>((ref) {
   final db = AppDatabase();
@@ -977,6 +979,14 @@ final saveThemeModeUseCaseProvider = Provider((ref) {
   return SaveThemeModeUseCase(ref.watch(settingsRepositoryProvider));
 });
 
+final getThemeProfileUseCaseProvider = Provider((ref) {
+  return GetThemeProfileUseCase(ref.watch(settingsRepositoryProvider));
+});
+
+final saveThemeProfileUseCaseProvider = Provider((ref) {
+  return SaveThemeProfileUseCase(ref.watch(settingsRepositoryProvider));
+});
+
 final getNotificationPreferencesUseCaseProvider = Provider((ref) {
   return GetNotificationPreferencesUseCase(ref.watch(settingsRepositoryProvider));
 });
@@ -1310,6 +1320,98 @@ final readingProgressProvider = StreamProvider<ReadingPosition?>((ref) {
   final useCase = ref.watch(watchReadingProgressUseCaseProvider);
   return useCase(userId);
 });
+
+final themeProfilesProvider =
+    Provider<List<AgeCohortThemeProfile>>((ref) => kAgeCohortThemeProfiles);
+
+final selectedThemeProfileProvider = Provider<AgeCohortThemeProfile?>((ref) {
+  final profileAsync = ref.watch(themeProfileControllerProvider);
+  return profileAsync.maybeWhen(data: (value) => value, orElse: () => null);
+});
+
+final themeProfileControllerProvider =
+    AsyncNotifierProvider<ThemeProfileController, AgeCohortThemeProfile>(
+        ThemeProfileController.new);
+
+class ThemeProfileController extends AsyncNotifier<AgeCohortThemeProfile> {
+  @override
+  Future<AgeCohortThemeProfile> build() async {
+    final profiles = ref.watch(themeProfilesProvider);
+    final fallbackProfile = defaultThemeProfile();
+    final account = ref.watch(activeAccountProvider).maybeWhen(
+          data: (value) => value,
+          orElse: () => null,
+        );
+    final inferredId = _inferProfileId(account, profiles);
+    final userId = ref.watch(activeUserIdProvider);
+    if (userId == null) {
+      return _resolveProfile(profiles, inferredId) ?? fallbackProfile;
+    }
+    final savedId = await ref.read(getThemeProfileUseCaseProvider)(userId);
+    final resolved = _resolveProfile(
+      profiles,
+      savedId ?? inferredId,
+    );
+    return resolved ?? fallbackProfile;
+  }
+
+  Future<void> setProfile(String id) async {
+    final profiles = ref.read(themeProfilesProvider);
+    final selected = _resolveProfile(profiles, id) ?? defaultThemeProfile();
+    final userId = ref.read(activeUserIdProvider);
+    if (userId != null) {
+      await ref.read(saveThemeProfileUseCaseProvider)(userId, selected.id);
+    }
+    state = AsyncValue.data(selected);
+  }
+
+  AgeCohortThemeProfile? _resolveProfile(
+    List<AgeCohortThemeProfile> profiles,
+    String? id,
+  ) {
+    if (id == null || id.isEmpty) {
+      return null;
+    }
+    final normalised = id.toLowerCase();
+    for (final profile in profiles) {
+      if (profile.id.toLowerCase() == normalised) {
+        return profile;
+      }
+    }
+    return null;
+  }
+
+  String? _inferProfileId(
+    LocalAccount? account,
+    List<AgeCohortThemeProfile> profiles,
+  ) {
+    if (account == null) {
+      return null;
+    }
+    final candidates = <String?>[
+      account.preferredLessonClass,
+      account.preferredCohortTitle,
+      account.preferredCohortId,
+    ];
+    for (final candidate in candidates) {
+      if (candidate == null || candidate.isEmpty) {
+        continue;
+      }
+      final normalised = candidate.toLowerCase();
+      for (final profile in profiles) {
+        if (profile.id.toLowerCase() == normalised) {
+          return profile.id;
+        }
+        for (final keyword in profile.cohortKeywords) {
+          if (normalised.contains(keyword.toLowerCase())) {
+            return profile.id;
+          }
+        }
+      }
+    }
+    return null;
+  }
+}
 
 class ThemeModeController extends AsyncNotifier<ThemeMode> {
   @override

--- a/lib/src/presentation/settings/settings_screen.dart
+++ b/lib/src/presentation/settings/settings_screen.dart
@@ -16,6 +16,7 @@ import 'data_sync_controller.dart';
 import 'lesson_sync_controller.dart';
 import 'privacy_policy_screen.dart';
 import '../accounts/profile_management_screen.dart';
+import '../theme/age_cohort_theme_profiles.dart';
 
 class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
@@ -23,6 +24,8 @@ class SettingsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final themeModeAsync = ref.watch(themeModeControllerProvider);
+    final themeProfileAsync = ref.watch(themeProfileControllerProvider);
+    final themeProfiles = ref.watch(themeProfilesProvider);
     final translationsAsync = ref.watch(translationsProvider);
     final syncState = ref.watch(lessonSyncControllerProvider);
     final dataSyncState = ref.watch(dataSyncControllerProvider);
@@ -86,8 +89,9 @@ class SettingsScreen extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
-      body: ListView(
-        children: [
+      body: FocusTraversalGroup(
+        child: ListView(
+          children: [
           activeAccountAsync.when(
             data: (account) => ListTile(
               leading: _ProfileAvatar(avatar: account?.avatarUrl, name: account?.displayName),
@@ -95,14 +99,17 @@ class SettingsScreen extends ConsumerWidget {
                   ? account!.displayName!
                   : 'No profile selected'),
               subtitle: const Text('Current profile'),
-              trailing: TextButton(
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => const ProfileManagementScreen()),
-                  );
-                },
-                child: const Text('Manage'),
+              trailing: Tooltip(
+                message: 'Manage profiles',
+                child: TextButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (_) => const ProfileManagementScreen()),
+                    );
+                  },
+                  child: const Text('Manage'),
+                ),
               ),
             ),
             loading: () => const ListTile(
@@ -112,21 +119,42 @@ class SettingsScreen extends ConsumerWidget {
             error: (error, stack) => ListTile(
               leading: const Icon(Icons.error_outline),
               title: Text('Failed to load profile: $error'),
-              trailing: TextButton(
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => const ProfileManagementScreen()),
-                  );
-                },
-                child: const Text('Manage'),
+              trailing: Tooltip(
+                message: 'Manage profiles',
+                child: TextButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (_) => const ProfileManagementScreen()),
+                    );
+                  },
+                  child: const Text('Manage'),
+                ),
               ),
+            ),
+          ),
+          const Divider(),
+          themeProfileAsync.when(
+            data: (selected) => _ThemeProfileSection(
+              profiles: themeProfiles,
+              selectedId: selected.id,
+              brightness: Theme.of(context).brightness,
+              onSelected: (value) =>
+                  ref.read(themeProfileControllerProvider.notifier).setProfile(value),
+            ),
+            loading: const _ThemeProfileLoadingPlaceholder(),
+            error: (error, stack) => Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Text('Unable to load theme profiles: $error'),
             ),
           ),
           const Divider(),
           const Padding(
             padding: EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-            child: Text('Cloud sync'),
+            child: Semantics(
+              header: true,
+              child: Text('Cloud sync'),
+            ),
           ),
           cloudUserAsync.when(
             data: (user) {
@@ -461,7 +489,8 @@ class SettingsScreen extends ConsumerWidget {
           ),
         ],
       ),
-    );
+    ),
+  );
   }
 
   Future<void> _exportUserData(
@@ -588,6 +617,164 @@ class SettingsScreen extends ConsumerWidget {
         : state.errorMessage ?? 'Unable to sign out. Please try again.';
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text(message)),
+    );
+  }
+}
+
+class _ThemeProfileLoadingPlaceholder extends StatelessWidget {
+  const _ThemeProfileLoadingPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    return const ListTile(
+      leading: CircularProgressIndicator.adaptive(),
+      title: Text('Loading theme profiles...'),
+    );
+  }
+}
+
+class _ThemeProfileSection extends StatelessWidget {
+  const _ThemeProfileSection({
+    required this.profiles,
+    required this.selectedId,
+    required this.brightness,
+    required this.onSelected,
+  });
+
+  final List<AgeCohortThemeProfile> profiles;
+  final String selectedId;
+  final Brightness brightness;
+  final ValueChanged<String> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+          child: Semantics(
+            header: true,
+            child: Text(
+              'Theme & accessibility profiles',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ),
+        ),
+        for (var index = 0; index < profiles.length; index++)
+          _ThemeProfileOption(
+            profile: profiles[index],
+            selectedId: selectedId,
+            brightness: brightness,
+            order: index.toDouble(),
+            onSelected: onSelected,
+          ),
+      ],
+    );
+  }
+}
+
+class _ThemeProfileOption extends StatelessWidget {
+  const _ThemeProfileOption({
+    required this.profile,
+    required this.selectedId,
+    required this.brightness,
+    required this.order,
+    required this.onSelected,
+  });
+
+  final AgeCohortThemeProfile profile;
+  final String selectedId;
+  final Brightness brightness;
+  final double order;
+  final ValueChanged<String> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final selected = selectedId == profile.id;
+    return FocusTraversalOrder(
+      order: NumericFocusOrder(order),
+      child: Semantics(
+        container: true,
+        selected: selected,
+        label: '${profile.label} theme profile',
+        hint: profile.description,
+        child: RadioListTile<String>(
+          value: profile.id,
+          groupValue: selectedId,
+          onChanged: (_) => onSelected(profile.id),
+          title: Text(profile.label),
+          subtitle: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(profile.description),
+              const SizedBox(height: 12),
+              _ThemeProfilePreview(
+                profile: profile,
+                brightness: brightness,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ThemeProfilePreview extends StatelessWidget {
+  const _ThemeProfilePreview({
+    required this.profile,
+    required this.brightness,
+  });
+
+  final AgeCohortThemeProfile profile;
+  final Brightness brightness;
+
+  @override
+  Widget build(BuildContext context) {
+    final previewTheme = profile.toThemeData(brightness);
+    return Theme(
+      data: previewTheme,
+      child: Semantics(
+        container: true,
+        label: 'Preview of ${profile.label} typography and contrast',
+        child: Container(
+          width: double.infinity,
+          decoration: BoxDecoration(
+            color: previewTheme.colorScheme.surface,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: previewTheme.colorScheme.outlineVariant),
+          ),
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Heading preview',
+                style: previewTheme.textTheme.titleMedium,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Readable body copy adapts font, spacing, and contrast to match the profile.',
+                style: previewTheme.textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Icon(Icons.menu_book_outlined, size: previewTheme.iconTheme.size),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'Icon sizing preview',
+                      style: previewTheme.textTheme.labelLarge,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/src/presentation/theme/accessibility_preferences.dart
+++ b/lib/src/presentation/theme/accessibility_preferences.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/foundation.dart';
+
+@immutable
+class AccessibilityPreferences {
+  const AccessibilityPreferences({
+    this.fontScale = 1.0,
+    this.useDyslexiaFriendlyFonts = false,
+    this.highContrast = false,
+  });
+
+  final double fontScale;
+  final bool useDyslexiaFriendlyFonts;
+  final bool highContrast;
+
+  AccessibilityPreferences merge(AccessibilityPreferences? overrides) {
+    if (overrides == null) {
+      return this;
+    }
+    return AccessibilityPreferences(
+      fontScale: fontScale * overrides.fontScale,
+      useDyslexiaFriendlyFonts:
+          useDyslexiaFriendlyFonts || overrides.useDyslexiaFriendlyFonts,
+      highContrast: highContrast || overrides.highContrast,
+    );
+  }
+
+  AccessibilityPreferences copyWith({
+    double? fontScale,
+    bool? useDyslexiaFriendlyFonts,
+    bool? highContrast,
+  }) {
+    return AccessibilityPreferences(
+      fontScale: fontScale ?? this.fontScale,
+      useDyslexiaFriendlyFonts:
+          useDyslexiaFriendlyFonts ?? this.useDyslexiaFriendlyFonts,
+      highContrast: highContrast ?? this.highContrast,
+    );
+  }
+}
+
+const AccessibilityPreferences kBaseAccessibilityPreferences =
+    AccessibilityPreferences();
+
+const AccessibilityPreferences kReadableAccessibilityPreferences =
+    AccessibilityPreferences(fontScale: 1.1, useDyslexiaFriendlyFonts: true);
+
+const AccessibilityPreferences kHighContrastAccessibilityPreferences =
+    AccessibilityPreferences(fontScale: 1.2, highContrast: true);

--- a/lib/src/presentation/theme/age_cohort_theme_profiles.dart
+++ b/lib/src/presentation/theme/age_cohort_theme_profiles.dart
@@ -1,0 +1,346 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'accessibility_preferences.dart';
+
+typedef ThemeTextBuilder = TextTheme Function(
+  AccessibilityPreferences preferences,
+  Brightness brightness,
+);
+
+class AgeCohortThemeProfile {
+  AgeCohortThemeProfile({
+    required this.id,
+    required this.label,
+    required this.description,
+    required this.iconScale,
+    AccessibilityPreferences baseAccessibility =
+        kBaseAccessibilityPreferences,
+    AccessibilityPreferences? accessibilityOverrides,
+    required Color seedColor,
+    required Color contrastSeedColor,
+    required Color lightSurface,
+    required Color darkSurface,
+    required ThemeTextBuilder textThemeBuilder,
+    this.cohortKeywords = const [],
+  })  : _seedColor = seedColor,
+        _contrastSeedColor = contrastSeedColor,
+        _lightSurface = lightSurface,
+        _darkSurface = darkSurface,
+        _textThemeBuilder = textThemeBuilder,
+        accessibility =
+            baseAccessibility.merge(accessibilityOverrides);
+
+  final String id;
+  final String label;
+  final String description;
+  final double iconScale;
+  final AccessibilityPreferences accessibility;
+  final List<String> cohortKeywords;
+
+  final Color _seedColor;
+  final Color _contrastSeedColor;
+  final Color _lightSurface;
+  final Color _darkSurface;
+  final ThemeTextBuilder _textThemeBuilder;
+
+  ThemeData toThemeData(Brightness brightness) {
+    final textTheme = _textThemeBuilder(accessibility, brightness);
+    final colorScheme = _buildColorScheme(brightness, accessibility);
+    final iconSize = 24.0 * iconScale * accessibility.fontScale;
+
+    return ThemeData(
+      useMaterial3: true,
+      colorScheme: colorScheme,
+      brightness: brightness,
+      scaffoldBackgroundColor: colorScheme.surface,
+      canvasColor: colorScheme.surface,
+      textTheme: textTheme,
+      iconTheme: IconThemeData(
+        size: iconSize,
+        color: colorScheme.primary,
+      ),
+      primaryIconTheme: IconThemeData(
+        size: iconSize,
+        color: colorScheme.onPrimary,
+      ),
+      appBarTheme: AppBarTheme(
+        backgroundColor: colorScheme.primary,
+        foregroundColor: colorScheme.onPrimary,
+        centerTitle: true,
+        titleTextStyle:
+            textTheme.titleLarge?.copyWith(color: colorScheme.onPrimary),
+      ),
+      listTileTheme: ListTileThemeData(
+        tileColor: colorScheme.surface,
+        textColor: colorScheme.onSurface,
+        iconColor: colorScheme.primary,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+      ),
+      cardTheme: CardTheme(
+        color: colorScheme.surface,
+        elevation: accessibility.highContrast ? 6 : 2,
+        margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(20),
+          side: BorderSide(
+            color: accessibility.highContrast
+                ? colorScheme.outline
+                : colorScheme.outlineVariant,
+          ),
+        ),
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: colorScheme.primary,
+          foregroundColor: colorScheme.onPrimary,
+          textStyle: textTheme.labelLarge,
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+        ),
+      ),
+      filledButtonTheme: FilledButtonThemeData(
+        style: FilledButton.styleFrom(
+          textStyle: textTheme.labelLarge,
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+        ),
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(textStyle: textTheme.labelLarge),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: colorScheme.surfaceVariant.withOpacity(0.4),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: BorderSide(color: colorScheme.outlineVariant),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: BorderSide(color: colorScheme.primary, width: 2),
+        ),
+      ),
+      focusColor: colorScheme.primary,
+      splashColor: colorScheme.primary.withOpacity(0.1),
+      highlightColor: colorScheme.primary.withOpacity(0.1),
+      bottomNavigationBarTheme: BottomNavigationBarThemeData(
+        selectedItemColor: colorScheme.primary,
+        unselectedItemColor: colorScheme.onSurfaceVariant,
+        showUnselectedLabels: true,
+        selectedIconTheme: IconThemeData(size: iconSize * 1.1),
+        unselectedIconTheme: IconThemeData(size: iconSize * 0.95),
+      ),
+      navigationRailTheme: NavigationRailThemeData(
+        selectedIconTheme: IconThemeData(size: iconSize * 1.1),
+        unselectedIconTheme: IconThemeData(size: iconSize * 0.95),
+        selectedLabelTextStyle: textTheme.labelLarge,
+        unselectedLabelTextStyle:
+            textTheme.labelLarge?.copyWith(color: colorScheme.onSurfaceVariant),
+      ),
+      visualDensity: VisualDensity.adaptivePlatformDensity,
+    );
+  }
+
+  ColorScheme _buildColorScheme(
+    Brightness brightness,
+    AccessibilityPreferences preferences,
+  ) {
+    final isDark = brightness == Brightness.dark;
+    final seed = preferences.highContrast ? _contrastSeedColor : _seedColor;
+    final surface = preferences.highContrast
+        ? (isDark ? const Color(0xFF101010) : Colors.white)
+        : (isDark ? _darkSurface : _lightSurface);
+
+    final scheme = ColorScheme.fromSeed(
+      seedColor: seed,
+      surface: surface,
+      brightness: brightness,
+    );
+
+    if (!preferences.highContrast) {
+      return scheme;
+    }
+
+    return scheme.copyWith(
+      surface: surface,
+      background: surface,
+      onSurface: isDark ? Colors.white : Colors.black,
+      primary: isDark ? Colors.amberAccent : seed,
+      onPrimary: isDark ? Colors.black : Colors.white,
+      outline: isDark ? Colors.white70 : Colors.black54,
+      outlineVariant: isDark ? Colors.white38 : Colors.black26,
+    );
+  }
+}
+
+TextTheme _composeTextTheme({
+  required TextTheme body,
+  required TextTheme display,
+  required AccessibilityPreferences preferences,
+  double bodyScale = 1.0,
+  double headingScale = 1.0,
+  double lineHeight = 1.5,
+}) {
+  final scaledBody =
+      body.apply(fontSizeFactor: bodyScale * preferences.fontScale);
+  final scaledDisplay =
+      display.apply(fontSizeFactor: headingScale * preferences.fontScale);
+
+  return scaledBody.copyWith(
+    displayLarge: scaledDisplay.displayLarge,
+    displayMedium: scaledDisplay.displayMedium,
+    displaySmall: scaledDisplay.displaySmall,
+    headlineLarge: scaledDisplay.headlineLarge,
+    headlineMedium: scaledDisplay.headlineMedium,
+    headlineSmall: scaledDisplay.headlineSmall,
+    titleLarge: scaledDisplay.titleLarge ?? scaledBody.titleLarge,
+    titleMedium: scaledDisplay.titleMedium ?? scaledBody.titleMedium,
+    titleSmall: scaledDisplay.titleSmall ?? scaledBody.titleSmall,
+    bodyLarge: scaledBody.bodyLarge?.copyWith(height: lineHeight),
+    bodyMedium: scaledBody.bodyMedium?.copyWith(height: lineHeight),
+    bodySmall: scaledBody.bodySmall?.copyWith(height: lineHeight),
+    labelLarge: scaledBody.labelLarge?.copyWith(fontWeight: FontWeight.w600),
+    labelMedium: scaledBody.labelMedium?.copyWith(fontWeight: FontWeight.w600),
+    labelSmall: scaledBody.labelSmall?.copyWith(fontWeight: FontWeight.w600),
+  );
+}
+
+TextTheme _earlyLearnerTypography(
+  AccessibilityPreferences preferences,
+  Brightness brightness,
+) {
+  final playful = GoogleFonts.fredokaTextTheme();
+  final display = GoogleFonts.baloo2TextTheme();
+  final base = preferences.useDyslexiaFriendlyFonts
+      ? GoogleFonts.atkinsonHyperlegibleTextTheme()
+      : playful;
+  return _composeTextTheme(
+    body: base,
+    display: display,
+    preferences: preferences,
+    bodyScale: 1.2,
+    headingScale: 1.3,
+    lineHeight: 1.6,
+  );
+}
+
+TextTheme _youthTypography(
+  AccessibilityPreferences preferences,
+  Brightness brightness,
+) {
+  final base = preferences.useDyslexiaFriendlyFonts
+      ? GoogleFonts.atkinsonHyperlegibleTextTheme()
+      : GoogleFonts.lexendTextTheme();
+  final display = GoogleFonts.spaceGroteskTextTheme();
+  return _composeTextTheme(
+    body: base,
+    display: display,
+    preferences: preferences,
+    bodyScale: 1.1,
+    headingScale: 1.15,
+    lineHeight: 1.55,
+  );
+}
+
+TextTheme _adultTypography(
+  AccessibilityPreferences preferences,
+  Brightness brightness,
+) {
+  final base = preferences.useDyslexiaFriendlyFonts
+      ? GoogleFonts.atkinsonHyperlegibleTextTheme()
+      : GoogleFonts.nunitoTextTheme();
+  final display = GoogleFonts.sourceSerifProTextTheme();
+  return _composeTextTheme(
+    body: base,
+    display: display,
+    preferences: preferences,
+    bodyScale: 1.05,
+    headingScale: 1.1,
+    lineHeight: 1.5,
+  );
+}
+
+TextTheme _mentorTypography(
+  AccessibilityPreferences preferences,
+  Brightness brightness,
+) {
+  final base = GoogleFonts.atkinsonHyperlegibleTextTheme();
+  final display = GoogleFonts.merriweatherTextTheme();
+  return _composeTextTheme(
+    body: base,
+    display: display,
+    preferences: preferences,
+    bodyScale: 1.2,
+    headingScale: 1.25,
+    lineHeight: 1.65,
+  );
+}
+
+final List<AgeCohortThemeProfile> kAgeCohortThemeProfiles = [
+  AgeCohortThemeProfile(
+    id: 'early-learners',
+    label: 'Early Learners (5-8)',
+    description:
+        'Playful typography, bright colors, and generous sizing for new readers.',
+    iconScale: 1.35,
+    accessibilityOverrides: kReadableAccessibilityPreferences,
+    seedColor: const Color(0xFF3DDC97),
+    contrastSeedColor: const Color(0xFF0B8043),
+    lightSurface: const Color(0xFFF0FFFA),
+    darkSurface: const Color(0xFF0C1A13),
+    textThemeBuilder: _earlyLearnerTypography,
+    cohortKeywords: const ['kid', 'child', 'junior', 'beginner', 'primary'],
+  ),
+  AgeCohortThemeProfile(
+    id: 'youth',
+    label: 'Youth & Teens',
+    description:
+        'Energetic palette with bold headings and supportive accessibility boosts.',
+    iconScale: 1.2,
+    accessibilityOverrides:
+        kBaseAccessibilityPreferences.copyWith(fontScale: 1.1),
+    seedColor: const Color(0xFF6750A4),
+    contrastSeedColor: const Color(0xFF311B92),
+    lightSurface: const Color(0xFFEFECFF),
+    darkSurface: const Color(0xFF1B1535),
+    textThemeBuilder: _youthTypography,
+    cohortKeywords: const ['teen', 'youth', 'student', 'middle', 'intermediate'],
+  ),
+  AgeCohortThemeProfile(
+    id: 'adults',
+    label: 'Adults',
+    description: 'Balanced contrast and comfortable typography for most readers.',
+    iconScale: 1.0,
+    accessibilityOverrides:
+        kBaseAccessibilityPreferences.copyWith(fontScale: 1.05),
+    seedColor: const Color(0xFF3F51B5),
+    contrastSeedColor: const Color(0xFF1A237E),
+    lightSurface: const Color(0xFFE8EAF6),
+    darkSurface: const Color(0xFF12131F),
+    textThemeBuilder: _adultTypography,
+    cohortKeywords: const ['adult', 'general', 'discovery', 'answer', 'parent'],
+  ),
+  AgeCohortThemeProfile(
+    id: 'mentors',
+    label: 'Mentors & Seniors',
+    description:
+        'High-contrast palette with dyslexia-friendly fonts and large icons.',
+    iconScale: 1.3,
+    accessibilityOverrides: kHighContrastAccessibilityPreferences,
+    seedColor: const Color(0xFF00696F),
+    contrastSeedColor: const Color(0xFF004D40),
+    lightSurface: const Color(0xFFE0F7FA),
+    darkSurface: const Color(0xFF002021),
+    textThemeBuilder: _mentorTypography,
+    cohortKeywords: const ['mentor', 'teacher', 'leader', 'senior', 'facilitator'],
+  ),
+];
+
+AgeCohortThemeProfile defaultThemeProfile() => kAgeCohortThemeProfiles[2];


### PR DESCRIPTION
## Summary
- add theme profile definitions per age cohort with accessibility-aware typography, colors, and icon sizing
- expose new Riverpod controllers to persist per-user theme selections and surface profile previews in settings
- improve semantics, focus order, and labels on major screens for better accessibility support

## Testing
- not run (tooling unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e00afbc1a48320bd55f54c577aa85f