### PR TITLE
Replace deprecated Material color APIs

### DIFF
--- a/lib/src/presentation/theme/age_cohort_theme_profiles.dart
+++ b/lib/src/presentation/theme/age_cohort_theme_profiles.dart
@@ -117,7 +117,8 @@ class AgeCohortThemeProfile {
       ),
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
-        fillColor: colorScheme.surfaceVariant.withOpacity(0.4),
+        fillColor:
+            colorScheme.surfaceContainerHighest.withValues(alpha: 0.4),
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(16),
           borderSide: BorderSide(color: colorScheme.outlineVariant),
@@ -128,8 +129,8 @@ class AgeCohortThemeProfile {
         ),
       ),
       focusColor: colorScheme.primary,
-      splashColor: colorScheme.primary.withOpacity(0.1),
-      highlightColor: colorScheme.primary.withOpacity(0.1),
+      splashColor: colorScheme.primary.withValues(alpha: 0.1),
+      highlightColor: colorScheme.primary.withValues(alpha: 0.1),
       bottomNavigationBarTheme: BottomNavigationBarThemeData(
         selectedItemColor: colorScheme.primary,
         unselectedItemColor: colorScheme.onSurfaceVariant,
@@ -170,7 +171,6 @@ class AgeCohortThemeProfile {
 
     return scheme.copyWith(
       surface: surface,
-      background: surface,
       onSurface: isDark ? Colors.white : Colors.black,
       primary: isDark ? Colors.amberAccent : seed,
       onPrimary: isDark ? Colors.black : Colors.white,


### PR DESCRIPTION
## Summary
- replace deprecated ColorScheme.surfaceVariant usage with surfaceContainerHighest and update alpha handling via withValues
- update splash and highlight colors to avoid deprecated withOpacity calls
- remove deprecated ColorScheme.background override in high contrast color scheme copy

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e024ff4f7083209e04411a7537d81d