### PR TITLE
Replace deprecated Quill toolbar API

### DIFF
--- a/lib/src/presentation/teacher/teacher_tools_screen.dart
+++ b/lib/src/presentation/teacher/teacher_tools_screen.dart
@@ -371,7 +371,7 @@ class _LessonEditorTabState extends ConsumerState<_LessonEditorTab> {
                 Expanded(
                   child: Column(
                     children: [
-                      QuillToolbar.simple(controller: _controller),
+                      QuillSimpleToolbar(controller: _controller),
                       const SizedBox(height: 12),
                       Expanded(
                         child: Container(


### PR DESCRIPTION
## Summary
- replace the deprecated `QuillToolbar.simple` constructor with the new `QuillSimpleToolbar`

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e028bbe2188320a0d9ec73e83b3a87