### PR TITLE
Fix missing PrivacyState import in settings screen

### DIFF
--- a/lib/src/presentation/settings/settings_screen.dart
+++ b/lib/src/presentation/settings/settings_screen.dart
@@ -14,6 +14,7 @@ import 'bible_import_controller.dart';
 import 'about_screen.dart';
 import 'data_sync_controller.dart';
 import 'lesson_sync_controller.dart';
+import 'privacy_controller.dart';
 import 'privacy_policy_screen.dart';
 import '../accounts/profile_management_screen.dart';
 import '../theme/age_cohort_theme_profiles.dart';


### PR DESCRIPTION
## Summary
- import the privacy controller into the settings screen so the `PrivacyState` type is available

## Testing
- Not run (flutter/dart tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e02be318d48320ab38fe3f03b0c928