### PR TITLE
Fix Riverpod listeners for lesson detail

### DIFF
--- a/lib/src/presentation/lessons/lesson_detail_screen.dart
+++ b/lib/src/presentation/lessons/lesson_detail_screen.dart
@@ -48,27 +48,14 @@ class _LessonDetailScreenState extends ConsumerState<LessonDetailScreen> {
         _sessionSeconds = seconds;
       });
     });
+    final initialUserId = ref.read(activeUserIdProvider);
+    _handleActiveUserChange(initialUserId);
+
     ref.listen<String?>(
       activeUserIdProvider,
       (previous, next) {
-        if (!mounted) {
-          return;
-        }
-        if (next == null || next.isEmpty) {
-          setState(() {
-            _userId = null;
-            _progress = null;
-          });
-          _progressSubscription?.close();
-          _progressSubscription = null;
-          return;
-        }
-        if (next != _userId) {
-          _userId = next;
-          _subscribeToProgress(next);
-        }
+        _handleActiveUserChange(next);
       },
-      fireImmediately: true,
     );
   }
 
@@ -81,14 +68,14 @@ class _LessonDetailScreenState extends ConsumerState<LessonDetailScreen> {
 
   void _subscribeToProgress(String userId) {
     _progressSubscription?.close();
-    _progressSubscription = ref.listen<AsyncValue<LessonProgress?>>(
+    _progressSubscription = ref.listenManual<AsyncValue<LessonProgress?>>(
       lessonProgressProvider(
         LessonProgressRequest(
           userId: userId,
           lessonId: widget.lesson.id,
         ),
       ),
-      (previous, next) {
+      (next) {
         next.whenData((value) {
           if (!mounted) {
             return;
@@ -100,6 +87,25 @@ class _LessonDetailScreenState extends ConsumerState<LessonDetailScreen> {
       },
       fireImmediately: true,
     );
+  }
+
+  void _handleActiveUserChange(String? next) {
+    if (!mounted) {
+      return;
+    }
+    if (next == null || next.isEmpty) {
+      setState(() {
+        _userId = null;
+        _progress = null;
+      });
+      _progressSubscription?.close();
+      _progressSubscription = null;
+      return;
+    }
+    if (next != _userId) {
+      _userId = next;
+      _subscribeToProgress(next);
+    }
   }
 
   bool _canHostLesson(LocalAccount? account) {


### PR DESCRIPTION
## Summary
- initialize the active user state manually instead of relying on `fireImmediately`
- switch lesson progress subscription to `listenManual` so it can be cancelled later
- ensure listener cleanup when the active user changes or is cleared

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0b496cf948320890e61204871eb28