### PR TITLE
Fix lesson progress listener signature

### DIFF
--- a/lib/src/presentation/lessons/lesson_detail_screen.dart
+++ b/lib/src/presentation/lessons/lesson_detail_screen.dart
@@ -75,7 +75,7 @@ class _LessonDetailScreenState extends ConsumerState<LessonDetailScreen> {
           lessonId: widget.lesson.id,
         ),
       ),
-      (next) {
+      (_, next) {
         next.whenData((value) {
           if (!mounted) {
             return;


### PR DESCRIPTION
## Summary
- update the manual lesson progress listener to accept both previous and next values so that it matches the latest Riverpod API

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0be575d64832095e0fc08278927df