### PR TITLE
Fix drift import for sync orchestrator

### DIFF
--- a/lib/src/infrastructure/sync/sync_orchestrator.dart
+++ b/lib/src/infrastructure/sync/sync_orchestrator.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:drift/drift.dart' show InsertMode, Value;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:workmanager/workmanager.dart';


### PR DESCRIPTION
## Summary
- add the missing drift import so the sync orchestrator can reference Value and InsertMode

## Testing
- not run (flutter tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0c0799e008320b57eeb24901c4d8c