### PR TITLE
Fix Flutter secure storage web options

### DIFF
--- a/lib/src/infrastructure/security/secure_storage_service.dart
+++ b/lib/src/infrastructure/security/secure_storage_service.dart
@@ -14,9 +14,7 @@ class SecureStorageService {
           mOptions: MacOsOptions(
             accessibility: KeychainAccessibility.unlocked_this_device,
           ),
-          webOptions: WebOptions(
-            webSecureMode: true,
-          ),
+          webOptions: const WebOptions(),
         );
 
   final FlutterSecureStorage _secureStorage;


### PR DESCRIPTION
## Summary
- update the secure storage service to use the new WebOptions API that shipped with flutter_secure_storage 9.2
- remove the deprecated `webSecureMode` parameter so the project builds again

## Testing
- not run (build-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e0c15f56b08320be1b5f65882102f4