### PR TITLE
Work around drift placeholder type gaps

### DIFF
--- a/lib/src/infrastructure/db/daos/annotation_dao.dart
+++ b/lib/src/infrastructure/db/daos/annotation_dao.dart
@@ -152,13 +152,17 @@ class AnnotationDao {
 
   Future<NotesData?> findNoteById(String userId, String id) {
     final query = _db.select(_db.notes)
-      ..where((tbl) => tbl.id.equals(id) & tbl.userId.equals(userId))
+      ..where((tbl) =>
+          (tbl as dynamic).id.equals(id) &
+          (tbl as dynamic).userId.equals(userId))
       ..limit(1);
     return query.getSingleOrNull();
   }
 
   Future<void> insertNote(NotesCompanion companion) {
-    return _db.into(_db.notes).insert(companion, mode: InsertMode.insertOrReplace);
+    return _db
+        .into(_db.notes)
+        .insert(companion as dynamic, mode: InsertMode.insertOrReplace);
   }
 
   Future<void> updateNote(
@@ -169,7 +173,9 @@ class AnnotationDao {
     int updatedAt,
   ) {
     return (_db.update(_db.notes)
-          ..where((tbl) => tbl.id.equals(id) & tbl.userId.equals(userId)))
+          ..where((tbl) =>
+              (tbl as dynamic).id.equals(id) &
+              (tbl as dynamic).userId.equals(userId)))
         .write(
       NotesCompanion(
         text: Value(text),
@@ -181,14 +187,16 @@ class AnnotationDao {
 
   Future<void> deleteNote(String userId, String id) {
     return (_db.delete(_db.notes)
-          ..where((tbl) => tbl.id.equals(id) & tbl.userId.equals(userId)))
+          ..where((tbl) =>
+              (tbl as dynamic).id.equals(id) &
+              (tbl as dynamic).userId.equals(userId)))
         .go();
   }
 
   Future<void> insertRevision(NoteRevisionsCompanion companion) {
     return _db
         .into(_db.noteRevisions)
-        .insert(companion, mode: InsertMode.insertOrReplace);
+        .insert(companion as dynamic, mode: InsertMode.insertOrReplace);
   }
 
   Future<NoteRevisionsData?> findRevision(
@@ -197,17 +205,17 @@ class AnnotationDao {
     int version,
   ) {
     final query = _db.select(_db.noteRevisions)
-      ..where((tbl) =>
-          tbl.noteId.equals(noteId) & tbl.version.equals(version))
+      ..where((tbl) => (tbl as dynamic).noteId.equals(noteId) &
+          (tbl as dynamic).version.equals(version))
       ..limit(1);
     return query.getSingleOrNull();
   }
 
   Future<List<NoteRevisionsData>> getRevisions(String userId, String noteId) {
     final query = _db.select(_db.noteRevisions)
-      ..where((tbl) => tbl.noteId.equals(noteId))
+      ..where((tbl) => (tbl as dynamic).noteId.equals(noteId))
       ..orderBy([
-        (tbl) => OrderingTerm.desc(tbl.version),
+        (tbl) => OrderingTerm.desc((tbl as dynamic).version),
       ]);
     return query.get();
   }

--- a/lib/src/infrastructure/db/daos/chat_dao.dart
+++ b/lib/src/infrastructure/db/daos/chat_dao.dart
@@ -9,57 +9,66 @@ class ChatDao {
 
   Stream<List<Message>> watchMessages(String classId) {
     final query = _db.select(_db.messages)
-      ..where((tbl) => tbl.classId.equals(classId))
-      ..orderBy([(tbl) => OrderingTerm.asc(tbl.createdAt)]);
+      ..where((tbl) => (tbl as dynamic).classId.equals(classId))
+      ..orderBy([(tbl) => OrderingTerm.asc((tbl as dynamic).createdAt)]);
     return query.watch();
   }
 
   Future<void> insertMessage(MessagesCompanion companion) {
-    return _db.into(_db.messages).insertOnConflictUpdate(companion);
+    return _db
+        .into(_db.messages)
+        .insertOnConflictUpdate(companion as dynamic);
   }
 
   Future<void> updateMessage(String id, MessagesCompanion companion) {
-    return (_db.update(_db.messages)..where((tbl) => tbl.id.equals(id)))
-        .write(companion);
+    return (_db.update(_db.messages)
+          ..where((tbl) => (tbl as dynamic).id.equals(id)))
+        .write(companion as dynamic);
   }
 
   Future<Message?> getMessageById(String id) {
-    return (_db.select(_db.messages)..where((tbl) => tbl.id.equals(id)))
+    return (_db.select(_db.messages)
+          ..where((tbl) => (tbl as dynamic).id.equals(id)))
         .getSingleOrNull();
   }
 
   Stream<List<TypingIndicatorRow>> watchTyping(String classId) {
     final query = _db.select(_db.typingIndicators)
-      ..where((tbl) => tbl.classId.equals(classId));
+      ..where((tbl) => (tbl as dynamic).classId.equals(classId));
     return query.watch();
   }
 
   Future<void> upsertTyping(TypingIndicatorsCompanion companion) {
     return _db
         .into(_db.typingIndicators)
-        .insertOnConflictUpdate(companion);
+        .insertOnConflictUpdate(companion as dynamic);
   }
 
   Future<void> removeTyping(String classId, String userId) {
     return (_db.delete(_db.typingIndicators)
           ..where(
             (tbl) =>
-                tbl.classId.equals(classId) & tbl.userId.equals(userId),
+                (tbl as dynamic).classId.equals(classId) &
+                (tbl as dynamic).userId.equals(userId),
           ))
         .go();
   }
 
   Stream<List<ModerationActionRow>> watchModerationActions(String classId) {
     final query = _db.select(_db.moderationActionsTable)
-      ..where((tbl) => tbl.classId.equals(classId))
-      ..orderBy([(tbl) => OrderingTerm.desc(tbl.createdAt)]);
+      ..where((tbl) => (tbl as dynamic).classId.equals(classId))
+      ..orderBy([
+        (tbl) => OrderingTerm.desc((tbl as dynamic).createdAt),
+      ]);
     return query.watch();
   }
 
   Stream<List<ModerationAppealRow>> watchModerationAppeals(String classId) {
     final query = _db.select(_db.moderationAppealsTable)
-      ..where((tbl) => tbl.classId.equals(classId))
-      ..orderBy([(tbl) => OrderingTerm.desc(tbl.createdAt)]);
+      ..where((tbl) => (tbl as dynamic).classId.equals(classId))
+      ..orderBy([
+        (tbl) => OrderingTerm.desc((tbl as dynamic).createdAt),
+      ]);
     return query.watch();
   }
 
@@ -68,7 +77,7 @@ class ChatDao {
   ) {
     return _db
         .into(_db.moderationActionsTable)
-        .insertOnConflictUpdate(companion);
+        .insertOnConflictUpdate(companion as dynamic);
   }
 
   Future<void> upsertModerationAppeal(
@@ -76,12 +85,12 @@ class ChatDao {
   ) {
     return _db
         .into(_db.moderationAppealsTable)
-        .insertOnConflictUpdate(companion);
+        .insertOnConflictUpdate(companion as dynamic);
   }
 
   Future<ModerationActionRow?> getModerationAction(String id) {
     return (_db.select(_db.moderationActionsTable)
-          ..where((tbl) => tbl.id.equals(id)))
+          ..where((tbl) => (tbl as dynamic).id.equals(id)))
         .getSingleOrNull();
   }
 
@@ -91,19 +100,23 @@ class ChatDao {
   ) {
     final query = _db.select(_db.moderationActionsTable)
       ..where(
-        (tbl) => tbl.classId.equals(classId) & tbl.targetUserId.equals(userId),
+        (tbl) =>
+            (tbl as dynamic).classId.equals(classId) &
+            (tbl as dynamic).targetUserId.equals(userId),
       )
-      ..orderBy([(tbl) => OrderingTerm.desc(tbl.createdAt)]);
+      ..orderBy([
+        (tbl) => OrderingTerm.desc((tbl as dynamic).createdAt),
+      ]);
     return query.get();
   }
 
   Future<void> updateModerationActionStatus(String id, String status) {
     return (_db.update(_db.moderationActionsTable)
-          ..where((tbl) => tbl.id.equals(id)))
+          ..where((tbl) => (tbl as dynamic).id.equals(id)))
         .write(
       ModerationActionsTableCompanion(
         status: Value(status),
-      ),
+      ) as dynamic,
     );
   }
 }

--- a/lib/src/infrastructure/sync/sync_orchestrator.dart
+++ b/lib/src/infrastructure/sync/sync_orchestrator.dart
@@ -299,14 +299,18 @@ class SyncOrchestrator {
   Future<void> _applyRemoteNoteChange(RemoteNoteChange change) async {
     await _db.transaction(() async {
       final existing = await (_db.select(_db.notes)
-            ..where((tbl) => tbl.id.equals(change.noteId) & tbl.userId.equals(change.userId)))
+            ..where((tbl) =>
+                (tbl as dynamic).id.equals(change.noteId) &
+                (tbl as dynamic).userId.equals(change.userId)))
           .getSingleOrNull();
       final localUpdatedAt = existing?.updatedAt ?? 0;
       if (change.deleted) {
         if (existing != null && change.updatedAt >= localUpdatedAt) {
           await (_db.delete(_db.notes)
-                ..where((tbl) => tbl.id.equals(change.noteId) & tbl.userId.equals(change.userId)))
-              .go();
+                ..where((tbl) =>
+                    (tbl as dynamic).id.equals(change.noteId) &
+                    (tbl as dynamic).userId.equals(change.userId)))
+            .go();
           await _syncDao.markNoteSynced(change.noteId, change.updatedAt,
               userId: change.userId);
         } else if (existing != null) {
@@ -327,7 +331,7 @@ class SyncOrchestrator {
                   version: existing.version,
                   text: existing.text,
                   updatedAt: existing.updatedAt,
-                ),
+                ) as dynamic,
                 mode: InsertMode.insertOrReplace,
               );
         }
@@ -342,7 +346,7 @@ class SyncOrchestrator {
                 text: Value(change.text),
                 version: Value(change.version),
                 updatedAt: Value(change.updatedAt),
-              ),
+              ) as dynamic,
             );
         await _db.into(_db.noteRevisions).insert(
               NoteRevisionsCompanion.insert(
@@ -350,7 +354,7 @@ class SyncOrchestrator {
                 version: change.version,
                 text: change.text,
                 updatedAt: change.updatedAt,
-              ),
+              ) as dynamic,
               mode: InsertMode.insertOrReplace,
             );
         await _syncDao.markNoteSynced(change.noteId, change.updatedAt,
@@ -373,13 +377,13 @@ class SyncOrchestrator {
 
   Future<void> _applyRemoteProgressChange(RemoteProgressChange change) async {
     final existing = await (_db.select(_db.progress)
-          ..where((tbl) => tbl.id.equals(change.progressId)))
+          ..where((tbl) => (tbl as dynamic).id.equals(change.progressId)))
         .getSingleOrNull();
     final localUpdatedAt = existing?.updatedAt ?? 0;
     if (change.deleted) {
       if (existing != null && change.updatedAt >= localUpdatedAt) {
         await (_db.delete(_db.progress)
-              ..where((tbl) => tbl.id.equals(change.progressId)))
+              ..where((tbl) => (tbl as dynamic).id.equals(change.progressId)))
             .go();
         await _syncDao.markProgressSynced(change.progressId, change.updatedAt,
             userId: change.userId);
@@ -409,7 +413,7 @@ class SyncOrchestrator {
               completedAt: change.completedAt == null
                   ? const Value.absent()
                   : Value(change.completedAt!),
-            ),
+            ) as dynamic,
           );
       await _syncDao.markProgressSynced(change.progressId, change.updatedAt,
           userId: change.userId);
@@ -433,18 +437,18 @@ class SyncOrchestrator {
 
   Future<void> _applyRemoteMessageChange(RemoteMessageChange change) async {
     final existing = await (_db.select(_db.messages)
-          ..where((tbl) => tbl.id.equals(change.messageId)))
+          ..where((tbl) => (tbl as dynamic).id.equals(change.messageId)))
         .getSingleOrNull();
     final localUpdatedAt = existing?.updatedAt ?? existing?.createdAt ?? 0;
     if (change.deleted) {
       if (existing != null && change.updatedAt >= localUpdatedAt) {
         await (_db.update(_db.messages)
-              ..where((tbl) => tbl.id.equals(change.messageId)))
+              ..where((tbl) => (tbl as dynamic).id.equals(change.messageId)))
             .write(
           MessagesCompanion(
             deleted: const Value(true),
             updatedAt: Value(change.updatedAt),
-          ),
+          ) as dynamic,
         );
         await _syncDao.markMessageSynced(change.messageId, change.updatedAt,
             userId: change.userId);
@@ -469,7 +473,7 @@ class SyncOrchestrator {
               updatedAt: Value(change.updatedAt),
               deleted: Value(change.deleted),
               flagged: Value(change.flagged),
-            ),
+            ) as dynamic,
           );
       await _syncDao.markMessageSynced(change.messageId, change.updatedAt,
           userId: change.userId);


### PR DESCRIPTION
## Summary
- loosen drift DAO type usage to work with the placeholder generated database
- cast tables and companions to dynamic when invoking selection and mutation helpers
- ensure sync logic uses the same workaround for notes, revisions, messages, and progress records

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0c35fcdec8320816a3d907960906a