### PR TITLE
Fix drift companion references in sync orchestrator

### DIFF
--- a/lib/src/infrastructure/sync/sync_orchestrator.dart
+++ b/lib/src/infrastructure/sync/sync_orchestrator.dart
@@ -326,7 +326,7 @@ class SyncOrchestrator {
       if (existing == null || change.updatedAt > localUpdatedAt) {
         if (existing != null) {
           await _db.into(_db.noteRevisions).insert(
-                NoteRevisionsCompanion.insert(
+                app_db.NoteRevisionsCompanion.insert(
                   noteId: existing.id,
                   version: existing.version,
                   text: existing.text,
@@ -336,7 +336,7 @@ class SyncOrchestrator {
               );
         }
         await _db.into(_db.notes).insertOnConflictUpdate(
-              NotesCompanion(
+              app_db.NotesCompanion(
                 id: Value(change.noteId),
                 userId: Value(change.userId),
                 translationId: Value(change.translationId),
@@ -349,7 +349,7 @@ class SyncOrchestrator {
               ) as dynamic,
             );
         await _db.into(_db.noteRevisions).insert(
-              NoteRevisionsCompanion.insert(
+              app_db.NoteRevisionsCompanion.insert(
                 noteId: change.noteId,
                 version: change.version,
                 text: change.text,


### PR DESCRIPTION
## Summary
- prefix drift companion usages in the sync orchestrator with the generated database namespace

## Testing
- dart analyze *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e0eaa7f6a88320a49beb996b46d7ec