### PR TITLE
Fix sync orchestrator companion references

### DIFF
--- a/lib/src/infrastructure/sync/sync_orchestrator.dart
+++ b/lib/src/infrastructure/sync/sync_orchestrator.dart
@@ -445,7 +445,7 @@ class SyncOrchestrator {
         await (_db.update(_db.messages)
               ..where((tbl) => (tbl as dynamic).id.equals(change.messageId)))
             .write(
-          MessagesCompanion(
+          app_db.MessagesCompanion(
             deleted: const Value(true),
             updatedAt: Value(change.updatedAt),
           ) as dynamic,
@@ -464,7 +464,7 @@ class SyncOrchestrator {
 
     if (existing == null || change.updatedAt > localUpdatedAt) {
       await _db.into(_db.messages).insertOnConflictUpdate(
-            MessagesCompanion(
+            app_db.MessagesCompanion(
               id: Value(change.messageId),
               classId: Value(change.classId),
               userId: Value(change.userId),


### PR DESCRIPTION
## Summary
- prefix message companion inserts with the app database alias in the sync orchestrator to use the generated drift companion

## Testing
- Not run (environment lacks Flutter SDK)


------
https://chatgpt.com/codex/tasks/task_e_68e0ec0040b88320ae08933bd5680d02