### PR TITLE
Update Android notification scheduling mode

### DIFF
--- a/lib/src/infrastructure/notifications/notification_service.dart
+++ b/lib/src/infrastructure/notifications/notification_service.dart
@@ -176,7 +176,7 @@ class NotificationService {
       '$title starts at ${startTime.toLocal()}.',
       tz.TZDateTime.from(reminderTime, tz.local),
       notificationDetails,
-      androidAllowWhileIdle: true,
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
       uiLocalNotificationDateInterpretation:
           UILocalNotificationDateInterpretation.absoluteTime,
       matchDateTimeComponents: DateTimeComponents.dateAndTime,
@@ -214,7 +214,7 @@ class NotificationService {
       '$title starts soon $roleLabel.',
       tz.TZDateTime.from(reminderTime, tz.local),
       notificationDetails,
-      androidAllowWhileIdle: true,
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
       uiLocalNotificationDateInterpretation:
           UILocalNotificationDateInterpretation.absoluteTime,
       matchDateTimeComponents: DateTimeComponents.dateAndTime,


### PR DESCRIPTION
## Summary
- replace the removed `androidAllowWhileIdle` flag with `AndroidScheduleMode.exactAllowWhileIdle` when scheduling reminders

## Testing
- flutter analyze *(fails: `flutter` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f01ecc18832098d89efdb0b01f83