### PR TITLE
Fix DartPluginRegistrant reference in lesson sync dispatcher

### DIFF
--- a/lib/src/infrastructure/lessons/lesson_sync_service.dart
+++ b/lib/src/infrastructure/lessons/lesson_sync_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -333,7 +334,7 @@ class LessonSyncSourceResult {
 void lessonSyncCallbackDispatcher() {
   Workmanager().executeTask((task, inputData) async {
     WidgetsFlutterBinding.ensureInitialized();
-    DartPluginRegistrant.ensureInitialized();
+    ui.DartPluginRegistrant.ensureInitialized();
 
     if (task == kDataSyncBackgroundTask) {
       return await runDataSyncTask();


### PR DESCRIPTION
## Summary
- import `dart:ui` so the background lesson sync dispatcher can call `DartPluginRegistrant.ensureInitialized()` without analysis errors

## Testing
- not run (environment lacks flutter)

------
https://chatgpt.com/codex/tasks/task_e_68e0f0c038d08320829574a1782e36fa