### PR TITLE
Fix lesson deletion set typing

### DIFF
--- a/lib/src/infrastructure/lessons/lesson_ingestion_pipeline.dart
+++ b/lib/src/infrastructure/lessons/lesson_ingestion_pipeline.dart
@@ -178,7 +178,7 @@ class LessonIngestionPipeline {
         final existing = await (_db.select(_db.lessons)
               ..where((tbl) => tbl.feedId.equals(feedId)))
             .get();
-        final existingIds = existing.map((row) => row.id).toSet();
+        final existingIds = existing.map<String>((row) => row.id).toSet();
         final incomingIds = lessons.map((lesson) => lesson.id).toSet();
         final toDelete = existingIds.difference(incomingIds);
         if (toDelete.isNotEmpty) {


### PR DESCRIPTION
## Summary
- ensure lesson ids collected from the database are treated as strings
- prevent Set<dynamic> from being passed into query helpers that expect string ids

## Testing
- ⚠️ `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e0fd410fd08320aff0ec669f9edd6e