### PR TITLE
Fix chunk helper indices for analyzer compatibility

### DIFF
--- a/lib/src/infrastructure/sync/sync_orchestrator.dart
+++ b/lib/src/infrastructure/sync/sync_orchestrator.dart
@@ -501,7 +501,8 @@ class SyncOrchestrator {
     }
     final result = <List<T>>[];
     for (var i = 0; i < source.length; i += size) {
-      result.add(source.sublist(i, math.min(source.length, i + size)));
+      final end = source.length < i + size ? source.length : i + size;
+      result.add(source.sublist(i, end));
     }
     return result;
   }


### PR DESCRIPTION
## Summary
- ensure the chunk helper computes integer end indices before calling `sublist`

## Testing
- not run (environment lacks Flutter/Dart SDK)


------
https://chatgpt.com/codex/tasks/task_e_68e104a26a5083209e8825a2baaf1280