### PR TITLE
Fix LessonAttachment queries casting

### DIFF
--- a/lib/src/infrastructure/db/daos/lesson_dao.dart
+++ b/lib/src/infrastructure/db/daos/lesson_dao.dart
@@ -53,9 +53,10 @@ class LessonDao {
     final scriptures = await (_db.select(_db.lessonScriptures)
           ..where((tbl) => tbl.lessonId.isIn(ids)))
         .get();
-    final attachments = await (_db.select(_db.lessonAttachments)
-          ..where((tbl) => tbl.lessonId.isIn(ids)))
-        .get();
+    final attachments = (await (_db.select(_db.lessonAttachments)
+              ..where((tbl) => tbl.lessonId.isIn(ids)))
+            .get())
+        .cast<LessonAttachmentRow>();
     final quizzes = await (_db.select(_db.lessonQuizzes)
           ..where((tbl) => tbl.lessonId.isIn(ids)))
         .get();
@@ -89,9 +90,10 @@ class LessonDao {
     final scriptures = await (_db.select(_db.lessonScriptures)
           ..where((tbl) => tbl.lessonId.equals(id)))
         .get();
-    final attachments = await (_db.select(_db.lessonAttachments)
-          ..where((tbl) => tbl.lessonId.equals(id)))
-        .get();
+    final attachments = (await (_db.select(_db.lessonAttachments)
+              ..where((tbl) => tbl.lessonId.equals(id)))
+            .get())
+        .cast<LessonAttachmentRow>();
     final quizzes = await (_db.select(_db.lessonQuizzes)
           ..where((tbl) => tbl.lessonId.equals(id)))
         .get();

--- a/lib/src/infrastructure/lessons/lesson_attachment_cache.dart
+++ b/lib/src/infrastructure/lessons/lesson_attachment_cache.dart
@@ -51,9 +51,10 @@ class LessonAttachmentCache {
     }
 
     final List<LessonAttachmentRow> attachments =
-        await (_db.select(_db.lessonAttachments)
-              ..where((tbl) => tbl.lessonId.isIn(ids.toList())))
-            .get();
+        (await (_db.select(_db.lessonAttachments)
+                  ..where((tbl) => tbl.lessonId.isIn(ids.toList())))
+                .get())
+            .cast<LessonAttachmentRow>();
     if (attachments.isEmpty) {
       final usage = await _currentUsage();
       return AttachmentCacheSummary.empty.copyWith(totalBytes: usage);
@@ -139,10 +140,11 @@ class LessonAttachmentCache {
       return 0;
     }
     final List<LessonAttachmentRow> attachments =
-        await (_db.select(_db.lessonAttachments)
-              ..where((tbl) => tbl.localPath.isNotNull())
-              ..orderBy([(tbl) => OrderingTerm(expression: tbl.downloadedAt)]))
-            .get();
+        (await (_db.select(_db.lessonAttachments)
+                  ..where((tbl) => tbl.localPath.isNotNull())
+                  ..orderBy([(tbl) => OrderingTerm(expression: tbl.downloadedAt)]))
+                .get())
+            .cast<LessonAttachmentRow>();
 
     var total = 0;
     final toDelete = <LessonAttachmentRow>[];
@@ -179,9 +181,10 @@ class LessonAttachmentCache {
 
   Future<int> _evictMissingFiles() async {
     final List<LessonAttachmentRow> attachments =
-        await (_db.select(_db.lessonAttachments)
-              ..where((tbl) => tbl.localPath.isNotNull()))
-            .get();
+        (await (_db.select(_db.lessonAttachments)
+                  ..where((tbl) => tbl.localPath.isNotNull()))
+                .get())
+            .cast<LessonAttachmentRow>();
 
     var removed = 0;
     for (final attachment in attachments) {
@@ -211,9 +214,10 @@ class LessonAttachmentCache {
 
   Future<int> _currentUsage() async {
     final List<LessonAttachmentRow> attachments =
-        await (_db.select(_db.lessonAttachments)
-              ..where((tbl) => tbl.sizeBytes.isNotNull()))
-            .get();
+        (await (_db.select(_db.lessonAttachments)
+                  ..where((tbl) => tbl.sizeBytes.isNotNull()))
+                .get())
+            .cast<LessonAttachmentRow>();
     return attachments.fold<int>(
       0,
       (int sum, LessonAttachmentRow item) => sum + (item.sizeBytes ?? 0),


### PR DESCRIPTION
## Summary
- ensure lesson attachment queries explicitly cast attachment rows when using the stub database bindings

## Testing
- not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e116b7c9c483208047116afe69eacf