### PR TITLE
Fix drift customSelect variable types

### DIFF
--- a/lib/src/infrastructure/db/daos/bible_dao.dart
+++ b/lib/src/infrastructure/db/daos/bible_dao.dart
@@ -91,11 +91,11 @@ class BibleDao {
       ..writeln('ORDER BY rank ASC, v.book_id ASC, v.chapter ASC, v.verse ASC')
       ..writeln('LIMIT ?');
 
-    final variables = <Variable<dynamic>>[
-      Variable<String>(translationId),
-      Variable<String>(matchQuery),
-      if (bookId != null) Variable<int>(bookId),
-      Variable<int>(limit ?? 50),
+    final variables = <Variable<Object?>>[
+      Variable<Object?>(translationId),
+      Variable<Object?>(matchQuery),
+      if (bookId != null) Variable<Object?>(bookId),
+      Variable<Object?>(limit ?? 50),
     ];
 
     final rows = await _db.customSelect(


### PR DESCRIPTION
## Summary
- adjust the bible DAO full-text search query to use `Variable<Object?>` values so the custom select compiles with the latest drift API

## Testing
- flutter --version *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e1224bb0808320b06c535b91f9b200