### PR TITLE
Fix migration custom statements

### DIFF
--- a/lib/src/infrastructure/db/app_database.dart
+++ b/lib/src/infrastructure/db/app_database.dart
@@ -587,15 +587,15 @@ class AppDatabase extends _$AppDatabase {
             await m.addColumn(localUsers, localUsers.preferredCohortTitle);
             await m.addColumn(localUsers, localUsers.preferredLessonClass);
             await m.addColumn(localUsers, localUsers.isActive);
-            await m.customStatement(
+            await m.database.customStatement(
                 "UPDATE local_users SET is_active = CASE WHEN id = 'local-user' THEN 1 ELSE 0 END");
-            await m.customStatement(
+            await m.database.customStatement(
                 "INSERT INTO local_users (id, display_name, avatar_url, preferred_cohort_id, preferred_cohort_title, preferred_lesson_class, is_active) SELECT 'local-user', NULL, NULL, NULL, NULL, NULL, 1 WHERE NOT EXISTS (SELECT 1 FROM local_users WHERE id = 'local-user')");
-            await m.customStatement(
+            await m.database.customStatement(
                 "UPDATE bookmarks SET user_id = 'local-user' WHERE user_id IS NULL");
-            await m.customStatement(
+            await m.database.customStatement(
                 "UPDATE highlights SET user_id = 'local-user' WHERE user_id IS NULL");
-            await m.customStatement(
+            await m.database.customStatement(
                 "UPDATE notes SET user_id = 'local-user' WHERE user_id IS NULL");
           }
           if (from < 8) {


### PR DESCRIPTION
## Summary
- update database migration to call custom SQL through the database instance so it compiles with the current drift Migrator API

## Testing
- `flutter analyze` *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1249d0b1c8320b5b78a7e8a93e910