### PR TITLE
Fix lesson source registry insertable type

### DIFF
--- a/lib/src/infrastructure/lessons/lesson_source_registry.dart
+++ b/lib/src/infrastructure/lessons/lesson_source_registry.dart
@@ -9,8 +9,9 @@ import 'package:flutter/services.dart';
 import '../db/app_database.dart';
 import 'lesson_sync_constants.dart';
 
-Insertable<dynamic> _lessonSourceInsertable(LessonSourcesCompanion companion) =>
-    companion as dynamic;
+Insertable<LessonSourceRow> _lessonSourceInsertable(
+        LessonSourcesCompanion companion) =>
+    companion;
 
 class LessonSourceType {
   const LessonSourceType._();


### PR DESCRIPTION
## Summary
- update the lesson source registry helper to return an Insertable<LessonSourceRow>
- ensure drift insert/update calls receive the correctly typed companion

## Testing
- not run (dart command not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e12516da4083208001de0ff2de4809