### PR TITLE
Fix sync tracker companion types

### DIFF
--- a/lib/src/data/sync/sync_repository_impl.dart
+++ b/lib/src/data/sync/sync_repository_impl.dart
@@ -1,7 +1,5 @@
 import 'dart:convert';
 
-import 'dart:convert';
-
 import 'package:drift/drift.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:uuid/uuid.dart';
@@ -85,9 +83,9 @@ class SyncRepositoryImpl implements SyncRepository {
       _dao.watchProgressConflicts(),
       _dao.watchMessageConflicts(),
       (
-        List<NoteChangeTrackerData> noteRows,
-        List<ProgressChangeTrackerData> progressRows,
-        List<MessageChangeTrackerData> messageRows,
+        List<NoteChangeTracker> noteRows,
+        List<ProgressChangeTracker> progressRows,
+        List<MessageChangeTracker> messageRows,
       ) {
         final conflicts = <SyncConflict>[];
         conflicts.addAll(noteRows.map(_mapNoteConflict));
@@ -117,7 +115,7 @@ class SyncRepositoryImpl implements SyncRepository {
         .toList();
   }
 
-  SyncConflict _mapNoteConflict(NoteChangeTrackerData row) {
+  SyncConflict _mapNoteConflict(NoteChangeTracker row) {
     return SyncConflict(
       entityType: SyncEntityType.note,
       entityId: row.noteId,
@@ -128,7 +126,7 @@ class SyncRepositoryImpl implements SyncRepository {
     );
   }
 
-  SyncConflict _mapProgressConflict(ProgressChangeTrackerData row) {
+  SyncConflict _mapProgressConflict(ProgressChangeTracker row) {
     return SyncConflict(
       entityType: SyncEntityType.progress,
       entityId: row.progressId,
@@ -139,7 +137,7 @@ class SyncRepositoryImpl implements SyncRepository {
     );
   }
 
-  SyncConflict _mapMessageConflict(MessageChangeTrackerData row) {
+  SyncConflict _mapMessageConflict(MessageChangeTracker row) {
     return SyncConflict(
       entityType: SyncEntityType.message,
       entityId: row.messageId,

--- a/lib/src/infrastructure/db/daos/sync_dao.dart
+++ b/lib/src/infrastructure/db/daos/sync_dao.dart
@@ -99,8 +99,8 @@ class SyncDao {
             NoteChangeTrackersCompanion.insert(
               noteId: noteId,
               userId: userId,
-              localUpdatedAt: localUpdatedAt,
-              lastOperation: operation,
+              localUpdatedAt: Value(localUpdatedAt),
+              lastOperation: Value(operation),
             ),
             mode: InsertMode.insertOrReplace,
           );
@@ -135,8 +135,8 @@ class SyncDao {
             ProgressChangeTrackersCompanion.insert(
               progressId: progressId,
               userId: userId,
-              localUpdatedAt: localUpdatedAt,
-              lastOperation: operation,
+              localUpdatedAt: Value(localUpdatedAt),
+              lastOperation: Value(operation),
             ),
             mode: InsertMode.insertOrReplace,
           );
@@ -171,8 +171,8 @@ class SyncDao {
             MessageChangeTrackersCompanion.insert(
               messageId: messageId,
               userId: userId,
-              localUpdatedAt: localUpdatedAt,
-              lastOperation: operation,
+              localUpdatedAt: Value(localUpdatedAt),
+              lastOperation: Value(operation),
             ),
             mode: InsertMode.insertOrReplace,
           );
@@ -342,19 +342,19 @@ class SyncDao {
     );
   }
 
-  Stream<List<NoteChangeTrackerData>> watchNoteConflicts() {
+  Stream<List<NoteChangeTracker>> watchNoteConflicts() {
     final query = _db.select(_db.noteChangeTrackers)
       ..where((tbl) => tbl.status.equals('conflict'));
     return query.watch();
   }
 
-  Stream<List<ProgressChangeTrackerData>> watchProgressConflicts() {
+  Stream<List<ProgressChangeTracker>> watchProgressConflicts() {
     final query = _db.select(_db.progressChangeTrackers)
       ..where((tbl) => tbl.status.equals('conflict'));
     return query.watch();
   }
 
-  Stream<List<MessageChangeTrackerData>> watchMessageConflicts() {
+  Stream<List<MessageChangeTracker>> watchMessageConflicts() {
     final query = _db.select(_db.messageChangeTrackers)
       ..where((tbl) => tbl.status.equals('conflict'));
     return query.watch();


### PR DESCRIPTION
## Summary
- fix conflict watcher stream types to use generated data classes
- wrap inserted values in Value objects when creating change tracker companions
- remove redundant import and update conflict mapping helpers to match new types

## Testing
- dart analyze *(fails: dart not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e129103a6c8320851f98c335b6041e