### PR TITLE
Fix sync queue count expression

### DIFF
--- a/lib/src/infrastructure/db/daos/sync_dao.dart
+++ b/lib/src/infrastructure/db/daos/sync_dao.dart
@@ -14,9 +14,10 @@ class SyncDao {
   }
 
   Future<int> queueCount() async {
-    final query = _db.selectOnly(_db.syncQueue)..addColumns([_db.syncQueue.id.count()]);
+    final countExpression = _db.syncQueue.id.count();
+    final query = _db.selectOnly(_db.syncQueue)..addColumns([countExpression]);
     final result = await query.getSingle();
-    return result.read<int>('COUNT(*)') ?? 0;
+    return result.read<int?>(countExpression) ?? 0;
   }
 
   Future<List<SyncQueueData>> pendingOps({int limit = 50}) {


### PR DESCRIPTION
## Summary
- use a dedicated count expression when reading the sync queue row count
- read the count value via the expression instead of a raw column name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e12a1a19348320b2a1811e2e244d02