### PR TITLE
Fix Apple sign-in failure message

### DIFF
--- a/lib/src/infrastructure/accounts/firebase_auth_service.dart
+++ b/lib/src/infrastructure/accounts/firebase_auth_service.dart
@@ -117,7 +117,7 @@ class FirebaseAuthService {
       if (error.code == AuthorizationErrorCode.canceled) {
         throw const AuthException('Apple sign-in was cancelled.');
       }
-      throw AuthException('Apple sign-in failed: ${error.localizedDescription ?? error.code.name}');
+      throw AuthException('Apple sign-in failed: ${error.message ?? error.code.name}');
     } on FirebaseAuthException catch (error) {
       throw AuthException(_mapError(error));
     }


### PR DESCRIPTION
## Summary
- replace use of the removed `localizedDescription` property when reporting Apple sign-in failures
- fall back to the exception message or code name provided by the plugin

## Testing
- flutter analyze *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e12a93d4ac832092a8a8f9a1651e2e