### PR TITLE
Fix sync queue count read type

### DIFF
--- a/lib/src/infrastructure/db/daos/sync_dao.dart
+++ b/lib/src/infrastructure/db/daos/sync_dao.dart
@@ -17,7 +17,7 @@ class SyncDao {
     final countExpression = _db.syncQueue.id.count();
     final query = _db.selectOnly(_db.syncQueue)..addColumns([countExpression]);
     final result = await query.getSingle();
-    return result.read<int?>(countExpression) ?? 0;
+    return result.read<int>(countExpression);
   }
 
   Future<List<SyncQueueData>> pendingOps({int limit = 50}) {


### PR DESCRIPTION
## Summary
- update the sync queue count query to read a non-nullable integer value

## Testing
- not run (missing Flutter/Dart SDK in container)


------
https://chatgpt.com/codex/tasks/task_e_68e12b1462188320ab6b7789e1907a91