### PR TITLE
Fix import package checksum and extraction

### DIFF
--- a/lib/src/domain/bible/import/import_bible_package_usecase.dart
+++ b/lib/src/domain/bible/import/import_bible_package_usecase.dart
@@ -44,7 +44,6 @@ class ImportBiblePackageUseCase {
       await ZipFile.extractToDirectory(
         zipFile: packageFile,
         destinationDir: tempDir,
-        allowWrite: true,
       );
 
       final manifestFile = File(p.join(tempDir.path, 'manifest.json'));
@@ -180,14 +179,8 @@ class ImportBiblePackageUseCase {
   }
 
   Future<String> _computeChecksum(File file) async {
-    final sink = crypto.AccumulatorSink<crypto.Digest>();
-    final input = crypto.sha256.startChunkedConversion(sink);
-    final stream = file.openRead();
-    await for (final chunk in stream) {
-      input.add(chunk);
-    }
-    input.close();
-    return sink.events.single.toString();
+    final digest = await crypto.sha256.bind(file.openRead()).first;
+    return digest.toString();
   }
 
   Future<List<BibleVerse>> _parsePayload({


### PR DESCRIPTION
## Summary
- remove the unsupported `allowWrite` flag when extracting bible packages
- update checksum calculation to use the crypto stream API instead of `AccumulatorSink`

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e12b5fc0388320b3f5970565bac45d