### PR TITLE
Handle null queue count result

### DIFF
--- a/lib/src/infrastructure/db/daos/sync_dao.dart
+++ b/lib/src/infrastructure/db/daos/sync_dao.dart
@@ -17,7 +17,7 @@ class SyncDao {
     final countExpression = _db.syncQueue.id.count();
     final query = _db.selectOnly(_db.syncQueue)..addColumns([countExpression]);
     final result = await query.getSingle();
-    return result.read<int>(countExpression);
+    return result.read<int>(countExpression) ?? 0;
   }
 
   Future<List<SyncQueueData>> pendingOps({int limit = 50}) {


### PR DESCRIPTION
## Summary
- ensure the queue count query returns zero when the count expression is null

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e12bf386a88320bbdb388549ba91b6