### PR TITLE
Fix missing Value import in roundtable repository

### DIFF
--- a/lib/src/data/lessons/roundtable_repository_impl.dart
+++ b/lib/src/data/lessons/roundtable_repository_impl.dart
@@ -1,3 +1,5 @@
+import 'package:drift/drift.dart';
+
 import '../../domain/lessons/entities.dart';
 import '../../domain/lessons/repositories.dart';
 import '../../domain/meetings/entities.dart';


### PR DESCRIPTION
## Summary
- add the drift import needed to access `Value` when constructing roundtable events

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e12d7f901c8320bb1b56ab4ae23aa8