### PR TITLE
Fix LessonAttachmentsCompanion reference in repository

### DIFF
--- a/lib/src/data/lessons/lesson_repository_impl.dart
+++ b/lib/src/data/lessons/lesson_repository_impl.dart
@@ -277,7 +277,7 @@ class LessonRepositoryImpl implements LessonRepository {
         .getSingleOrNull();
     final nextPosition = (existing?.position ?? -1) + 1;
     await _db.into(_db.lessonAttachments).insertOnConflictUpdate(
-          LessonAttachmentsCompanion(
+          db.LessonAttachmentsCompanion(
             lessonId: Value(lessonId),
             position: Value(nextPosition),
             type: Value(_mapAttachmentTypeToString(attachment.type)),


### PR DESCRIPTION
## Summary
- reference the generated LessonAttachmentsCompanion via the database alias to resolve the undefined method error when adding attachments

## Testing
- flutter analyze *(fails: Flutter SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e12d9a89a083209b8c9bf4b9f33aeb