### PR TITLE
Fix missing Value import in discussion forum repository

### DIFF
--- a/lib/src/data/lessons/discussion_forum_repository_impl.dart
+++ b/lib/src/data/lessons/discussion_forum_repository_impl.dart
@@ -1,3 +1,5 @@
+import 'package:drift/drift.dart' show Value;
+
 import '../../domain/lessons/entities.dart';
 import '../../domain/lessons/repositories.dart';
 import '../../domain/sync/entities.dart';


### PR DESCRIPTION
## Summary
- import the Drift Value helper in the discussion forum repository implementation so generated companions compile

## Testing
- flutter analyze *(fails: Flutter SDK not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e12db418c88320a52a3c5e0c41ead9