### PR TITLE
Fix timestamp parsing helper visibility

### DIFF
--- a/lib/src/data/chat/chat_remote_data_source.dart
+++ b/lib/src/data/chat/chat_remote_data_source.dart
@@ -357,17 +357,17 @@ class ChatRemoteDataSource {
         .doc(appeal.id)
         .set(appeal.toMap(), SetOptions(merge: true));
   }
+}
 
-  static DateTime _fromTimestamp(dynamic value) {
-    if (value is Timestamp) {
-      return value.toDate().toUtc();
-    }
-    if (value is DateTime) {
-      return value.toUtc();
-    }
-    if (value is int) {
-      return DateTime.fromMillisecondsSinceEpoch(value, isUtc: true);
-    }
-    return DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
+DateTime _fromTimestamp(dynamic value) {
+  if (value is Timestamp) {
+    return value.toDate().toUtc();
   }
+  if (value is DateTime) {
+    return value.toUtc();
+  }
+  if (value is int) {
+    return DateTime.fromMillisecondsSinceEpoch(value, isUtc: true);
+  }
+  return DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
 }


### PR DESCRIPTION
## Summary
- move the shared timestamp conversion helper out of the data source class
- ensure remote chat entities can deserialize Firestore timestamps consistently

## Testing
- flutter analyze *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e12fca77948320a7ff0efe4664f699