### PR TITLE
Fix Bible verse watcher using verse text

### DIFF
--- a/lib/src/data/bible/bible_repository_impl.dart
+++ b/lib/src/data/bible/bible_repository_impl.dart
@@ -92,15 +92,15 @@ class BibleRepositoryImpl implements BibleRepository {
     yield* _dao.watchChapter(translationId, bookId, chapter).map(
       (rows) => rows
           .map(
-            (row) => BibleVerse(
-              translationId: row.translationId,
-              bookId: row.bookId,
-              chapter: row.chapter,
-              verse: row.verse,
-              text: row.text,
-            ),
-          )
-          .toList(),
+          (row) => BibleVerse(
+            translationId: row.translationId,
+            bookId: row.bookId,
+            chapter: row.chapter,
+            verse: row.verse,
+            text: row.verseText,
+          ),
+        )
+        .toList(),
     );
   }
 


### PR DESCRIPTION
## Summary
- ensure watched bible verses map use the verseText column when constructing BibleVerse models

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1301883488320920134c5c58bbf44