### PR TITLE
Fix note companion version value usage

### DIFF
--- a/lib/src/data/bible/annotation_repository_impl.dart
+++ b/lib/src/data/bible/annotation_repository_impl.dart
@@ -207,7 +207,7 @@ class AnnotationRepositoryImpl implements AnnotationRepository {
           chapter: location.chapter,
           verse: location.verse,
           noteText: text,
-          version: 1,
+          version: const Value(1),
           updatedAt: now.millisecondsSinceEpoch,
         ),
       );


### PR DESCRIPTION
## Summary
- wrap the note version passed to `NotesCompanion.insert` in a `Value` to match the generated Drift API

## Testing
- not run (platform missing dart/flutter)

------
https://chatgpt.com/codex/tasks/task_e_68e131f181d48320942acc66d9c7419f