### PR TITLE
Fix Android manifest activity reference

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity
-            android:name=".MainActivity"
+            android:name="org.afc.studymate.MainActivity"
             android:exported="true"
             android:launchMode="singleTop"
             android:taskAffinity=""


### PR DESCRIPTION
## Summary
- update the Android manifest to reference MainActivity with its fully-qualified name so it resolves correctly when using the Gradle namespace configuration

## Testing
- not run (tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e14973e2808320b59302eee97d28ef