### PR TITLE
Fix import ordering in Windows bridge

### DIFF
--- a/third_party/quill_native_bridge_windows/lib/quill_native_bridge_windows.dart
+++ b/third_party/quill_native_bridge_windows/lib/quill_native_bridge_windows.dart
@@ -10,6 +10,11 @@ import 'package:flutter/foundation.dart';
 import 'package:quill_native_bridge_platform_interface/quill_native_bridge_platform_interface.dart';
 import 'package:win32/win32.dart';
 
+import 'src/clipboard_html_format.dart';
+import 'src/html_cleaner.dart';
+import 'src/html_formatter.dart';
+import 'src/image_saver.dart';
+
 /// Flag indicating that the allocated memory can be moved in physical memory.
 ///
 /// The upstream package previously relied on the [GMEM_MOVEABLE] constant from
@@ -18,11 +23,6 @@ import 'package:win32/win32.dart';
 /// constant locally keeps the behaviour intact while restoring compatibility
 /// with recent `win32` releases.
 const int _kGlobalAllocMoveable = 0x0002;
-
-import 'src/clipboard_html_format.dart';
-import 'src/html_cleaner.dart';
-import 'src/html_formatter.dart';
-import 'src/image_saver.dart';
 
 /// A Windows implementation of the [QuillNativeBridgePlatform].
 ///


### PR DESCRIPTION
## Summary
- ensure all import directives precede constant declarations in the Windows bridge implementation
- group package and local imports to satisfy Dart analyzer requirements during Flutter builds

## Testing
- flutter analyze *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e14e31ce808320933178641b08e4a8