### PR TITLE
Fix Android USB camera dependency resolution

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -3,6 +3,7 @@ buildscript {
         google()
         mavenCentral()
         maven(url = "https://github.com/jitsi/jitsi-maven-repository/raw/master/releases")
+        maven(url = "https://jitpack.io")
     }
     dependencies {
         classpath("com.google.gms:google-services:4.4.2")
@@ -14,8 +15,11 @@ allprojects {
         google()
         mavenCentral()
         maven(url = "https://github.com/jitsi/jitsi-maven-repository/raw/master/releases")
+        maven(url = "https://jitpack.io")
     }
 }
+
+val usbCameraVersion = "3.3.3"
 
 val newBuildDir: Directory =
     rootProject.layout.buildDirectory
@@ -29,6 +33,17 @@ subprojects {
 }
 subprojects {
     project.evaluationDependsOn(":app")
+}
+
+subprojects {
+    configurations.all {
+        resolutionStrategy.dependencySubstitution {
+            substitute(module("com.github.jiangdongguo.AndroidUSBCamera:libnative"))
+                .using(module("com.github.jiangdongguo.androidusbcamera:libnative:$usbCameraVersion"))
+            substitute(module("com.github.jiangdongguo.AndroidUSBCamera:libuvc"))
+                .using(module("com.github.jiangdongguo.androidusbcamera:libuvc:$usbCameraVersion"))
+        }
+    }
 }
 
 tasks.register<Delete>("clean") {


### PR DESCRIPTION
## Summary
- add the JitPack repository to the Android build so USB camera artifacts can be resolved
- substitute the broken USB camera coordinates with the lowercase variants published on JitPack

## Testing
- `./gradlew checkDebugAarMetadata` *(fails: wrapper not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e17093219883209b88cfee380c6b51