### PR TITLE
Fix Android USB camera dependency resolution

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -42,6 +42,8 @@ subprojects {
                 .using(module("com.github.jiangdongguo.androidusbcamera:libnative:$usbCameraVersion"))
             substitute(module("com.github.jiangdongguo.AndroidUSBCamera:libuvc"))
                 .using(module("com.github.jiangdongguo.androidusbcamera:libuvc:$usbCameraVersion"))
+            substitute(module("com.github.jiangdongguo.AndroidUSBCamera:libausbc"))
+                .using(module("com.github.jiangdongguo.androidusbcamera:libausbc:$usbCameraVersion"))
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a dependency substitution so the AndroidUSBCamera libausbc artifact resolves from the lowercase repository path

## Testing
- N/A (Gradle wrapper is not present in the repository)


------
https://chatgpt.com/codex/tasks/task_e_68e179b241188320a990dff378c0ab46