### PR TITLE
Enable core library desugaring for Android app

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -23,6 +23,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
@@ -51,4 +52,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
 }


### PR DESCRIPTION
## Summary
- enable core library desugaring in the Android module to satisfy flutter_local_notifications requirements
- add the desugar_jdk_libs dependency so the Gradle build can process Java 8+ APIs

## Testing
- Not run (Android Gradle wrapper not included in repo)


------
https://chatgpt.com/codex/tasks/task_e_68e17cdfca788320a8fd7852c885038b