### PR TITLE
chore: upgrade workmanager dependency to 0.9.0+3

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1677,10 +1677,10 @@ packages:
     dependency: "direct main"
     description:
       name: workmanager
-      sha256: ed13530cccd28c5c9959ad42d657cd0666274ca74c56dea0ca183ddd527d3a00
+      sha256: "065673b2a465865183093806925419d311a9a5e0995aa74ccf8920fd695e2d10"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.2"
+    version: "0.9.0+3"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   file_picker: ^8.1.2
   crypto: ^3.0.3
   rxdart: ^0.28.0
-  workmanager: ^0.5.2
+  workmanager: ^0.9.0+3
   firebase_core: ^3.11.0
   firebase_auth: ^5.2.1
   firebase_storage: ^12.4.1


### PR DESCRIPTION
## Summary
- update the workmanager dependency to the latest 0.9.0+3 release to fix Android compilation errors with newer toolchains

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e18e99aac08320b6b783c23ace028d