### PR TITLE
Fix workmanager periodic work policy usage

### DIFF
--- a/lib/src/infrastructure/lessons/lesson_sync_service.dart
+++ b/lib/src/infrastructure/lessons/lesson_sync_service.dart
@@ -61,7 +61,7 @@ class LessonSyncService {
         kLessonSyncBackgroundTask,
         frequency: const Duration(hours: 6),
         initialDelay: const Duration(minutes: 15),
-        existingWorkPolicy: ExistingWorkPolicy.keep,
+        existingWorkPolicy: ExistingPeriodicWorkPolicy.keep,
         constraints: Constraints(
           networkType: NetworkType.connected,
         ),

--- a/lib/src/infrastructure/sync/sync_orchestrator.dart
+++ b/lib/src/infrastructure/sync/sync_orchestrator.dart
@@ -80,7 +80,7 @@ class SyncOrchestrator {
         kDataSyncBackgroundTask,
         frequency: const Duration(hours: 1),
         initialDelay: const Duration(minutes: 10),
-        existingWorkPolicy: ExistingWorkPolicy.keep,
+        existingWorkPolicy: ExistingPeriodicWorkPolicy.keep,
         backoffPolicy: BackoffPolicy.exponential,
         backoffPolicyDelay: const Duration(minutes: 5),
         constraints: Constraints(


### PR DESCRIPTION
## Summary
- update background task scheduling to use the new `ExistingPeriodicWorkPolicy.keep` enum when registering periodic background tasks

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e193732bec832095d3f21929875c41