### PR TITLE
Fix iOS notification date interpretation constant

### DIFF
--- a/lib/src/infrastructure/notifications/notification_service.dart
+++ b/lib/src/infrastructure/notifications/notification_service.dart
@@ -179,7 +179,7 @@ class NotificationService {
       notificationDetails,
       androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
       uiLocalNotificationDateInterpretation:
-          UILocalNotificationDateInterpretation.absoluteTime,
+          DarwinNotificationDateInterpretation.absoluteTime,
       matchDateTimeComponents: DateTimeComponents.dateAndTime,
     );
   }
@@ -217,7 +217,7 @@ class NotificationService {
       notificationDetails,
       androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
       uiLocalNotificationDateInterpretation:
-          UILocalNotificationDateInterpretation.absoluteTime,
+          DarwinNotificationDateInterpretation.absoluteTime,
       matchDateTimeComponents: DateTimeComponents.dateAndTime,
     );
   }


### PR DESCRIPTION
## Summary
- replace deprecated UILocalNotificationDateInterpretation with DarwinNotificationDateInterpretation for zoned schedules on iOS

## Testing
- flutter analyze *(fails: Flutter SDK unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e193ae80a88320a61d92f6d5816ea1