### PR TITLE
Remove deprecated iOS notification interpretation parameter

### DIFF
--- a/lib/src/infrastructure/notifications/notification_service.dart
+++ b/lib/src/infrastructure/notifications/notification_service.dart
@@ -178,8 +178,6 @@ class NotificationService {
       tz.TZDateTime.from(reminderTime, tz.local),
       notificationDetails,
       androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
-      uiLocalNotificationDateInterpretation:
-          DarwinNotificationDateInterpretation.absoluteTime,
       matchDateTimeComponents: DateTimeComponents.dateAndTime,
     );
   }
@@ -216,8 +214,6 @@ class NotificationService {
       tz.TZDateTime.from(reminderTime, tz.local),
       notificationDetails,
       androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
-      uiLocalNotificationDateInterpretation:
-          DarwinNotificationDateInterpretation.absoluteTime,
       matchDateTimeComponents: DateTimeComponents.dateAndTime,
     );
   }


### PR DESCRIPTION
## Summary
- remove usage of `uiLocalNotificationDateInterpretation` and the obsolete `DarwinNotificationDateInterpretation` enum when scheduling local notifications
- rely on `matchDateTimeComponents` for scheduling behaviour while keeping the existing Android scheduling mode

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e19507aee88320b3e87b3a630ea5e4