### PR TITLE
Update desugar_jdk_libs version for Android build

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -55,5 +55,5 @@ flutter {
 }
 
 dependencies {
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }


### PR DESCRIPTION
## Summary
- bump `com.android.tools:desugar_jdk_libs` to version 2.1.4 to satisfy plugin requirements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e19ccaf2248320a7396d26abcbeae6