### PR TITLE
Increase Android minSdk to 26 for Jitsi SDK

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         applicationId = "org.afc.studymate"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = maxOf(flutter.minSdkVersion, 24)
+        minSdk = maxOf(flutter.minSdkVersion, 26)
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName


### PR DESCRIPTION
## Summary
- raise the Android minSdk configuration to 26 to satisfy the Jitsi Meet SDK requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e19f7f9f9c83208258c9e6415145a5