### PR TITLE
Remove deprecated iOS notification parameter

### DIFF
--- a/lib/data/services/notification_service.dart
+++ b/lib/data/services/notification_service.dart
@@ -40,7 +40,6 @@ class NotificationService {
       ),
       androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
       matchDateTimeComponents: DateTimeComponents.dayOfWeekAndTime,
-      uiLocalNotificationDateInterpretation: UILocalNotificationDateInterpretation.absoluteTime,
     );
   }
 }


### PR DESCRIPTION
## Summary
- remove the deprecated `uiLocalNotificationDateInterpretation` argument from the zoned notification scheduling call since it is no longer part of the API

## Testing
- not run (Flutter SDK is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e52ac99bec83209d3727bf48c5d16a