### PR TITLE
Fix Android build configuration for Java 8 features

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -13,6 +13,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
@@ -24,7 +25,7 @@ android {
         applicationId = "com.example.afc_studymate"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
+        minSdk = maxOf(flutter.minSdkVersion, 23)
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
@@ -41,4 +42,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.3")
 }


### PR DESCRIPTION
## Summary
- enable core library desugaring so Java 8 APIs used by dependencies compile correctly
- raise the Android minSdk to at least 23 to satisfy modern Firebase and notification plugins

## Testing
- not run (Flutter SDK unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e554a699b48320b241648664523932