### PR TITLE
Update desugar_jdk_libs dependency

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -45,5 +45,5 @@ flutter {
 }
 
 dependencies {
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.3")
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }


### PR DESCRIPTION
## Summary
- bump the core library desugaring dependency to version 2.1.4 to satisfy flutter_local_notifications requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e558d3d13c8320a32f8bbf1744a133