### PR TITLE
Specify entrypoint for VS Code debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,18 +9,21 @@
         {
             "name": "AFC-StudyMate",
             "request": "launch",
-            "type": "dart"
+            "type": "dart",
+            "program": "lib/main.dart"
         },
         {
             "name": "AFC-StudyMate (profile mode)",
             "request": "launch",
             "type": "dart",
+            "program": "lib/main.dart",
             "flutterMode": "profile"
         },
         {
             "name": "AFC-StudyMate (release mode)",
             "request": "launch",
             "type": "dart",
+            "program": "lib/main.dart",
             "flutterMode": "release"
         }
     ]


### PR DESCRIPTION
## Summary
- configure VS Code launch configurations to point to lib/main.dart for all modes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e579f6a1a083209df064eba590da18