### PR TITLE
Handle Track.answer in lesson parsing

### DIFF
--- a/lib/data/drift/app_database.dart
+++ b/lib/data/drift/app_database.dart
@@ -49,12 +49,20 @@ class AppDatabase {
         final entries = (decoded['primary_pals_lessons'] as List<dynamic>? ?? <dynamic>[])
             .whereType<Map<String, dynamic>>();
         return entries.map(_mapPrimaryPalsLesson).toList();
+      case Track.answer:
+        // Answer lessons are not yet available in the local dataset.
+        return <Lesson>[];
       case Track.search:
         if (decoded is! List) {
           return <Lesson>[];
         }
         final entries = decoded.whereType<Map<String, dynamic>>();
         return entries.map(_mapSearchLesson).toList();
+      case Track.discovery:
+      case Track.daybreak:
+        // Discovery and Daybreak lessons are sourced remotely and are not part of the
+        // bundled assets yet, so we return an empty collection for now.
+        return <Lesson>[];
     }
   }
 


### PR DESCRIPTION
## Summary
- cover all `Track` variants in the local lesson parsing switch
- return an empty collection for tracks that are not yet backed by bundled assets

## Testing
- `flutter analyze` *(fails: Flutter SDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5803fd11c832090bb37a66a739c25