### PR TITLE
Add Sunday School all-lessons listing and detail navigation

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -9,6 +9,8 @@ import 'features/home/home_shell.dart';
 import 'features/onboarding/onboarding_screen.dart';
 import 'features/profile/profile_screen.dart';
 import 'features/settings/settings_screen.dart';
+import 'features/sunday_school/all_lessons/sunday_school_all_lessons_screen.dart';
+import 'features/sunday_school/all_lessons/sunday_school_lesson_detail_screen.dart';
 import 'features/sunday_school/sunday_school_screen.dart';
 import 'features/today/today_screen.dart';
 
@@ -43,6 +45,25 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                 path: '/home/sunday-school',
                 name: SundaySchoolScreen.routeName,
                 builder: (BuildContext context, GoRouterState state) => const SundaySchoolScreen(),
+                routes: <RouteBase>[
+                  GoRoute(
+                    path: 'all-lessons',
+                    name: SundaySchoolAllLessonsScreen.routeName,
+                    builder: (BuildContext context, GoRouterState state) =>
+                        const SundaySchoolAllLessonsScreen(),
+                  ),
+                  GoRoute(
+                    path: 'lessons/:lessonId',
+                    name: SundaySchoolLessonDetailScreen.routeName,
+                    builder: (BuildContext context, GoRouterState state) {
+                      final lessonId = state.pathParameters['lessonId'];
+                      if (lessonId == null) {
+                        return const SundaySchoolAllLessonsScreen();
+                      }
+                      return SundaySchoolLessonDetailScreen(lessonId: lessonId);
+                    },
+                  ),
+                ],
               ),
             ],
           ),

--- a/lib/features/sunday_school/all_lessons/sunday_school_all_lessons_screen.dart
+++ b/lib/features/sunday_school/all_lessons/sunday_school_all_lessons_screen.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../data/models/enums.dart';
+import '../../../data/models/lesson.dart';
+import '../../../data/repositories/lesson_repository.dart';
+import 'sunday_school_lesson_detail_screen.dart';
+
+class SundaySchoolAllLessonsScreen extends HookConsumerWidget {
+  const SundaySchoolAllLessonsScreen({super.key});
+
+  static const String routeName = 'sundaySchoolAllLessons';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncLessons = ref.watch(_allSundayLessonsProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('All Sunday School Lessons')),
+      body: asyncLessons.when(
+        data: (value) {
+          if (value.values.every((lessons) => lessons.isEmpty)) {
+            return const Center(child: Text('Lessons will appear here soon.'));
+          }
+          return _AllLessonsList(lessonsByTrack: value);
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stackTrace) => Center(child: Text('Something went wrong: $error')),
+      ),
+    );
+  }
+}
+
+const List<Track> _sundaySchoolTracks = <Track>[
+  Track.beginners,
+  Track.primaryPals,
+  Track.search,
+];
+
+final _allSundayLessonsProvider = FutureProvider<Map<Track, List<Lesson>>>((ref) async {
+  final repository = ref.read(lessonRepositoryProvider);
+  final entries = await Future.wait(
+    _sundaySchoolTracks.map((Track track) async {
+      final lessons = await repository.getLessonsForTrack(track);
+      return MapEntry(track, lessons);
+    }),
+  );
+  return Map<Track, List<Lesson>>.fromEntries(entries);
+});
+
+class _AllLessonsList extends StatelessWidget {
+  const _AllLessonsList({required this.lessonsByTrack});
+
+  final Map<Track, List<Lesson>> lessonsByTrack;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: _sundaySchoolTracks.length,
+      itemBuilder: (BuildContext context, int index) {
+        final track = _sundaySchoolTracks[index];
+        final lessons = lessonsByTrack[track] ?? <Lesson>[];
+        return _TrackSection(track: track, lessons: lessons);
+      },
+    );
+  }
+}
+
+class _TrackSection extends StatelessWidget {
+  const _TrackSection({required this.track, required this.lessons});
+
+  final Track track;
+  final List<Lesson> lessons;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: const EdgeInsets.only(bottom: 16),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(_trackLabel(track), style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+            if (lessons.isEmpty)
+              Text('Lessons coming soon.', style: theme.textTheme.bodyMedium?.copyWith(color: theme.hintColor))
+            else
+              ...lessons.map((lesson) => _LessonListTile(lesson: lesson)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _LessonListTile extends StatelessWidget {
+  const _LessonListTile({required this.lesson});
+
+  final Lesson lesson;
+
+  @override
+  Widget build(BuildContext context) {
+    final subtitle = <String?>[
+      if (lesson.weekIndex != null) 'Week ${lesson.weekIndex}',
+      if (lesson.bibleReferences.isNotEmpty)
+        lesson.bibleReferences.map((ref) => ref.displayText).join('; '),
+    ].whereType<String>().join(' • ');
+
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      title: Text(lesson.title),
+      subtitle: subtitle.isEmpty ? null : Text(subtitle),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () {
+        context.pushNamed(
+          SundaySchoolLessonDetailScreen.routeName,
+          pathParameters: <String, String>{'lessonId': lesson.id},
+        );
+      },
+    );
+  }
+}
+
+String _trackLabel(Track track) {
+  switch (track) {
+    case Track.beginners:
+      return 'Beginners (Ages 2–5)';
+    case Track.primaryPals:
+      return 'Primary Pals (1st–3rd)';
+    case Track.answer:
+      return 'Answer (4th–8th)';
+    case Track.search:
+      return 'Search (High School–Adults)';
+    default:
+      final name = track.name;
+      return name[0].toUpperCase() + name.substring(1);
+  }
+}

--- a/lib/features/sunday_school/all_lessons/sunday_school_lesson_detail_screen.dart
+++ b/lib/features/sunday_school/all_lessons/sunday_school_lesson_detail_screen.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../data/models/lesson.dart';
+import '../../../data/repositories/lesson_repository.dart';
+import '../widgets/sunday_school_lesson_view.dart';
+
+class SundaySchoolLessonDetailScreen extends HookConsumerWidget {
+  const SundaySchoolLessonDetailScreen({required this.lessonId, super.key});
+
+  static const String routeName = 'sundaySchoolLessonDetail';
+
+  final String lessonId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncLesson = ref.watch(_lessonProvider(lessonId));
+    final lessonTitle = asyncLesson.maybeWhen(
+      data: (lesson) => lesson?.title,
+      orElse: () => null,
+    );
+
+    return Scaffold(
+      appBar: AppBar(title: Text(lessonTitle ?? 'Lesson details')),
+      body: asyncLesson.when(
+        data: (lesson) {
+          if (lesson == null) {
+            return const Center(child: Text('Lesson not found.'));
+          }
+          return SundaySchoolLessonView(lesson: lesson);
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stackTrace) => Center(child: Text('Something went wrong: $error')),
+      ),
+    );
+  }
+}
+
+final _lessonProvider = FutureProvider.family<Lesson?, String>((ref, lessonId) {
+  final repository = ref.read(lessonRepositoryProvider);
+  return repository.getLessonById(lessonId);
+});

--- a/lib/features/sunday_school/sunday_school_screen.dart
+++ b/lib/features/sunday_school/sunday_school_screen.dart
@@ -1,11 +1,11 @@
 import 'package:afc_studymate/data/models/enums.dart';
 import 'package:afc_studymate/data/models/lesson.dart';
 import 'package:afc_studymate/data/repositories/lesson_repository.dart';
-import 'package:afc_studymate/features/sunday_school/beginners/beginners_lesson_view.dart';
-import 'package:afc_studymate/features/sunday_school/primary_pals/primary_pals_lesson_view.dart';
-import 'package:afc_studymate/features/sunday_school/search/search_lesson_view.dart';
+import 'package:afc_studymate/features/sunday_school/all_lessons/sunday_school_all_lessons_screen.dart';
+import 'package:afc_studymate/features/sunday_school/widgets/sunday_school_lesson_view.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 class SundaySchoolScreen extends HookConsumerWidget {
   const SundaySchoolScreen({super.key});
@@ -16,17 +16,45 @@ class SundaySchoolScreen extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final asyncLesson = ref.watch(_currentLessonProvider);
 
+    void openAllLessons() => context.pushNamed(SundaySchoolAllLessonsScreen.routeName);
+
     return Scaffold(
-      appBar: AppBar(title: const Text('Sunday School')),
-      body: asyncLesson.when(
-        data: (value) {
-          if (value == null) {
-            return const Center(child: Text('Your lesson will appear here soon.'));
-          }
-          return _LessonSwitcher(lesson: value);
-        },
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (error, stackTrace) => Center(child: Text('Something went wrong: $error')),
+      appBar: AppBar(
+        title: const Text('Sunday School'),
+        actions: <Widget>[
+          IconButton(
+            tooltip: 'View all lessons',
+            icon: const Icon(Icons.library_books_outlined),
+            onPressed: openAllLessons,
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Column(
+          children: <Widget>[
+            Expanded(
+              child: asyncLesson.when(
+                data: (value) {
+                  if (value == null) {
+                    return const Center(child: Text('Your lesson will appear here soon.'));
+                  }
+                  return SundaySchoolLessonView(lesson: value);
+                },
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (error, stackTrace) => Center(child: Text('Something went wrong: $error')),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+              child: FilledButton.icon(
+                onPressed: openAllLessons,
+                icon: const Icon(Icons.library_books_outlined),
+                label: const Text('View all lessons'),
+                style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(48)),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -36,32 +64,3 @@ final _currentLessonProvider = FutureProvider<Lesson?>((ref) {
   final repository = ref.read(lessonRepositoryProvider);
   return repository.getCurrentSundayLesson(Track.beginners);
 });
-
-class _LessonSwitcher extends StatelessWidget {
-  const _LessonSwitcher({required this.lesson});
-
-  final Lesson lesson;
-
-  @override
-  Widget build(BuildContext context) {
-    switch (lesson.track) {
-      case Track.beginners:
-        return BeginnersLessonView(lesson: lesson);
-      case Track.primaryPals:
-        return PrimaryPalsLessonView(lesson: lesson);
-      case Track.search:
-        return SearchLessonView(lesson: lesson);
-      default:
-        return Padding(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            children: <Widget>[
-              Text(lesson.title, style: Theme.of(context).textTheme.headlineSmall),
-              const SizedBox(height: 16),
-              const Text('Lesson format coming soon.'),
-            ],
-          ),
-        );
-    }
-  }
-}

--- a/lib/features/sunday_school/widgets/sunday_school_lesson_view.dart
+++ b/lib/features/sunday_school/widgets/sunday_school_lesson_view.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+import '../../../data/models/enums.dart';
+import '../../../data/models/lesson.dart';
+import '../beginners/beginners_lesson_view.dart';
+import '../primary_pals/primary_pals_lesson_view.dart';
+import '../search/search_lesson_view.dart';
+
+class SundaySchoolLessonView extends StatelessWidget {
+  const SundaySchoolLessonView({required this.lesson, super.key});
+
+  final Lesson lesson;
+
+  @override
+  Widget build(BuildContext context) {
+    switch (lesson.track) {
+      case Track.beginners:
+        return BeginnersLessonView(lesson: lesson);
+      case Track.primaryPals:
+        return PrimaryPalsLessonView(lesson: lesson);
+      case Track.search:
+        return SearchLessonView(lesson: lesson);
+      default:
+        return Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(lesson.title, style: Theme.of(context).textTheme.headlineSmall),
+              const SizedBox(height: 16),
+              const Text('Lesson format coming soon.'),
+            ],
+          ),
+        );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add an all-lessons screen that lists every Sunday School class and links to lesson details
- reuse a shared SundaySchoolLessonView widget so any lesson can render its track-specific layout
- update the Sunday School home screen and router to surface the new navigation option

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68eb5add35e08320b91c7612cb7190ac