### PR TITLE
Add display text getter for Bible references

### DIFF
--- a/lib/data/models/bible_ref.dart
+++ b/lib/data/models/bible_ref.dart
@@ -45,6 +45,21 @@ class BibleRef {
     );
   }
 
+  String get displayText {
+    final buffer = StringBuffer('$book $chapter');
+
+    if (verseStart != null) {
+      buffer.write(':${verseStart!}');
+
+      final end = verseEnd;
+      if (end != null && end != verseStart) {
+        buffer.write('-$end');
+      }
+    }
+
+    return buffer.toString();
+  }
+
   @override
   int get hashCode => Object.hash(book, chapter, verseStart, verseEnd);
 


### PR DESCRIPTION
## Summary
- add a `displayText` getter to `BibleRef` for rendering human-friendly references
- ensure the getter handles optional verse ranges when present

## Testing
- flutter test *(fails: Flutter SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ebab1e03f883209aea8c01fbd030cf