### PR TITLE
Fix lesson seeding and add offline Bible reader

### DIFF
--- a/lib/data/drift/app_database.dart
+++ b/lib/data/drift/app_database.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/bible_ref.dart';
 import '../models/enums.dart';
@@ -23,6 +22,7 @@ class AppDatabase {
   final Map<String, Note> _notes = <String, Note>{};
   final Map<String, String> _settings = <String, String>{};
   final Map<String, MemoryVerse> _memoryVerses = <String, MemoryVerse>{};
+  Future<void>? _seedFuture;
 
   Future<void> importLessonsFromAsset(String assetPath, Track track) async {
     final raw = await rootBundle.loadString(assetPath);
@@ -236,16 +236,17 @@ class AppDatabase {
     return fallback;
   }
 
-  Future<void> seedFromAssets() async {
-    final prefs = await SharedPreferences.getInstance();
-    final seeded = prefs.getBool('seeded_v1') ?? false;
-    if (seeded) {
+  Future<void> seedFromAssets() {
+    return _seedFuture ??= _performSeed();
+  }
+
+  Future<void> _performSeed() async {
+    if (_lessons.isNotEmpty) {
       return;
     }
     await importLessonsFromAsset('assets/data/beginners_lessons.json', Track.beginners);
     await importLessonsFromAsset('assets/data/primary_pals_lessons.json', Track.primaryPals);
     await importLessonsFromAsset('assets/data/search_lessons.json', Track.search);
-    await prefs.setBool('seeded_v1', true);
   }
 
   Future<List<Lesson>> getLessonsByTrack(Track track) async {

--- a/lib/data/services/bible_service.dart
+++ b/lib/data/services/bible_service.dart
@@ -1,35 +1,163 @@
 import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
 
+import 'package:flutter/services.dart' show AssetBundle, rootBundle;
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:sqlite3/sqlite3.dart';
 
 import '../models/bible_ref.dart';
 import '../models/enums.dart';
 import '../models/verse.dart';
 
 final bibleServiceProvider = Provider<BibleService>((ref) {
-  return BibleService();
+  final service = BibleService();
+  ref.onDispose(service.dispose);
+  return service;
 });
 
 class BibleService {
+  BibleService({AssetBundle? bundle, Future<Directory> Function()? supportDirectoryBuilder})
+      : _bundle = bundle ?? rootBundle,
+        _supportDirectoryBuilder = supportDirectoryBuilder ?? getApplicationSupportDirectory;
+
+  final AssetBundle _bundle;
+  final Future<Directory> Function() _supportDirectoryBuilder;
+  final Map<Translation, Future<Database>> _databaseCache = <Translation, Future<Database>>{};
+
+  Future<List<String>> getBooks(Translation translation) async {
+    final db = await _databaseFor(translation);
+    final result = db.select(
+      'SELECT DISTINCT book_name_text FROM bible_verses ORDER BY book ASC',
+    );
+    return result.map((row) => row['book_name_text'] as String).toList();
+  }
+
+  Future<int> getChapterCount(String book, Translation translation) async {
+    final db = await _databaseFor(translation);
+    final result = db.select(
+      'SELECT MAX(chapter) AS chapterCount FROM bible_verses WHERE book_name_text = ?',
+      <Object?>[book],
+    );
+    if (result.isEmpty) {
+      return 0;
+    }
+    final value = result.first['chapterCount'];
+    if (value is int) {
+      return value;
+    }
+    if (value is num) {
+      return value.toInt();
+    }
+    return 0;
+  }
+
+  Future<List<Verse>> getChapter(String book, int chapter, Translation translation) async {
+    final db = await _databaseFor(translation);
+    final result = db.select(
+      'SELECT book_name_text, chapter, verse, text FROM bible_verses '
+      'WHERE book_name_text = ? AND chapter = ? ORDER BY verse ASC',
+      <Object?>[book, chapter],
+    );
+    return result
+        .map((row) => Verse(
+              row['book_name_text'] as String,
+              row['chapter'] as int,
+              row['verse'] as int,
+              row['text'] as String,
+            ))
+        .toList();
+  }
+
   Future<List<Verse>> getPassage(BibleRef ref, Translation translation) async {
-    // In this scaffold implementation we simply return a placeholder verse to
-    // demonstrate offline capability without requiring platform-specific
-    // SQLite bindings during bootstrapping. The bundled databases are still
-    // shipped with the application and can be queried once native builds are
-    // configured.
-    return <Verse>[
-      Verse(ref.book, ref.chapter, ref.verseStart ?? 1,
-          'For God so loved the world, that he gave his only begotten Son.'),
-      if ((ref.verseEnd ?? ref.verseStart ?? 1) > (ref.verseStart ?? 1))
-        Verse(ref.book, ref.chapter, (ref.verseStart ?? 1) + 1,
-            'That whosoever believeth in him should not perish, but have everlasting life.'),
-    ];
+    final db = await _databaseFor(translation);
+    final start = ref.verseStart ?? 1;
+    final end = ref.verseEnd ?? await _maxVerseInChapter(db, ref.book, ref.chapter, start);
+    final result = db.select(
+      'SELECT book_name_text, chapter, verse, text FROM bible_verses '
+      'WHERE book_name_text = ? AND chapter = ? AND verse BETWEEN ? AND ? '
+      'ORDER BY verse ASC',
+      <Object?>[ref.book, ref.chapter, start, end],
+    );
+    return result
+        .map((row) => Verse(
+              row['book_name_text'] as String,
+              row['chapter'] as int,
+              row['verse'] as int,
+              row['text'] as String,
+            ))
+        .toList();
   }
 
   Future<List<VerseSearchHit>> search(String query, Translation translation) async {
-    // This stub returns a single mock result for offline demonstration.
-    return <VerseSearchHit>[
-      VerseSearchHit(reference: 'John 3:16', preview: 'For God so loved the world...'),
-    ];
+    final db = await _databaseFor(translation);
+    final likeQuery = '%${query.trim()}%';
+    final result = db.select(
+      'SELECT book_name_text, chapter, verse, text FROM bible_verses '
+      'WHERE text LIKE ? ORDER BY book, chapter, verse LIMIT 25',
+      <Object?>[likeQuery],
+    );
+    return result
+        .map(
+          (row) => VerseSearchHit(
+            reference: '${row['book_name_text']} ${row['chapter']}:${row['verse']}',
+            preview: row['text'] as String,
+          ),
+        )
+        .toList();
+  }
+
+  Future<Database> _databaseFor(Translation translation) {
+    return _databaseCache.putIfAbsent(translation, () async {
+      final assetPath = _assetPathForTranslation(translation);
+      final directory = await _supportDirectoryBuilder();
+      final fileName = assetPath.split('/').last;
+      final file = File('${directory.path}/$fileName');
+
+      if (!await file.exists()) {
+        final data = await _bundle.load(assetPath);
+        final bytes = data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
+        await file.create(recursive: true);
+        await file.writeAsBytes(bytes, flush: true);
+      }
+
+      return sqlite3.open(file.path, mode: OpenMode.readOnly);
+    });
+  }
+
+  Future<int> _maxVerseInChapter(Database db, String book, int chapter, int fallback) async {
+    final result = db.select(
+      'SELECT MAX(verse) AS maxVerse FROM bible_verses WHERE book_name_text = ? AND chapter = ?',
+      <Object?>[book, chapter],
+    );
+    if (result.isEmpty) {
+      return fallback;
+    }
+    final value = result.first['maxVerse'];
+    if (value is int) {
+      return value;
+    }
+    if (value is num) {
+      return value.toInt();
+    }
+    return fallback;
+  }
+
+  String _assetPathForTranslation(Translation translation) {
+    switch (translation) {
+      case Translation.kjv:
+        return 'assets/db/kjv.db';
+      case Translation.shona:
+        return 'assets/db/shona_bible.db';
+    }
+  }
+
+  Future<void> dispose() async {
+    for (final future in _databaseCache.values) {
+      final db = await future;
+      db.dispose();
+    }
+    _databaseCache.clear();
   }
 }

--- a/lib/features/bible/bible_screen.dart
+++ b/lib/features/bible/bible_screen.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-import '../../data/models/bible_ref.dart';
 import '../../data/models/enums.dart';
 import '../../data/models/verse.dart';
 import '../../data/services/bible_service.dart';
@@ -13,51 +14,411 @@ class BibleScreen extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final passageAsync = ref.watch(_parallelPassageProvider);
+    final bibleService = ref.read(bibleServiceProvider);
+    final translation = useState(Translation.kjv);
+    final selectedBook = useState<String?>(null);
+    final selectedChapter = useState<int>(1);
+
+    final booksFuture = useMemoized(
+      () => bibleService.getBooks(translation.value),
+      <Object?>[translation.value],
+    );
+    final booksSnapshot = useFuture(booksFuture);
+
+    useEffect(() {
+      final books = booksSnapshot.data;
+      if (books == null || books.isEmpty) {
+        selectedBook.value = null;
+        return null;
+      }
+      if (selectedBook.value == null || !books.contains(selectedBook.value)) {
+        selectedBook.value = books.first;
+        selectedChapter.value = 1;
+      }
+      return null;
+    }, <Object?>[booksSnapshot.data]);
+
+    final chapterCountFuture = useMemoized(
+      () {
+        final book = selectedBook.value;
+        if (book == null) {
+          return Future<int>.value(0);
+        }
+        return bibleService.getChapterCount(book, translation.value);
+      },
+      <Object?>[selectedBook.value, translation.value],
+    );
+    final chapterCountSnapshot = useFuture(chapterCountFuture);
+
+    useEffect(() {
+      final count = chapterCountSnapshot.data;
+      if (count == null || count == 0) {
+        return null;
+      }
+      if (selectedChapter.value > count) {
+        selectedChapter.value = 1;
+      }
+      return null;
+    }, <Object?>[chapterCountSnapshot.data]);
+
+    final passageFuture = useMemoized(
+      () {
+        final book = selectedBook.value;
+        if (book == null) {
+          return Future<List<Verse>>.value(<Verse>[]);
+        }
+        return bibleService.getChapter(book, selectedChapter.value, translation.value);
+      },
+      <Object?>[selectedBook.value, selectedChapter.value, translation.value],
+    );
+    final passageSnapshot = useFuture(passageFuture);
+
+    final verses = passageSnapshot.data ?? <Verse>[];
+    final isLoading = booksSnapshot.connectionState != ConnectionState.done ||
+        chapterCountSnapshot.connectionState != ConnectionState.done ||
+        passageSnapshot.connectionState != ConnectionState.done;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Parallel Bible')),
-      body: passageAsync.when(
-        data: (verses) => _ParallelView(verses: verses),
-        error: (error, stackTrace) => Center(child: Text('Unable to open Bible: $error')),
-        loading: () => const Center(child: CircularProgressIndicator()),
+      appBar: AppBar(title: const Text('Bible Reader')),
+      body: Column(
+        children: <Widget>[
+          if (isLoading) const LinearProgressIndicator(minHeight: 2),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                _TranslationSelector(
+                  translation: translation.value,
+                  onChanged: (value) {
+                    translation.value = value;
+                    selectedBook.value = null;
+                    selectedChapter.value = 1;
+                  },
+                ),
+                const SizedBox(height: 12),
+                _BookSelector(
+                  snapshot: booksSnapshot,
+                  value: selectedBook.value,
+                  onChanged: (value) {
+                    selectedBook.value = value;
+                    selectedChapter.value = 1;
+                  },
+                ),
+                const SizedBox(height: 12),
+                _ChapterSelector(
+                  snapshot: chapterCountSnapshot,
+                  value: selectedChapter.value,
+                  onChanged: (value) => selectedChapter.value = value,
+                  onPrevious: () {
+                    if (selectedChapter.value > 1) {
+                      selectedChapter.value = selectedChapter.value - 1;
+                    }
+                  },
+                  onNext: () {
+                    final count = chapterCountSnapshot.data;
+                    if (count != null && selectedChapter.value < count) {
+                      selectedChapter.value = selectedChapter.value + 1;
+                    }
+                  },
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: Builder(
+              builder: (BuildContext context) {
+                if (booksSnapshot.hasError) {
+                  return _ErrorView(message: 'Unable to load books: ${booksSnapshot.error}');
+                }
+                if (chapterCountSnapshot.hasError) {
+                  return _ErrorView(
+                    message: 'Unable to load chapters for ${selectedBook.value}: ${chapterCountSnapshot.error}',
+                  );
+                }
+                if (passageSnapshot.hasError) {
+                  return _ErrorView(message: 'Unable to load passage: ${passageSnapshot.error}');
+                }
+                if (verses.isEmpty) {
+                  return const Center(child: Text('Select a book and chapter to begin reading.'));
+                }
+                return ListView.separated(
+                  padding: const EdgeInsets.all(16),
+                  itemBuilder: (BuildContext context, int index) {
+                    final verse = verses[index];
+                    return _VerseCard(verse: verse);
+                  },
+                  separatorBuilder: (_, __) => const SizedBox(height: 12),
+                  itemCount: verses.length,
+                );
+              },
+            ),
+          ),
+        ],
       ),
     );
   }
 }
 
-final _parallelPassageProvider = FutureProvider<List<Verse>>((ref) {
-  final service = ref.read(bibleServiceProvider);
-  const refRange = BibleRef(book: 'John', chapter: 3, verseStart: 16, verseEnd: 17);
-  return service.getPassage(refRange, Translation.kjv);
-});
+class _TranslationSelector extends StatelessWidget {
+  const _TranslationSelector({required this.translation, required this.onChanged});
 
-class _ParallelView extends StatelessWidget {
-  const _ParallelView({required this.verses});
-
-  final List<Verse> verses;
+  final Translation translation;
+  final ValueChanged<Translation> onChanged;
 
   @override
   Widget build(BuildContext context) {
-    return ListView.separated(
-      padding: const EdgeInsets.all(24),
-      itemBuilder: (BuildContext context, int index) {
-        final verse = verses[index];
-        return ListTile(
-          title: Text('${verse.book} ${verse.chapter}:${verse.verse}'),
-          subtitle: Text(verse.text),
-          trailing: IconButton(
-            icon: const Icon(Icons.copy),
-            onPressed: () {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text('Copied ${verse.book} ${verse.chapter}:${verse.verse} to clipboard.')),
-              );
-            },
-          ),
-        );
-      },
-      separatorBuilder: (_, __) => const Divider(),
-      itemCount: verses.length,
+    return InputDecorator(
+      decoration: const InputDecoration(labelText: 'Translation', border: OutlineInputBorder()),
+      child: DropdownButtonHideUnderline(
+        child: DropdownButton<Translation>(
+          value: translation,
+          isExpanded: true,
+          items: Translation.values
+              .map(
+                (translation) => DropdownMenuItem<Translation>(
+                  value: translation,
+                  child: Text(_translationLabel(translation)),
+                ),
+              )
+              .toList(),
+          onChanged: (value) {
+            if (value != null) {
+              onChanged(value);
+            }
+          },
+        ),
+      ),
     );
+  }
+}
+
+class _BookSelector extends StatelessWidget {
+  const _BookSelector({required this.snapshot, required this.value, required this.onChanged});
+
+  final AsyncSnapshot<List<String>> snapshot;
+  final String? value;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    if (snapshot.hasError) {
+      return _ErrorField(message: 'Could not load books.');
+    }
+    if (snapshot.connectionState != ConnectionState.done) {
+      return const _LoadingField(label: 'Book');
+    }
+
+    final books = snapshot.data ?? <String>[];
+    if (books.isEmpty) {
+      return const _ErrorField(message: 'No books available in this translation.');
+    }
+
+    return InputDecorator(
+      decoration: const InputDecoration(labelText: 'Book', border: OutlineInputBorder()),
+      child: DropdownButtonHideUnderline(
+        child: DropdownButton<String>(
+          value: value ?? books.first,
+          isExpanded: true,
+          items: books
+              .map(
+                (book) => DropdownMenuItem<String>(
+                  value: book,
+                  child: Text(book),
+                ),
+              )
+              .toList(),
+          onChanged: (selected) {
+            if (selected != null) {
+              onChanged(selected);
+            }
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _ChapterSelector extends StatelessWidget {
+  const _ChapterSelector({
+    required this.snapshot,
+    required this.value,
+    required this.onChanged,
+    required this.onPrevious,
+    required this.onNext,
+  });
+
+  final AsyncSnapshot<int> snapshot;
+  final int value;
+  final ValueChanged<int> onChanged;
+  final VoidCallback onPrevious;
+  final VoidCallback onNext;
+
+  @override
+  Widget build(BuildContext context) {
+    if (snapshot.hasError) {
+      return _ErrorField(message: 'Could not load chapters.');
+    }
+    if (snapshot.connectionState != ConnectionState.done) {
+      return const _LoadingField(label: 'Chapter');
+    }
+
+    final count = snapshot.data ?? 0;
+    if (count == 0) {
+      return const _ErrorField(message: 'No chapters available for this book.');
+    }
+
+    final chapters = List<int>.generate(count, (index) => index + 1);
+
+    return Row(
+      children: <Widget>[
+        Expanded(
+          child: InputDecorator(
+            decoration: const InputDecoration(labelText: 'Chapter', border: OutlineInputBorder()),
+            child: DropdownButtonHideUnderline(
+              child: DropdownButton<int>(
+                value: value.clamp(1, count),
+                isExpanded: true,
+                items: chapters
+                    .map(
+                      (chapter) => DropdownMenuItem<int>(
+                        value: chapter,
+                        child: Text(chapter.toString()),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (selected) {
+                  if (selected != null) {
+                    onChanged(selected);
+                  }
+                },
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 12),
+        IconButton.filledTonal(
+          icon: const Icon(Icons.chevron_left),
+          onPressed: value > 1 ? onPrevious : null,
+          tooltip: 'Previous chapter',
+        ),
+        const SizedBox(width: 8),
+        IconButton.filledTonal(
+          icon: const Icon(Icons.chevron_right),
+          onPressed: value < count ? onNext : null,
+          tooltip: 'Next chapter',
+        ),
+      ],
+    );
+  }
+}
+
+class _VerseCard extends StatelessWidget {
+  const _VerseCard({required this.verse});
+
+  final Verse verse;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: Text(
+                    '${verse.book} ${verse.chapter}:${verse.verse}',
+                    style: theme.textTheme.titleMedium,
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.copy),
+                  tooltip: 'Copy verse',
+                  onPressed: () {
+                    Clipboard.setData(
+                      ClipboardData(text: '${verse.book} ${verse.chapter}:${verse.verse} — ${verse.text}'),
+                    );
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text('Copied ${verse.book} ${verse.chapter}:${verse.verse}'),
+                      ),
+                    );
+                  },
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            SelectableText(
+              verse.text,
+              style: theme.textTheme.bodyLarge,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(message, textAlign: TextAlign.center),
+      ),
+    );
+  }
+}
+
+class _ErrorField extends StatelessWidget {
+  const _ErrorField({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return InputDecorator(
+      decoration: const InputDecoration(border: OutlineInputBorder()),
+      child: Text(message, style: Theme.of(context).textTheme.bodyMedium),
+    );
+  }
+}
+
+class _LoadingField extends StatelessWidget {
+  const _LoadingField({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return InputDecorator(
+      decoration: InputDecoration(labelText: label, border: const OutlineInputBorder()),
+      child: const SizedBox(
+        height: 40,
+        child: Align(
+          alignment: Alignment.centerLeft,
+          child: SizedBox(width: 24, height: 24, child: CircularProgressIndicator(strokeWidth: 2)),
+        ),
+      ),
+    );
+  }
+}
+
+String _translationLabel(Translation translation) {
+  switch (translation) {
+    case Translation.kjv:
+      return 'King James Version (KJV)';
+    case Translation.shona:
+      return 'Shona Bible';
   }
 }


### PR DESCRIPTION
## Summary
- ensure bundled Sunday School lessons are seeded exactly once per runtime so the "all lessons" view populates reliably
- replace the placeholder Bible service with a SQLite-backed implementation that reads from the bundled KJV and Shona databases
- rebuild the Bible screen with translation/book/chapter selectors and a scrollable verse reader that supports copying verses

## Testing
- not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68ebdb60159483209c75fd53140fbbc6