### PR TITLE
Revamp Bible reader and lessons exploration UX

### DIFF
--- a/lib/data/models/bible_book.dart
+++ b/lib/data/models/bible_book.dart
@@ -1,0 +1,13 @@
+import 'package:meta/meta.dart';
+
+import 'enums.dart';
+
+@immutable
+class BibleBook {
+  const BibleBook({required this.number, required this.name});
+
+  final int number;
+  final String name;
+
+  Testament get testament => number <= 39 ? Testament.old : Testament.new;
+}

--- a/lib/data/models/enums.dart
+++ b/lib/data/models/enums.dart
@@ -3,3 +3,5 @@ enum Track { beginners, primaryPals, answer, search, discovery, daybreak }
 enum Role { learner, parent, teacher, admin, anonymous }
 
 enum Translation { kjv, shona }
+
+enum Testament { old, new }

--- a/lib/data/services/bible_service.dart
+++ b/lib/data/services/bible_service.dart
@@ -7,6 +7,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:sqlite3/sqlite3.dart';
 
+import '../models/bible_book.dart';
 import '../models/bible_ref.dart';
 import '../models/enums.dart';
 import '../models/verse.dart';
@@ -26,12 +27,19 @@ class BibleService {
   final Future<Directory> Function() _supportDirectoryBuilder;
   final Map<Translation, Future<Database>> _databaseCache = <Translation, Future<Database>>{};
 
-  Future<List<String>> getBooks(Translation translation) async {
+  Future<List<BibleBook>> getBooks(Translation translation) async {
     final db = await _databaseFor(translation);
     final result = db.select(
-      'SELECT DISTINCT book_name_text FROM bible_verses ORDER BY book ASC',
+      'SELECT DISTINCT book, book_name_text FROM bible_verses ORDER BY book ASC',
     );
-    return result.map((row) => row['book_name_text'] as String).toList();
+    return result.map((row) {
+      final rawNumber = row['book'];
+      final number = rawNumber is int ? rawNumber : (rawNumber as num).toInt();
+      return BibleBook(
+        number: number,
+        name: row['book_name_text'] as String,
+      );
+    }).toList();
   }
 
   Future<int> getChapterCount(String book, Translation translation) async {

--- a/lib/features/bible/bible_screen.dart
+++ b/lib/features/bible/bible_screen.dart
@@ -1,8 +1,10 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../data/models/bible_book.dart';
+import '../../data/models/bible_ref.dart';
 import '../../data/models/enums.dart';
 import '../../data/models/verse.dart';
 import '../../data/services/bible_service.dart';
@@ -14,10 +16,14 @@ class BibleScreen extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
     final bibleService = ref.read(bibleServiceProvider);
+
     final translation = useState(Translation.kjv);
-    final selectedBook = useState<String?>(null);
-    final selectedChapter = useState<int>(1);
+    final selectedBookNumber = useState<int?>(null);
+    final selectedChapter = useState(1);
+    final fontScale = useState(1.0);
+    final readingFontStyle = useState(ReadingFontStyle.serif);
 
     final booksFuture = useMemoized(
       () => bibleService.getBooks(translation.value),
@@ -28,25 +34,31 @@ class BibleScreen extends HookConsumerWidget {
     useEffect(() {
       final books = booksSnapshot.data;
       if (books == null || books.isEmpty) {
-        selectedBook.value = null;
+        selectedBookNumber.value = null;
         return null;
       }
-      if (selectedBook.value == null || !books.contains(selectedBook.value)) {
-        selectedBook.value = books.first;
+
+      final current = selectedBookNumber.value;
+      if (current == null || books.firstWhereOrNull((book) => book.number == current) == null) {
+        selectedBookNumber.value = books.first.number;
         selectedChapter.value = 1;
       }
       return null;
     }, <Object?>[booksSnapshot.data]);
 
+    final selectedBook = booksSnapshot.data?.firstWhereOrNull(
+      (book) => book.number == selectedBookNumber.value,
+    );
+
     final chapterCountFuture = useMemoized(
       () {
-        final book = selectedBook.value;
+        final book = selectedBook;
         if (book == null) {
           return Future<int>.value(0);
         }
-        return bibleService.getChapterCount(book, translation.value);
+        return bibleService.getChapterCount(book.name, translation.value);
       },
-      <Object?>[selectedBook.value, translation.value],
+      <Object?>[selectedBook?.number, translation.value],
     );
     final chapterCountSnapshot = useFuture(chapterCountFuture);
 
@@ -63,13 +75,13 @@ class BibleScreen extends HookConsumerWidget {
 
     final passageFuture = useMemoized(
       () {
-        final book = selectedBook.value;
+        final book = selectedBook;
         if (book == null) {
           return Future<List<Verse>>.value(<Verse>[]);
         }
-        return bibleService.getChapter(book, selectedChapter.value, translation.value);
+        return bibleService.getChapter(book.name, selectedChapter.value, translation.value);
       },
-      <Object?>[selectedBook.value, selectedChapter.value, translation.value],
+      <Object?>[selectedBook?.number, selectedChapter.value, translation.value],
     );
     final passageSnapshot = useFuture(passageFuture);
 
@@ -78,78 +90,133 @@ class BibleScreen extends HookConsumerWidget {
         chapterCountSnapshot.connectionState != ConnectionState.done ||
         passageSnapshot.connectionState != ConnectionState.done;
 
+    final title = selectedBook != null ? '${selectedBook.name} ${selectedChapter.value}' : 'Bible';
+
     return Scaffold(
-      appBar: AppBar(title: const Text('Bible Reader')),
+      appBar: AppBar(
+        title: Text(title),
+        actions: <Widget>[
+          TextButton.icon(
+            onPressed: booksSnapshot.hasData && (booksSnapshot.data?.isNotEmpty ?? false)
+                ? () async {
+                    final books = booksSnapshot.data;
+                    if (books == null || books.isEmpty) {
+                      return;
+                    }
+                    final result = await showModalBottomSheet<_PassageSelectionResult>(
+                      context: context,
+                      isScrollControlled: true,
+                      useSafeArea: true,
+                      builder: (BuildContext context) {
+                        return _PassageSelectorSheet(
+                          books: books,
+                          initialBookNumber: selectedBookNumber.value,
+                          initialChapter: selectedChapter.value,
+                          translation: translation.value,
+                          bibleService: bibleService,
+                        );
+                      },
+                    );
+
+                    if (result != null) {
+                      selectedBookNumber.value = result.book.number;
+                      selectedChapter.value = result.chapter;
+                    }
+                  }
+                : null,
+            icon: const Icon(Icons.menu_book_outlined),
+            label: const Text('Passage'),
+            style: TextButton.styleFrom(
+              foregroundColor: theme.colorScheme.onPrimary,
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.search),
+            tooltip: 'Search Bible',
+            onPressed: () async {
+              final result = await showSearch<BibleRef?>(
+                context: context,
+                delegate: _BibleSearchDelegate(
+                  bibleService: bibleService,
+                  translation: translation.value,
+                ),
+              );
+              if (result == null) {
+                return;
+              }
+
+              final books = booksSnapshot.data;
+              final match = books?.firstWhereOrNull(
+                (book) => book.name.toLowerCase() == result.book.toLowerCase(),
+              );
+
+              if (match == null) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text('Unable to open ${result.book} in this translation.')),
+                );
+                return;
+              }
+
+              selectedBookNumber.value = match.number;
+              selectedChapter.value = result.chapter;
+            },
+          ),
+        ],
+      ),
       body: Column(
         children: <Widget>[
           if (isLoading) const LinearProgressIndicator(minHeight: 2),
-          Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                _TranslationSelector(
-                  translation: translation.value,
-                  onChanged: (value) {
-                    translation.value = value;
-                    selectedBook.value = null;
-                    selectedChapter.value = 1;
-                  },
-                ),
-                const SizedBox(height: 12),
-                _BookSelector(
-                  snapshot: booksSnapshot,
-                  value: selectedBook.value,
-                  onChanged: (value) {
-                    selectedBook.value = value;
-                    selectedChapter.value = 1;
-                  },
-                ),
-                const SizedBox(height: 12),
-                _ChapterSelector(
-                  snapshot: chapterCountSnapshot,
-                  value: selectedChapter.value,
-                  onChanged: (value) => selectedChapter.value = value,
-                  onPrevious: () {
-                    if (selectedChapter.value > 1) {
-                      selectedChapter.value = selectedChapter.value - 1;
-                    }
-                  },
-                  onNext: () {
-                    final count = chapterCountSnapshot.data;
-                    if (count != null && selectedChapter.value < count) {
-                      selectedChapter.value = selectedChapter.value + 1;
-                    }
-                  },
-                ),
-              ],
-            ),
-          ),
-          const Divider(height: 1),
           Expanded(
             child: Builder(
               builder: (BuildContext context) {
                 if (booksSnapshot.hasError) {
-                  return _ErrorView(message: 'Unable to load books: ${booksSnapshot.error}');
+                  return _CenteredMessage('Unable to load books: ${booksSnapshot.error}');
                 }
                 if (chapterCountSnapshot.hasError) {
-                  return _ErrorView(
-                    message: 'Unable to load chapters for ${selectedBook.value}: ${chapterCountSnapshot.error}',
+                  return _CenteredMessage(
+                    'Unable to load chapters for ${selectedBook?.name ?? 'this book'}: ${chapterCountSnapshot.error}',
                   );
                 }
                 if (passageSnapshot.hasError) {
-                  return _ErrorView(message: 'Unable to load passage: ${passageSnapshot.error}');
+                  return _CenteredMessage('Unable to load passage: ${passageSnapshot.error}');
+                }
+                if ((booksSnapshot.data?.isEmpty ?? true)) {
+                  return const _CenteredMessage('No books available for this translation.');
                 }
                 if (verses.isEmpty) {
-                  return const Center(child: Text('Select a book and chapter to begin reading.'));
+                  return const _CenteredMessage('Select a passage to begin reading.');
                 }
+
+                final textStyle = _readingTextStyle(context, fontScale.value, readingFontStyle.value);
+                final verseNumberStyle = textStyle.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: theme.colorScheme.primary,
+                );
+
                 return ListView.separated(
-                  padding: const EdgeInsets.all(16),
+                  padding: const EdgeInsets.fromLTRB(16, 24, 16, 24),
                   itemBuilder: (BuildContext context, int index) {
                     final verse = verses[index];
-                    return _VerseCard(verse: verse);
+                    return SelectableText.rich(
+                      TextSpan(
+                        children: <InlineSpan>[
+                          WidgetSpan(
+                            baseline: TextBaseline.alphabetic,
+                            alignment: PlaceholderAlignment.aboveBaseline,
+                            child: Padding(
+                              padding: const EdgeInsets.only(right: 8),
+                              child: Text(
+                                '${verse.verse}',
+                                style: verseNumberStyle,
+                              ),
+                            ),
+                          ),
+                          TextSpan(text: verse.text, style: textStyle),
+                        ],
+                      ),
+                    );
                   },
-                  separatorBuilder: (_, __) => const SizedBox(height: 12),
+                  separatorBuilder: (_, __) => const SizedBox(height: 16),
                   itemCount: verses.length,
                 );
               },
@@ -157,215 +224,50 @@ class BibleScreen extends HookConsumerWidget {
           ),
         ],
       ),
-    );
-  }
-}
-
-class _TranslationSelector extends StatelessWidget {
-  const _TranslationSelector({required this.translation, required this.onChanged});
-
-  final Translation translation;
-  final ValueChanged<Translation> onChanged;
-
-  @override
-  Widget build(BuildContext context) {
-    return InputDecorator(
-      decoration: const InputDecoration(labelText: 'Translation', border: OutlineInputBorder()),
-      child: DropdownButtonHideUnderline(
-        child: DropdownButton<Translation>(
-          value: translation,
-          isExpanded: true,
-          items: Translation.values
-              .map(
-                (translation) => DropdownMenuItem<Translation>(
-                  value: translation,
-                  child: Text(_translationLabel(translation)),
-                ),
-              )
-              .toList(),
-          onChanged: (value) {
-            if (value != null) {
-              onChanged(value);
-            }
-          },
-        ),
-      ),
-    );
-  }
-}
-
-class _BookSelector extends StatelessWidget {
-  const _BookSelector({required this.snapshot, required this.value, required this.onChanged});
-
-  final AsyncSnapshot<List<String>> snapshot;
-  final String? value;
-  final ValueChanged<String> onChanged;
-
-  @override
-  Widget build(BuildContext context) {
-    if (snapshot.hasError) {
-      return _ErrorField(message: 'Could not load books.');
-    }
-    if (snapshot.connectionState != ConnectionState.done) {
-      return const _LoadingField(label: 'Book');
-    }
-
-    final books = snapshot.data ?? <String>[];
-    if (books.isEmpty) {
-      return const _ErrorField(message: 'No books available in this translation.');
-    }
-
-    return InputDecorator(
-      decoration: const InputDecoration(labelText: 'Book', border: OutlineInputBorder()),
-      child: DropdownButtonHideUnderline(
-        child: DropdownButton<String>(
-          value: value ?? books.first,
-          isExpanded: true,
-          items: books
-              .map(
-                (book) => DropdownMenuItem<String>(
-                  value: book,
-                  child: Text(book),
-                ),
-              )
-              .toList(),
-          onChanged: (selected) {
-            if (selected != null) {
-              onChanged(selected);
-            }
-          },
-        ),
-      ),
-    );
-  }
-}
-
-class _ChapterSelector extends StatelessWidget {
-  const _ChapterSelector({
-    required this.snapshot,
-    required this.value,
-    required this.onChanged,
-    required this.onPrevious,
-    required this.onNext,
-  });
-
-  final AsyncSnapshot<int> snapshot;
-  final int value;
-  final ValueChanged<int> onChanged;
-  final VoidCallback onPrevious;
-  final VoidCallback onNext;
-
-  @override
-  Widget build(BuildContext context) {
-    if (snapshot.hasError) {
-      return _ErrorField(message: 'Could not load chapters.');
-    }
-    if (snapshot.connectionState != ConnectionState.done) {
-      return const _LoadingField(label: 'Chapter');
-    }
-
-    final count = snapshot.data ?? 0;
-    if (count == 0) {
-      return const _ErrorField(message: 'No chapters available for this book.');
-    }
-
-    final chapters = List<int>.generate(count, (index) => index + 1);
-
-    return Row(
-      children: <Widget>[
-        Expanded(
-          child: InputDecorator(
-            decoration: const InputDecoration(labelText: 'Chapter', border: OutlineInputBorder()),
-            child: DropdownButtonHideUnderline(
-              child: DropdownButton<int>(
-                value: value.clamp(1, count),
-                isExpanded: true,
-                items: chapters
-                    .map(
-                      (chapter) => DropdownMenuItem<int>(
-                        value: chapter,
-                        child: Text(chapter.toString()),
-                      ),
-                    )
-                    .toList(),
-                onChanged: (selected) {
-                  if (selected != null) {
-                    onChanged(selected);
-                  }
-                },
-              ),
-            ),
-          ),
-        ),
-        const SizedBox(width: 12),
-        IconButton.filledTonal(
-          icon: const Icon(Icons.chevron_left),
-          onPressed: value > 1 ? onPrevious : null,
-          tooltip: 'Previous chapter',
-        ),
-        const SizedBox(width: 8),
-        IconButton.filledTonal(
-          icon: const Icon(Icons.chevron_right),
-          onPressed: value < count ? onNext : null,
-          tooltip: 'Next chapter',
-        ),
-      ],
-    );
-  }
-}
-
-class _VerseCard extends StatelessWidget {
-  const _VerseCard({required this.verse});
-
-  final Verse verse;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Row(
-              children: <Widget>[
-                Expanded(
-                  child: Text(
-                    '${verse.book} ${verse.chapter}:${verse.verse}',
-                    style: theme.textTheme.titleMedium,
-                  ),
-                ),
-                IconButton(
-                  icon: const Icon(Icons.copy),
-                  tooltip: 'Copy verse',
-                  onPressed: () {
-                    Clipboard.setData(
-                      ClipboardData(text: '${verse.book} ${verse.chapter}:${verse.verse} — ${verse.text}'),
-                    );
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text('Copied ${verse.book} ${verse.chapter}:${verse.verse}'),
-                      ),
-                    );
+      bottomNavigationBar: SafeArea(
+        child: _DisplayOptionsBar(
+          onPressed: () {
+            showModalBottomSheet<void>(
+              context: context,
+              useSafeArea: true,
+              builder: (BuildContext context) {
+                return _DisplayOptionsSheet(
+                  fontScale: fontScale.value,
+                  onFontScaleChanged: (value) => fontScale.value = value,
+                  fontStyle: readingFontStyle.value,
+                  onFontStyleChanged: (value) => readingFontStyle.value = value,
+                  translation: translation.value,
+                  onTranslationChanged: (value) {
+                    translation.value = value;
+                    selectedBookNumber.value = null;
+                    selectedChapter.value = 1;
                   },
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-            SelectableText(
-              verse.text,
-              style: theme.textTheme.bodyLarge,
-            ),
-          ],
+                );
+              },
+            );
+          },
         ),
       ),
     );
   }
 }
 
-class _ErrorView extends StatelessWidget {
-  const _ErrorView({required this.message});
+TextStyle _readingTextStyle(BuildContext context, double scale, ReadingFontStyle style) {
+  final base = Theme.of(context).textTheme.bodyLarge ?? const TextStyle(fontSize: 16, height: 1.5);
+  final baseSize = base.fontSize ?? 16;
+  final fontFamilyFallback = style == ReadingFontStyle.serif
+      ? const <String>['Noto Serif', 'Merriweather', 'Times New Roman', 'serif']
+      : base.fontFamilyFallback;
+
+  return base.copyWith(
+    fontSize: baseSize * scale,
+    height: 1.6,
+    fontFamilyFallback: fontFamilyFallback,
+  );
+}
+
+class _CenteredMessage extends StatelessWidget {
+  const _CenteredMessage(this.message);
 
   final String message;
 
@@ -374,41 +276,121 @@ class _ErrorView extends StatelessWidget {
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(24),
-        child: Text(message, textAlign: TextAlign.center),
+        child: Text(
+          message,
+          style: Theme.of(context).textTheme.bodyLarge,
+          textAlign: TextAlign.center,
+        ),
       ),
     );
   }
 }
 
-class _ErrorField extends StatelessWidget {
-  const _ErrorField({required this.message});
+class _DisplayOptionsBar extends StatelessWidget {
+  const _DisplayOptionsBar({required this.onPressed});
 
-  final String message;
+  final VoidCallback onPressed;
 
   @override
   Widget build(BuildContext context) {
-    return InputDecorator(
-      decoration: const InputDecoration(border: OutlineInputBorder()),
-      child: Text(message, style: Theme.of(context).textTheme.bodyMedium),
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      child: FilledButton.tonalIcon(
+        onPressed: onPressed,
+        icon: const Icon(Icons.text_fields),
+        label: const Text('Display options'),
+      ),
     );
   }
 }
 
-class _LoadingField extends StatelessWidget {
-  const _LoadingField({required this.label});
+class _DisplayOptionsSheet extends StatefulWidget {
+  const _DisplayOptionsSheet({
+    required this.fontScale,
+    required this.onFontScaleChanged,
+    required this.fontStyle,
+    required this.onFontStyleChanged,
+    required this.translation,
+    required this.onTranslationChanged,
+  });
 
-  final String label;
+  final double fontScale;
+  final ValueChanged<double> onFontScaleChanged;
+  final ReadingFontStyle fontStyle;
+  final ValueChanged<ReadingFontStyle> onFontStyleChanged;
+  final Translation translation;
+  final ValueChanged<Translation> onTranslationChanged;
+
+  @override
+  State<_DisplayOptionsSheet> createState() => _DisplayOptionsSheetState();
+}
+
+class _DisplayOptionsSheetState extends State<_DisplayOptionsSheet> {
+  late double _fontScale = widget.fontScale;
+  late ReadingFontStyle _fontStyle = widget.fontStyle;
+  late Translation _translation = widget.translation;
 
   @override
   Widget build(BuildContext context) {
-    return InputDecorator(
-      decoration: InputDecoration(labelText: label, border: const OutlineInputBorder()),
-      child: const SizedBox(
-        height: 40,
-        child: Align(
-          alignment: Alignment.centerLeft,
-          child: SizedBox(width: 24, height: 24, child: CircularProgressIndicator(strokeWidth: 2)),
-        ),
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 24, 24, 32),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text('Reading preferences', style: theme.textTheme.titleLarge),
+          const SizedBox(height: 24),
+          Text('Font size', style: theme.textTheme.titleMedium),
+          Slider(
+            value: _fontScale,
+            min: 0.8,
+            max: 1.6,
+            divisions: 8,
+            label: '${(_fontScale * 100).round()}%',
+            onChanged: (value) {
+              setState(() => _fontScale = value);
+              widget.onFontScaleChanged(value);
+            },
+          ),
+          const SizedBox(height: 16),
+          Text('Font style', style: theme.textTheme.titleMedium),
+          const SizedBox(height: 8),
+          SegmentedButton<ReadingFontStyle>(
+            segments: const <ButtonSegment<ReadingFontStyle>>[
+              ButtonSegment(value: ReadingFontStyle.serif, label: Text('Serif')),
+              ButtonSegment(value: ReadingFontStyle.sans, label: Text('Sans-serif')),
+            ],
+            selected: <ReadingFontStyle>{_fontStyle},
+            onSelectionChanged: (selection) {
+              final value = selection.first;
+              setState(() => _fontStyle = value);
+              widget.onFontStyleChanged(value);
+            },
+          ),
+          const SizedBox(height: 16),
+          Text('Translation', style: theme.textTheme.titleMedium),
+          const SizedBox(height: 8),
+          DropdownButtonFormField<Translation>(
+            value: _translation,
+            decoration: const InputDecoration(border: OutlineInputBorder()),
+            items: Translation.values
+                .map(
+                  (translation) => DropdownMenuItem<Translation>(
+                    value: translation,
+                    child: Text(_translationLabel(translation)),
+                  ),
+                )
+                .toList(),
+            onChanged: (value) {
+              if (value == null) {
+                return;
+              }
+              setState(() => _translation = value);
+              widget.onTranslationChanged(value);
+            },
+          ),
+        ],
       ),
     );
   }
@@ -422,3 +404,375 @@ String _translationLabel(Translation translation) {
       return 'Shona Bible';
   }
 }
+
+class _PassageSelectorSheet extends HookWidget {
+  const _PassageSelectorSheet({
+    required this.books,
+    required this.initialBookNumber,
+    required this.initialChapter,
+    required this.translation,
+    required this.bibleService,
+  });
+
+  final List<BibleBook> books;
+  final int? initialBookNumber;
+  final int initialChapter;
+  final Translation translation;
+  final BibleService bibleService;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final activeBookNumber = useState<int?>(initialBookNumber ?? books.first.number);
+
+    final initialTabIndex = _tabIndexFor(activeBookNumber.value ?? books.first.number);
+    final tabController = useTabController(initialLength: 2, initialIndex: initialTabIndex);
+
+    useEffect(() {
+      final bookNumber = activeBookNumber.value;
+      if (bookNumber != null) {
+        final index = _tabIndexFor(bookNumber);
+        if (tabController.index != index) {
+          tabController.index = index;
+        }
+      }
+      return null;
+    }, <Object?>[activeBookNumber.value]);
+
+    final selectedChapter = useState(initialChapter);
+
+    useEffect(() {
+      if (activeBookNumber.value == initialBookNumber) {
+        selectedChapter.value = initialChapter;
+      } else {
+        selectedChapter.value = 1;
+      }
+      return null;
+    }, <Object?>[activeBookNumber.value]);
+
+    final activeBook = books.firstWhereOrNull((book) => book.number == activeBookNumber.value) ?? books.first;
+
+    final chapterCountFuture = useMemoized(
+      () => bibleService.getChapterCount(activeBook.name, translation),
+      <Object?>[activeBook.number, translation],
+    );
+    final chapterCountSnapshot = useFuture(chapterCountFuture);
+
+    final oldTestamentBooks = useMemoized(
+      () => books.where((book) => book.testament == Testament.old).toList(),
+      <Object?>[books],
+    );
+    final newTestamentBooks = useMemoized(
+      () => books.where((book) => book.testament == Testament.new).toList(),
+      <Object?>[books],
+    );
+
+    final handleColor = theme.colorScheme.onSurfaceVariant.withOpacity(0.3);
+
+    return SafeArea(
+      child: SizedBox(
+        height: MediaQuery.of(context).size.height * 0.9,
+        child: Column(
+          children: <Widget>[
+            const SizedBox(height: 12),
+            Container(
+              width: 48,
+              height: 4,
+              decoration: BoxDecoration(
+                color: handleColor,
+                borderRadius: BorderRadius.circular(999),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text('Select passage', style: theme.textTheme.titleLarge),
+            const SizedBox(height: 12),
+            TabBar(
+              controller: tabController,
+              tabs: const <Widget>[
+                Tab(text: 'Old Testament'),
+                Tab(text: 'New Testament'),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Expanded(
+              child: Column(
+                children: <Widget>[
+                  Expanded(
+                    flex: 3,
+                    child: TabBarView(
+                      controller: tabController,
+                      children: <Widget>[
+                        _BookGrid(
+                          books: oldTestamentBooks,
+                          activeBook: activeBook,
+                          onSelected: (book) => activeBookNumber.value = book.number,
+                        ),
+                        _BookGrid(
+                          books: newTestamentBooks,
+                          activeBook: activeBook,
+                          onSelected: (book) => activeBookNumber.value = book.number,
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: Text(
+                        'Chapters in ${activeBook.name}',
+                        style: theme.textTheme.titleMedium,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Expanded(
+                    flex: 4,
+                    child: AnimatedSwitcher(
+                      duration: const Duration(milliseconds: 200),
+                      child: Builder(
+                        key: ValueKey<int?>(activeBook.number),
+                        builder: (BuildContext context) {
+                          if (chapterCountSnapshot.hasError) {
+                            return Center(
+                              child: Padding(
+                                padding: const EdgeInsets.all(16),
+                                child: Text(
+                                  'Unable to load chapters for ${activeBook.name}.',
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
+                            );
+                          }
+                          if (chapterCountSnapshot.connectionState != ConnectionState.done) {
+                            return const Center(child: CircularProgressIndicator());
+                          }
+
+                          final count = chapterCountSnapshot.data ?? 0;
+                          if (count == 0) {
+                            return const Center(child: Text('No chapters available.'));
+                          }
+
+                          return _ChapterGrid(
+                            chapterCount: count,
+                            selectedChapter: selectedChapter.value,
+                            onSelected: (chapter) {
+                              Navigator.of(context).pop(
+                                _PassageSelectionResult(book: activeBook, chapter: chapter),
+                              );
+                            },
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BookGrid extends StatelessWidget {
+  const _BookGrid({
+    required this.books,
+    required this.activeBook,
+    required this.onSelected,
+  });
+
+  final List<BibleBook> books;
+  final BibleBook activeBook;
+  final ValueChanged<BibleBook> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    if (books.isEmpty) {
+      return const Center(child: Text('No books available.'));
+    }
+
+    final theme = Theme.of(context);
+
+    return GridView.builder(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 3,
+        childAspectRatio: 2.8,
+        mainAxisSpacing: 12,
+        crossAxisSpacing: 12,
+      ),
+      itemCount: books.length,
+      itemBuilder: (BuildContext context, int index) {
+        final book = books[index];
+        final isSelected = activeBook.number == book.number;
+        return OutlinedButton(
+          style: OutlinedButton.styleFrom(
+            backgroundColor: isSelected ? theme.colorScheme.primaryContainer : null,
+            foregroundColor: isSelected ? theme.colorScheme.onPrimaryContainer : null,
+          ),
+          onPressed: () => onSelected(book),
+          child: Text(
+            book.name,
+            textAlign: TextAlign.center,
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _ChapterGrid extends StatelessWidget {
+  const _ChapterGrid({
+    required this.chapterCount,
+    required this.selectedChapter,
+    required this.onSelected,
+  });
+
+  final int chapterCount;
+  final int selectedChapter;
+  final ValueChanged<int> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return GridView.builder(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 6,
+        mainAxisSpacing: 12,
+        crossAxisSpacing: 12,
+      ),
+      itemCount: chapterCount,
+      itemBuilder: (BuildContext context, int index) {
+        final chapter = index + 1;
+        final isSelected = selectedChapter == chapter;
+        return FilledButton.tonal(
+          style: FilledButton.styleFrom(
+            backgroundColor: isSelected ? theme.colorScheme.primary : null,
+            foregroundColor: isSelected ? theme.colorScheme.onPrimary : null,
+          ),
+          onPressed: () => onSelected(chapter),
+          child: Text('$chapter'),
+        );
+      },
+    );
+  }
+}
+
+class _PassageSelectionResult {
+  const _PassageSelectionResult({required this.book, required this.chapter});
+
+  final BibleBook book;
+  final int chapter;
+}
+
+class _BibleSearchDelegate extends SearchDelegate<BibleRef?> {
+  _BibleSearchDelegate({required this.bibleService, required this.translation})
+      : super(searchFieldLabel: 'Search Bible');
+
+  final BibleService bibleService;
+  final Translation translation;
+
+  @override
+  List<Widget>? buildActions(BuildContext context) {
+    return <Widget>[
+      if (query.isNotEmpty)
+        IconButton(
+          icon: const Icon(Icons.clear),
+          onPressed: () => query = '',
+        ),
+    ];
+  }
+
+  @override
+  Widget? buildLeading(BuildContext context) {
+    return IconButton(
+      icon: const Icon(Icons.arrow_back),
+      onPressed: () => close(context, null),
+    );
+  }
+
+  @override
+  Widget buildResults(BuildContext context) => _buildResultList();
+
+  @override
+  Widget buildSuggestions(BuildContext context) => _buildResultList();
+
+  Widget _buildResultList() {
+    final trimmedQuery = query.trim();
+    if (trimmedQuery.length < 3) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text('Enter at least three characters to search.'),
+        ),
+      );
+    }
+
+    return FutureBuilder<List<VerseSearchHit>>(
+      future: bibleService.search(trimmedQuery, translation),
+      builder: (BuildContext context, AsyncSnapshot<List<VerseSearchHit>> snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (snapshot.hasError) {
+          return Center(child: Text('Search failed: ${snapshot.error}'));
+        }
+        final results = snapshot.data ?? <VerseSearchHit>[];
+        if (results.isEmpty) {
+          return const Center(child: Text('No verses found.'));
+        }
+        return ListView.separated(
+          itemCount: results.length,
+          separatorBuilder: (_, __) => const Divider(height: 1),
+          itemBuilder: (BuildContext context, int index) {
+            final hit = results[index];
+            return ListTile(
+              title: Text(hit.reference),
+              subtitle: Text(
+                hit.preview,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              onTap: () {
+                final reference = _parseReference(hit.reference);
+                if (reference == null) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('Unable to open ${hit.reference}')),
+                  );
+                  return;
+                }
+                close(context, reference);
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+
+  BibleRef? _parseReference(String reference) {
+    final match = RegExp('^(.+)\s+(\d+):(\d+)$').firstMatch(reference.trim());
+    if (match == null) {
+      return null;
+    }
+
+    final book = match.group(1)!.trim();
+    final chapter = int.tryParse(match.group(2)!);
+    if (chapter == null) {
+      return null;
+    }
+
+    final verse = int.tryParse(match.group(3)!);
+    return BibleRef(book: book, chapter: chapter, verseStart: verse, verseEnd: verse);
+  }
+}
+
+enum ReadingFontStyle { serif, sans }
+
+int _tabIndexFor(int bookNumber) => bookNumber <= 39 ? 0 : 1;
+

--- a/lib/features/sunday_school/all_lessons/sunday_school_all_lessons_screen.dart
+++ b/lib/features/sunday_school/all_lessons/sunday_school_all_lessons_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../../data/models/bible_ref.dart';
 import '../../../data/models/enums.dart';
 import '../../../data/models/lesson.dart';
 import '../../../data/repositories/lesson_repository.dart';
@@ -23,7 +25,7 @@ class SundaySchoolAllLessonsScreen extends HookConsumerWidget {
           if (value.values.every((lessons) => lessons.isEmpty)) {
             return const Center(child: Text('Lessons will appear here soon.'));
           }
-          return _AllLessonsList(lessonsByTrack: value);
+          return _LessonsExplorer(lessonsByTrack: value);
         },
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (error, stackTrace) => Center(child: Text('Something went wrong: $error')),
@@ -49,80 +51,399 @@ final _allSundayLessonsProvider = FutureProvider<Map<Track, List<Lesson>>>((ref)
   return Map<Track, List<Lesson>>.fromEntries(entries);
 });
 
-class _AllLessonsList extends StatelessWidget {
-  const _AllLessonsList({required this.lessonsByTrack});
+class _LessonsExplorer extends HookConsumerWidget {
+  const _LessonsExplorer({required this.lessonsByTrack});
 
   final Map<Track, List<Lesson>> lessonsByTrack;
 
   @override
-  Widget build(BuildContext context) {
-    return ListView.builder(
-      padding: const EdgeInsets.all(16),
-      itemCount: _sundaySchoolTracks.length,
-      itemBuilder: (BuildContext context, int index) {
-        final track = _sundaySchoolTracks[index];
-        final lessons = lessonsByTrack[track] ?? <Lesson>[];
-        return _TrackSection(track: track, lessons: lessons);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final searchController = useTextEditingController();
+    final searchQuery = useState('');
+    final selectedTrack = useState<Track?>(null);
+    final selectedQuarter = useState<int?>(null);
+    final selectedTopic = useState<String?>(null);
+
+    useEffect(() {
+      void listener() => searchQuery.value = searchController.text;
+      searchController.addListener(listener);
+      return () => searchController.removeListener(listener);
+    }, <Object?>[searchController]);
+
+    final allLessons = useMemoized(
+      () => _sundaySchoolTracks
+          .expand((track) => lessonsByTrack[track] ?? <Lesson>[])
+          .toList(growable: false),
+      <Object?>[lessonsByTrack],
+    );
+
+    final quarters = useMemoized(
+      () {
+        final values = <int>{};
+        for (final lesson in allLessons) {
+          final quarter = _quarterForLesson(lesson);
+          if (quarter != null) {
+            values.add(quarter);
+          }
+        }
+        final list = values.toList()..sort();
+        return list;
       },
+      <Object?>[allLessons],
+    );
+
+    final topics = useMemoized(
+      () {
+        final values = <String>{};
+        for (final lesson in allLessons) {
+          final topic = _topicForLesson(lesson);
+          if (topic != null && topic.isNotEmpty) {
+            values.add(topic);
+          }
+        }
+        final list = values.toList()
+          ..sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
+        return list;
+      },
+      <Object?>[allLessons],
+    );
+
+    final filteredLessons = useMemoized(
+      () {
+        final query = searchQuery.value.trim().toLowerCase();
+        return allLessons.where((lesson) {
+          if (selectedTrack.value != null && lesson.track != selectedTrack.value) {
+            return false;
+          }
+          final quarter = _quarterForLesson(lesson);
+          if (selectedQuarter.value != null && quarter != selectedQuarter.value) {
+            return false;
+          }
+          final topic = _topicForLesson(lesson);
+          if (selectedTopic.value != null && topic != selectedTopic.value) {
+            return false;
+          }
+          if (query.isEmpty) {
+            return true;
+          }
+          final summary = _lessonSummary(lesson) ?? '';
+          final topicText = topic ?? '';
+          final referenceText = lesson.bibleReferences.map((ref) => ref.displayText).join(' ');
+          final haystack = '${lesson.title} $summary $topicText $referenceText'.toLowerCase();
+          return haystack.contains(query);
+        }).toList();
+      },
+      <Object?>[allLessons, searchQuery.value, selectedTrack.value, selectedQuarter.value, selectedTopic.value],
+    );
+
+    filteredLessons.sort((a, b) {
+      final trackComparison = _sundaySchoolTracks.indexOf(a.track).compareTo(
+        _sundaySchoolTracks.indexOf(b.track),
+      );
+      if (trackComparison != 0) {
+        return trackComparison;
+      }
+      final weekA = a.weekIndex ?? 0;
+      final weekB = b.weekIndex ?? 0;
+      return weekA.compareTo(weekB);
+    });
+
+    return Column(
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          child: TextField(
+            controller: searchController,
+            decoration: InputDecoration(
+              hintText: 'Search by title, topic, or scripture',
+              prefixIcon: const Icon(Icons.search),
+              border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+            ),
+          ),
+        ),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Row(
+            children: <Widget>[
+              ChoiceChip(
+                label: const Text('All tracks'),
+                selected: selectedTrack.value == null,
+                onSelected: (_) => selectedTrack.value = null,
+              ),
+              const SizedBox(width: 8),
+              ..._sundaySchoolTracks.map(
+                (track) => Padding(
+                  padding: const EdgeInsets.only(right: 8),
+                  child: ChoiceChip(
+                    label: Text(_trackLabel(track)),
+                    selected: selectedTrack.value == track,
+                    onSelected: (_) => selectedTrack.value =
+                        selectedTrack.value == track ? null : track,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+          child: Wrap(
+            spacing: 16,
+            runSpacing: 12,
+            children: <Widget>[
+              if (quarters.isNotEmpty)
+                SizedBox(
+                  width: 200,
+                  child: DropdownButtonFormField<int?>(
+                    value: selectedQuarter.value,
+                    decoration: const InputDecoration(
+                      border: OutlineInputBorder(),
+                      labelText: 'Quarter',
+                    ),
+                    items: <DropdownMenuItem<int?>>[
+                      const DropdownMenuItem<int?>(
+                        value: null,
+                        child: Text('All quarters'),
+                      ),
+                      ...quarters
+                          .map(
+                            (quarter) => DropdownMenuItem<int?>(
+                              value: quarter,
+                              child: Text('Quarter $quarter'),
+                            ),
+                          )
+                          .toList(),
+                    ],
+                    onChanged: (value) => selectedQuarter.value = value,
+                  ),
+                ),
+              if (topics.isNotEmpty)
+                SizedBox(
+                  width: 240,
+                  child: DropdownButtonFormField<String?>(
+                    value: selectedTopic.value,
+                    decoration: const InputDecoration(
+                      border: OutlineInputBorder(),
+                      labelText: 'Topic',
+                    ),
+                    items: <DropdownMenuItem<String?>>[
+                      const DropdownMenuItem<String?>(
+                        value: null,
+                        child: Text('All topics'),
+                      ),
+                      ...topics
+                          .map(
+                            (topic) => DropdownMenuItem<String?>(
+                              value: topic,
+                              child: Text(topic),
+                            ),
+                          )
+                          .toList(),
+                    ],
+                    onChanged: (value) => selectedTopic.value = value,
+                  ),
+                ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 8),
+        Expanded(
+          child: filteredLessons.isEmpty
+              ? const Center(child: Text('No lessons match your filters yet.'))
+              : ListView.builder(
+                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+                  itemCount: filteredLessons.length,
+                  itemBuilder: (BuildContext context, int index) {
+                    final lesson = filteredLessons[index];
+                    return _LessonCard(
+                      lesson: lesson,
+                      onTap: () {
+                        context.pushNamed(
+                          SundaySchoolLessonDetailScreen.routeName,
+                          pathParameters: <String, String>{'lessonId': lesson.id},
+                        );
+                      },
+                    );
+                  },
+                ),
+        ),
+      ],
     );
   }
 }
 
-class _TrackSection extends StatelessWidget {
-  const _TrackSection({required this.track, required this.lessons});
+class _LessonCard extends StatelessWidget {
+  const _LessonCard({required this.lesson, required this.onTap});
 
-  final Track track;
-  final List<Lesson> lessons;
+  final Lesson lesson;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final subtitle = _lessonSubtitle(lesson);
+    final summary = _lessonSummary(lesson);
+    final topic = _topicForLesson(lesson);
+
+    final chips = <Widget>[
+      Chip(label: Text(_trackLabel(lesson.track))),
+      if (lesson.weekIndex != null) Chip(label: Text('Week ${lesson.weekIndex}')),
+      ...lesson.bibleReferences.take(3).map((BibleRef ref) => Chip(label: Text(ref.displayText))),
+      if ((lesson.bibleReferences.length) > 3)
+        Chip(label: Text('+${lesson.bibleReferences.length - 3} refs')),
+      if (topic != null && topic.isNotEmpty) Chip(label: Text(topic)),
+    ];
+
     return Card(
-      margin: const EdgeInsets.only(bottom: 16),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Text(_trackLabel(track), style: theme.textTheme.titleMedium),
-            const SizedBox(height: 8),
-            if (lessons.isEmpty)
-              Text('Lessons coming soon.', style: theme.textTheme.bodyMedium?.copyWith(color: theme.hintColor))
-            else
-              ...lessons.map((lesson) => _LessonListTile(lesson: lesson)),
-          ],
+      margin: const EdgeInsets.only(bottom: 12),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Row(
+                children: <Widget>[
+                  CircleAvatar(
+                    backgroundColor: theme.colorScheme.primaryContainer,
+                    foregroundColor: theme.colorScheme.onPrimaryContainer,
+                    child: const Icon(Icons.menu_book_outlined),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          lesson.title,
+                          style: theme.textTheme.titleMedium,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        if (subtitle != null)
+                          Padding(
+                            padding: const EdgeInsets.only(top: 4),
+                            child: Text(
+                              subtitle,
+                              style: theme.textTheme.bodySmall,
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                  const Icon(Icons.chevron_right),
+                ],
+              ),
+              if (summary != null && summary.isNotEmpty) ...<Widget>[
+                const SizedBox(height: 12),
+                Text(
+                  summary,
+                  style: theme.textTheme.bodyMedium,
+                  maxLines: 3,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+              if (chips.isNotEmpty) ...<Widget>[
+                const SizedBox(height: 12),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: chips,
+                ),
+              ],
+            ],
+          ),
         ),
       ),
     );
   }
 }
 
-class _LessonListTile extends StatelessWidget {
-  const _LessonListTile({required this.lesson});
+String? _lessonSubtitle(Lesson lesson) {
+  final parts = <String>[
+    if (lesson.weekIndex != null) 'Week ${lesson.weekIndex}',
+    if (lesson.bibleReferences.isNotEmpty)
+      lesson.bibleReferences.map((ref) => ref.displayText).join(' • '),
+  ].where((element) => element.isNotEmpty).toList();
 
-  final Lesson lesson;
-
-  @override
-  Widget build(BuildContext context) {
-    final subtitle = <String?>[
-      if (lesson.weekIndex != null) 'Week ${lesson.weekIndex}',
-      if (lesson.bibleReferences.isNotEmpty)
-        lesson.bibleReferences.map((ref) => ref.displayText).join('; '),
-    ].whereType<String>().join(' • ');
-
-    return ListTile(
-      contentPadding: EdgeInsets.zero,
-      title: Text(lesson.title),
-      subtitle: subtitle.isEmpty ? null : Text(subtitle),
-      trailing: const Icon(Icons.chevron_right),
-      onTap: () {
-        context.pushNamed(
-          SundaySchoolLessonDetailScreen.routeName,
-          pathParameters: <String, String>{'lessonId': lesson.id},
-        );
-      },
-    );
+  if (parts.isEmpty) {
+    return null;
   }
+  return parts.join(' • ');
+}
+
+String? _lessonSummary(Lesson lesson) {
+  final payload = lesson.payload;
+  final keyVerse = payload['keyVerse'] as String?;
+  if (keyVerse != null && keyVerse.trim().isNotEmpty) {
+    return keyVerse.trim();
+  }
+
+  final sections = payload['sections'] as List<dynamic>?;
+  if (sections != null && sections.isNotEmpty) {
+    final first = sections.first;
+    if (first is Map<String, dynamic>) {
+      final content = first['sectionContent'] as String?;
+      if (content != null && content.trim().isNotEmpty) {
+        return content.trim();
+      }
+    }
+  }
+
+  final story = payload['story'] as List<dynamic>?;
+  if (story != null && story.isNotEmpty) {
+    final first = story.first;
+    if (first is String && first.trim().isNotEmpty) {
+      return first.trim();
+    }
+  }
+
+  final parentGuide = payload['parentGuide'] as Map<String, dynamic>?;
+  if (parentGuide != null) {
+    final parentsCorner = parentGuide['parentsCorner'] as String?;
+    if (parentsCorner != null && parentsCorner.trim().isNotEmpty) {
+      return parentsCorner.trim();
+    }
+  }
+
+  return null;
+}
+
+String? _topicForLesson(Lesson lesson) {
+  final payload = lesson.payload;
+  final topic = payload['topic'] as String?;
+  if (topic != null && topic.trim().isNotEmpty) {
+    return topic.trim();
+  }
+
+  final ageCategory = payload['ageCategory'] as String?;
+  if (ageCategory != null && ageCategory.trim().isNotEmpty) {
+    return ageCategory.trim();
+  }
+
+  final resource = payload['resourceMaterial'] as String?;
+  if (resource != null && resource.trim().isNotEmpty) {
+    return resource.trim();
+  }
+
+  if (lesson.title.contains(':')) {
+    return lesson.title.split(':').first.trim();
+  }
+  if (lesson.bibleReferences.isNotEmpty) {
+    return lesson.bibleReferences.first.book;
+  }
+  return null;
+}
+
+int? _quarterForLesson(Lesson lesson) {
+  final week = lesson.weekIndex;
+  if (week == null || week <= 0) {
+    return null;
+  }
+  return ((week - 1) ~/ 13) + 1;
 }
 
 String _trackLabel(Track track) {
@@ -140,3 +461,4 @@ String _trackLabel(Track track) {
       return name[0].toUpperCase() + name.substring(1);
   }
 }
+


### PR DESCRIPTION
## Summary
- redesign the Bible screen around a clean reading surface with modal passage selector, search integration, and display options sheet
- add Bible book metadata support to drive testament-aware grids and font controls
- rebuild the Sunday School lessons explorer with search, filters, and card-based lesson previews

## Testing
- not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ebf393d7408320957858a0575970b4