### PR TITLE
Rename Testament enum value to avoid reserved word conflict

### DIFF
--- a/lib/data/models/bible_book.dart
+++ b/lib/data/models/bible_book.dart
@@ -9,5 +9,6 @@ class BibleBook {
   final int number;
   final String name;
 
-  Testament get testament => number <= 39 ? Testament.old : Testament.new;
+  Testament get testament =>
+      number <= 39 ? Testament.old : Testament.newTestament;
 }

--- a/lib/data/models/enums.dart
+++ b/lib/data/models/enums.dart
@@ -4,4 +4,7 @@ enum Role { learner, parent, teacher, admin, anonymous }
 
 enum Translation { kjv, shona }
 
-enum Testament { old, new }
+enum Testament {
+  old,
+  newTestament,
+}

--- a/lib/features/bible/bible_screen.dart
+++ b/lib/features/bible/bible_screen.dart
@@ -463,7 +463,8 @@ class _PassageSelectorSheet extends HookWidget {
       <Object?>[books],
     );
     final newTestamentBooks = useMemoized(
-      () => books.where((book) => book.testament == Testament.new).toList(),
+      () =>
+          books.where((book) => book.testament == Testament.newTestament).toList(),
       <Object?>[books],
     );
 


### PR DESCRIPTION
## Summary
- rename the Testament enum value from `new` to `newTestament` to avoid conflict with generative constructor tear-offs
- update the BibleBook model and Bible screen filters to use the renamed enum value

## Testing
- flutter test *(fails: flutter is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ebfb8a36cc8320809327d952f29f93