### PR TITLE
Enhance Sunday School overview and verse previews

### DIFF
--- a/lib/data/drift/app_database.dart
+++ b/lib/data/drift/app_database.dart
@@ -40,15 +40,22 @@ class AppDatabase {
         if (decoded is! List) {
           return <Lesson>[];
         }
-        final entries = decoded.whereType<Map<String, dynamic>>();
-        return entries.map(_mapBeginnersLesson).toList();
+        final entries = decoded.whereType<Map<String, dynamic>>().toList();
+        return <Lesson>[
+          for (var index = 0; index < entries.length; index++)
+            _mapBeginnersLesson(entries[index], index),
+        ];
       case Track.primaryPals:
         if (decoded is! Map<String, dynamic>) {
           return <Lesson>[];
         }
         final entries = (decoded['primary_pals_lessons'] as List<dynamic>? ?? <dynamic>[])
-            .whereType<Map<String, dynamic>>();
-        return entries.map(_mapPrimaryPalsLesson).toList();
+            .whereType<Map<String, dynamic>>()
+            .toList();
+        return <Lesson>[
+          for (var index = 0; index < entries.length; index++)
+            _mapPrimaryPalsLesson(entries[index], index),
+        ];
       case Track.answer:
         // Answer lessons are not yet available in the local dataset.
         return <Lesson>[];
@@ -56,8 +63,11 @@ class AppDatabase {
         if (decoded is! List) {
           return <Lesson>[];
         }
-        final entries = decoded.whereType<Map<String, dynamic>>();
-        return entries.map(_mapSearchLesson).toList();
+        final entries = decoded.whereType<Map<String, dynamic>>().toList();
+        return <Lesson>[
+          for (var index = 0; index < entries.length; index++)
+            _mapSearchLesson(entries[index], index),
+        ];
       case Track.discovery:
       case Track.daybreak:
         // Discovery and Daybreak lessons are sourced remotely and are not part of the
@@ -66,7 +76,7 @@ class AppDatabase {
     }
   }
 
-  Lesson _mapBeginnersLesson(Map<String, dynamic> raw) {
+  Lesson _mapBeginnersLesson(Map<String, dynamic> raw, int index) {
     final sections = (raw['lessonSections'] as List<dynamic>? ?? <dynamic>[])
         .whereType<Map<String, dynamic>>()
         .map((section) => <String, dynamic>{
@@ -88,12 +98,12 @@ class AppDatabase {
       title: _coerceString(raw['title'] ?? raw['lessonTitle'], 'Lesson'),
       bibleReferences: _parseBibleReferences(raw['bibleReference']),
       payload: payload,
-      weekIndex: raw['weekIndex'] as int?,
+      weekIndex: (raw['weekIndex'] as int?) ?? index,
       dayIndex: raw['dayIndex'] as int?,
     );
   }
 
-  Lesson _mapPrimaryPalsLesson(Map<String, dynamic> raw) {
+  Lesson _mapPrimaryPalsLesson(Map<String, dynamic> raw, int index) {
     final activities = (raw['activities'] as List<dynamic>? ?? <dynamic>[])
         .whereType<Map<String, dynamic>>()
         .map((activity) => <String, dynamic>{
@@ -130,12 +140,12 @@ class AppDatabase {
       title: _coerceString(raw['title'], 'Lesson'),
       bibleReferences: _parseBibleReferences(raw['bibleReference']),
       payload: payload,
-      weekIndex: raw['weekIndex'] as int?,
+      weekIndex: (raw['weekIndex'] as int?) ?? index,
       dayIndex: raw['dayIndex'] as int?,
     );
   }
 
-  Lesson _mapSearchLesson(Map<String, dynamic> raw) {
+  Lesson _mapSearchLesson(Map<String, dynamic> raw, int index) {
     final sections = (raw['lessonSections'] as List<dynamic>? ?? <dynamic>[])
         .whereType<Map<String, dynamic>>();
 
@@ -171,7 +181,7 @@ class AppDatabase {
       title: _coerceString(raw['title'] ?? raw['lessonTitle'], 'Lesson'),
       bibleReferences: _parseBibleReferences(raw['bibleReference']),
       payload: payload,
-      weekIndex: raw['weekIndex'] as int?,
+      weekIndex: (raw['weekIndex'] as int?) ?? index,
       dayIndex: raw['dayIndex'] as int?,
     );
   }

--- a/lib/data/repositories/lesson_repository.dart
+++ b/lib/data/repositories/lesson_repository.dart
@@ -21,19 +21,24 @@ class LessonRepository {
 
   Future<Lesson?> getCurrentSundayLesson(Track track) async {
     final lessons = await database.getLessonsByTrack(track);
-    final matchingLesson = lessons.firstWhereOrNull(
-      (lesson) => lesson.weekIndex == scheduleService.currentSundayWeekIndex,
+    if (lessons.isEmpty) {
+      return null;
+    }
+
+    final sortedLessons = lessons.toList()
+      ..sort((a, b) => (a.weekIndex ?? 0).compareTo(b.weekIndex ?? 0));
+    final targetWeek = scheduleService.weekIndexForTrack(track);
+
+    final matchingLesson = sortedLessons.firstWhereOrNull(
+      (lesson) => (lesson.weekIndex ?? -1) == targetWeek,
     );
 
     if (matchingLesson != null) {
       return matchingLesson;
     }
 
-    if (lessons.isEmpty) {
-      return null;
-    }
-
-    return lessons.first;
+    return sortedLessons.firstWhereOrNull((lesson) => (lesson.weekIndex ?? 0) > targetWeek) ??
+        sortedLessons.last;
   }
 
   Future<Lesson?> getDiscoveryLesson() async {

--- a/lib/data/services/schedule_service.dart
+++ b/lib/data/services/schedule_service.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
 
@@ -10,14 +12,7 @@ final scheduleServiceProvider = Provider<ScheduleService>((ref) {
 class ScheduleService {
   DateTime get today => DateTime.now();
 
-  int get currentSundayWeekIndex {
-    final now = today;
-    final weekday = now.weekday % DateTime.daysPerWeek;
-    final startOfWeek = now.subtract(Duration(days: weekday));
-    final startOfYear = DateTime(now.year, 1, 1);
-    final diff = startOfWeek.difference(startOfYear).inDays;
-    return diff ~/ DateTime.daysPerWeek;
-  }
+  int get currentSundayWeekIndex => weekIndexForTrack(Track.beginners);
 
   int get discoveryWeekIndex {
     final now = today;
@@ -31,4 +26,29 @@ class ScheduleService {
   int get daybreakIndex => int.parse(DateFormat('yyyyDDD').format(today));
 
   Track trackForRole(Track preferred) => preferred;
+
+  int weekIndexForTrack(Track track) {
+    switch (track) {
+      case Track.search:
+      case Track.primaryPals:
+        return _weekIndexFromAnchor(DateTime(2024, 9, 1));
+      default:
+        final anchor = DateTime(today.year, 1, 1);
+        return _weekIndexFromAnchor(anchor);
+    }
+  }
+
+  int _weekIndexFromAnchor(DateTime anchor) {
+    final startOfCurrentWeek = _startOfWeek(today);
+    final startOfAnchorWeek = _startOfWeek(anchor);
+    final diffDays = startOfCurrentWeek.difference(startOfAnchorWeek).inDays;
+    final weeks = diffDays ~/ DateTime.daysPerWeek;
+    return max(0, weeks);
+  }
+
+  DateTime _startOfWeek(DateTime date) {
+    final normalized = DateTime(date.year, date.month, date.day);
+    final daysFromMonday = (normalized.weekday + 6) % DateTime.daysPerWeek;
+    return normalized.subtract(Duration(days: daysFromMonday));
+  }
 }

--- a/lib/features/sunday_school/all_lessons/sunday_school_all_lessons_screen.dart
+++ b/lib/features/sunday_school/all_lessons/sunday_school_all_lessons_screen.dart
@@ -286,9 +286,10 @@ class _LessonCard extends StatelessWidget {
     final summary = _lessonSummary(lesson);
     final topic = _topicForLesson(lesson);
 
+    final lessonNumber = (lesson.weekIndex ?? 0) + 1;
     final chips = <Widget>[
       Chip(label: Text(_trackLabel(lesson.track))),
-      if (lesson.weekIndex != null) Chip(label: Text('Week ${lesson.weekIndex}')),
+      Chip(label: Text('Lesson $lessonNumber')),
       ...lesson.bibleReferences.take(3).map((BibleRef ref) => Chip(label: Text(ref.displayText))),
       if ((lesson.bibleReferences.length) > 3)
         Chip(label: Text('+${lesson.bibleReferences.length - 3} refs')),
@@ -364,7 +365,7 @@ class _LessonCard extends StatelessWidget {
 
 String? _lessonSubtitle(Lesson lesson) {
   final parts = <String>[
-    if (lesson.weekIndex != null) 'Week ${lesson.weekIndex}',
+    'Lesson ${(lesson.weekIndex ?? 0) + 1}',
     if (lesson.bibleReferences.isNotEmpty)
       lesson.bibleReferences.map((ref) => ref.displayText).join(' • '),
   ].where((element) => element.isNotEmpty).toList();

--- a/lib/features/sunday_school/beginners/beginners_lesson_view.dart
+++ b/lib/features/sunday_school/beginners/beginners_lesson_view.dart
@@ -2,57 +2,156 @@ import 'package:flutter/material.dart';
 
 import '../../../data/models/lesson.dart';
 
-class BeginnersLessonView extends StatelessWidget {
+class BeginnersLessonView extends StatefulWidget {
   const BeginnersLessonView({required this.lesson, super.key});
 
   final Lesson lesson;
 
   @override
+  State<BeginnersLessonView> createState() => _BeginnersLessonViewState();
+}
+
+class _BeginnersLessonViewState extends State<BeginnersLessonView> {
+  late final PageController _controller;
+  int _index = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = PageController();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final sections = (lesson.payload['sections'] as List<dynamic>? ?? <dynamic>[])
+    final sections = (widget.lesson.payload['sections'] as List<dynamic>? ?? <dynamic>[])
         .map((dynamic e) => e as Map<String, dynamic>)
         .toList();
 
-    return PageView.builder(
-      itemCount: sections.length,
-      itemBuilder: (BuildContext context, int index) {
-        final section = sections[index];
-        final type = section['sectionType'] as String? ?? 'text';
-        return Padding(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Text(
-                section['sectionTitle'] as String? ?? 'Story moment',
-                style: Theme.of(context).textTheme.headlineSmall,
-              ),
-              const SizedBox(height: 16),
-              Expanded(
-                child: Card(
-                  clipBehavior: Clip.antiAlias,
-                  child: Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: Text(
-                      section['sectionContent'] as String? ?? 'Content coming soon.',
-                      textScaler: TextScaler.linear(1.2),
+    return Column(
+      children: <Widget>[
+        Expanded(
+          child: PageView.builder(
+            controller: _controller,
+            itemCount: sections.length,
+            onPageChanged: (value) => setState(() => _index = value),
+            itemBuilder: (BuildContext context, int index) {
+              final section = sections[index];
+              final type = (section['sectionType'] as String? ?? 'text').toLowerCase();
+              final title = section['sectionTitle'] as String? ?? 'Story moment';
+              final content = section['sectionContent'] as String? ?? 'Content coming soon.';
+              final imagePath = section['imagePath'] as String?;
+
+              return Padding(
+                padding: const EdgeInsets.fromLTRB(24, 24, 24, 12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(title, style: Theme.of(context).textTheme.titleLarge),
+                    const SizedBox(height: 16),
+                    Expanded(
+                      child: Card(
+                        clipBehavior: Clip.antiAlias,
+                        child: SingleChildScrollView(
+                          padding: const EdgeInsets.all(24),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: <Widget>[
+                              if (imagePath != null)
+                                Padding(
+                                  padding: const EdgeInsets.only(bottom: 16),
+                                  child: ClipRRect(
+                                    borderRadius: BorderRadius.circular(16),
+                                    child: Image.asset(imagePath, fit: BoxFit.cover),
+                                  ),
+                                ),
+                              Text(
+                                content,
+                                style: Theme.of(context).textTheme.bodyLarge,
+                                textScaler: const TextScaler.linear(1.15),
+                              ),
+                              if (type == 'question') ...<Widget>[
+                                const SizedBox(height: 16),
+                                Container(
+                                  decoration: BoxDecoration(
+                                    color: Theme.of(context).colorScheme.primary.withOpacity(0.08),
+                                    borderRadius: BorderRadius.circular(12),
+                                  ),
+                                  padding: const EdgeInsets.all(16),
+                                  child: Row(
+                                    children: <Widget>[
+                                      Icon(Icons.question_answer,
+                                          color: Theme.of(context).colorScheme.primary),
+                                      const SizedBox(width: 12),
+                                      Expanded(
+                                        child: Text(
+                                          'Ask this question to spark a conversation!',
+                                          style: Theme.of(context).textTheme.bodyMedium,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ],
+                            ],
+                          ),
+                        ),
+                      ),
                     ),
-                  ),
+                  ],
                 ),
+              );
+            },
+          ),
+        ),
+        if (sections.length > 1)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+            child: Text(
+              'Section ${_index + 1} of ${sections.length}',
+              style: Theme.of(context).textTheme.labelMedium,
+            ),
+          ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: <Widget>[
+              OutlinedButton.icon(
+                onPressed: sections.length <= 1
+                    ? null
+                    : () => _goRelative(sections.length, -1),
+                icon: const Icon(Icons.arrow_back_ios_new),
+                label: const Text('Previous'),
               ),
-              if (type == 'question')
-                Padding(
-                  padding: const EdgeInsets.only(top: 16),
-                  child: ElevatedButton.icon(
-                    onPressed: () {},
-                    icon: const Icon(Icons.record_voice_over),
-                    label: const Text('Read aloud'),
-                  ),
-                ),
+              OutlinedButton.icon(
+                onPressed:
+                    sections.length <= 1 ? null : () => _goRelative(sections.length, 1),
+                icon: const Icon(Icons.arrow_forward_ios),
+                label: const Text('Next'),
+              ),
             ],
           ),
-        );
-      },
+        ),
+      ],
+    );
+  }
+
+  void _goRelative(int length, int delta) {
+    if (length <= 1) {
+      return;
+    }
+    final target = (_index + delta) % length;
+    final normalized = target < 0 ? target + length : target;
+    _controller.animateToPage(
+      normalized,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
     );
   }
 }

--- a/lib/features/sunday_school/primary_pals/primary_pals_lesson_view.dart
+++ b/lib/features/sunday_school/primary_pals/primary_pals_lesson_view.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
 import '../../../data/models/lesson.dart';
@@ -24,14 +25,48 @@ class _PrimaryPalsLessonViewState extends State<PrimaryPalsLessonView> {
         .toList();
 
     final pages = <Widget>[
-      _StorySection(story: story),
-      ...activities.map((activity) => ActivityMatching(data: Map<String, String>.from(activity['data'] as Map? ?? {}))),
-      _ParentsCorner(payload: payload),
+      KeyedSubtree(key: const ValueKey('story'), child: _StorySection(story: story)),
+      ...activities.mapIndexed(
+        (index, activity) => KeyedSubtree(
+          key: ValueKey('activity_$index'),
+          child: ActivityMatching(
+            data: Map<String, String>.from(activity['data'] as Map? ?? {}),
+          ),
+        ),
+      ),
+      KeyedSubtree(key: const ValueKey('parents'), child: _ParentsCorner(payload: payload)),
     ];
+
+    final labels = <String>[
+      'Story adventure',
+      ...activities.map((activity) => activity['title'] as String? ?? 'Activity'),
+      'Parent connection',
+    ];
+    final total = pages.length;
+    if (total == 0) {
+      return const Center(child: Text('Lesson content will appear here soon.'));
+    }
+    final currentIndex = _index % total;
+    final currentLabel = labels[currentIndex];
 
     return Column(
       children: <Widget>[
-        Expanded(child: pages[_index % pages.length]),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(24, 24, 24, 8),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              currentLabel,
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
+            ),
+          ),
+        ),
+        Expanded(
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 250),
+            child: pages[currentIndex],
+          ),
+        ),
         Padding(
           padding: const EdgeInsets.all(16),
           child: Row(
@@ -40,7 +75,7 @@ class _PrimaryPalsLessonViewState extends State<PrimaryPalsLessonView> {
               ElevatedButton(
                 onPressed: () {
                   setState(() {
-                    _index = (_index - 1) % pages.length;
+                    _index = (_index - 1) % total;
                   });
                 },
                 child: const Text('Back'),
@@ -48,7 +83,7 @@ class _PrimaryPalsLessonViewState extends State<PrimaryPalsLessonView> {
               ElevatedButton(
                 onPressed: () {
                   setState(() {
-                    _index = (_index + 1) % pages.length;
+                    _index = (_index + 1) % total;
                   });
                 },
                 child: const Text('Next'),
@@ -62,30 +97,44 @@ class _PrimaryPalsLessonViewState extends State<PrimaryPalsLessonView> {
 }
 
 class _StorySection extends StatelessWidget {
-  const _StorySection({required this.story});
+  const _StorySection({required this.story, super.key});
 
   final List<String> story;
 
   @override
   Widget build(BuildContext context) {
-    return ListView.builder(
+    final paragraphs = story.where((paragraph) => paragraph.trim().isNotEmpty).toList();
+    return SingleChildScrollView(
       padding: const EdgeInsets.all(24),
-      itemCount: story.length,
-      itemBuilder: (BuildContext context, int index) {
-        return Padding(
-          padding: const EdgeInsets.only(bottom: 16),
-          child: Text(
-            story[index],
-            style: Theme.of(context).textTheme.bodyLarge,
+      child: Card(
+        clipBehavior: Clip.antiAlias,
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              for (final paragraph in paragraphs) ...<Widget>[
+                Text(
+                  paragraph,
+                  style: Theme.of(context).textTheme.bodyLarge,
+                ),
+                const SizedBox(height: 16),
+              ],
+              if (paragraphs.isEmpty)
+                Text(
+                  'Story content will be available soon.',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+            ],
           ),
-        );
-      },
+        ),
+      ),
     );
   }
 }
 
 class _ParentsCorner extends StatelessWidget {
-  const _ParentsCorner({required this.payload});
+  const _ParentsCorner({required this.payload, super.key});
 
   final Map<String, dynamic> payload;
 

--- a/lib/features/sunday_school/search/search_lesson_view.dart
+++ b/lib/features/sunday_school/search/search_lesson_view.dart
@@ -44,18 +44,7 @@ class _SearchLessonViewState extends State<SearchLessonView> {
     return ListView(
       padding: const EdgeInsets.all(24),
       children: <Widget>[
-        Text(widget.lesson.title, style: textTheme.headlineSmall),
-        if (widget.lesson.weekIndex != null) ...<Widget>[
-          const SizedBox(height: 4),
-          Text(
-            'Lesson ${widget.lesson.weekIndex}',
-            style: textTheme.titleMedium?.copyWith(
-              color: theme.colorScheme.primary,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ],
-        const SizedBox(height: 24),
+        const SizedBox(height: 12),
         if (keyVerse.isNotEmpty) ...<Widget>[
           _KeyVerseBlock(text: keyVerse),
           const SizedBox(height: 24),

--- a/lib/features/sunday_school/sunday_school_screen.dart
+++ b/lib/features/sunday_school/sunday_school_screen.dart
@@ -1,11 +1,15 @@
-import 'package:afc_studymate/data/models/enums.dart';
-import 'package:afc_studymate/data/models/lesson.dart';
-import 'package:afc_studymate/data/repositories/lesson_repository.dart';
-import 'package:afc_studymate/features/sunday_school/all_lessons/sunday_school_all_lessons_screen.dart';
-import 'package:afc_studymate/features/sunday_school/widgets/sunday_school_lesson_view.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../data/models/bible_ref.dart';
+import '../../data/models/enums.dart';
+import '../../data/models/lesson.dart';
+import '../../data/repositories/lesson_repository.dart';
+import '../../widgets/linked_verse.dart';
+import 'all_lessons/sunday_school_all_lessons_screen.dart';
+import 'all_lessons/sunday_school_lesson_detail_screen.dart';
 
 class SundaySchoolScreen extends HookConsumerWidget {
   const SundaySchoolScreen({super.key});
@@ -14,7 +18,7 @@ class SundaySchoolScreen extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final asyncLesson = ref.watch(_currentLessonProvider);
+    final asyncLessons = ref.watch(_currentLessonsProvider);
 
     void openAllLessons() => context.pushNamed(SundaySchoolAllLessonsScreen.routeName);
 
@@ -30,27 +34,171 @@ class SundaySchoolScreen extends HookConsumerWidget {
         ],
       ),
       body: SafeArea(
-        child: Column(
-          children: <Widget>[
-            Expanded(
-              child: asyncLesson.when(
-                data: (value) {
-                  if (value == null) {
-                    return const Center(child: Text('Your lesson will appear here soon.'));
-                  }
-                  return SundaySchoolLessonView(lesson: value);
-                },
-                loading: () => const Center(child: CircularProgressIndicator()),
-                error: (error, stackTrace) => Center(child: Text('Something went wrong: $error')),
+        child: asyncLessons.when(
+          data: (lessons) {
+            final hasLesson = _sundaySchoolTracks.any((track) => lessons[track] != null);
+            if (!hasLesson) {
+              return const Center(child: Text('Weekly lessons will appear here soon.'));
+            }
+
+            return ListView(
+              padding: const EdgeInsets.fromLTRB(16, 24, 16, 16),
+              children: <Widget>[
+                Text(
+                  'This week\'s Sunday School snapshot',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 16),
+                ..._sundaySchoolTracks.map(
+                  (track) => _LessonPreviewCard(
+                    track: track,
+                    lesson: lessons[track],
+                    onOpen: lessons[track] == null
+                        ? null
+                        : () {
+                            context.pushNamed(
+                              SundaySchoolLessonDetailScreen.routeName,
+                              pathParameters: <String, String>{
+                                'lessonId': lessons[track]!.id,
+                              },
+                            );
+                          },
+                  ),
+                ),
+                const SizedBox(height: 8),
+                FilledButton.icon(
+                  onPressed: openAllLessons,
+                  icon: const Icon(Icons.library_books_outlined),
+                  label: const Text('View all lessons'),
+                  style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(48)),
+                ),
+              ],
+            );
+          },
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (error, stackTrace) => Center(child: Text('Something went wrong: $error')),
+        ),
+      ),
+    );
+  }
+}
+
+const List<Track> _sundaySchoolTracks = <Track>[
+  Track.beginners,
+  Track.primaryPals,
+  Track.search,
+];
+
+final _currentLessonsProvider = FutureProvider<Map<Track, Lesson?>>((ref) async {
+  final repository = ref.read(lessonRepositoryProvider);
+  final entries = await Future.wait(
+    _sundaySchoolTracks.map((track) async {
+      final lesson = await repository.getCurrentSundayLesson(track);
+      return MapEntry(track, lesson);
+    }),
+  );
+  return Map<Track, Lesson?>.fromEntries(entries);
+});
+
+class _LessonPreviewCard extends StatelessWidget {
+  const _LessonPreviewCard({required this.track, this.lesson, this.onOpen});
+
+  final Track track;
+  final Lesson? lesson;
+  final VoidCallback? onOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final titleStyle = theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700);
+    final background = theme.colorScheme.surfaceVariant.withOpacity(0.4);
+
+    if (lesson == null) {
+      return Card(
+        margin: const EdgeInsets.only(bottom: 16),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              _TrackChip(track: track),
+              const SizedBox(height: 12),
+              Text(
+                'We\'re preparing this week\'s lesson.',
+                style: theme.textTheme.bodyMedium,
               ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final lessonNumber = (lesson!.weekIndex ?? 0) + 1;
+    final snippet = _lessonPreviewSnippet(lesson!);
+    final references = lesson!.bibleReferences;
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 16),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                CircleAvatar(
+                  radius: 24,
+                  backgroundColor: background,
+                  child: Icon(_trackIcon(track), color: theme.colorScheme.primary),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      _TrackChip(track: track),
+                      const SizedBox(height: 8),
+                      Text('Lesson $lessonNumber', style: theme.textTheme.labelLarge),
+                      const SizedBox(height: 4),
+                      Text(lesson!.title, style: titleStyle),
+                    ],
+                  ),
+                ),
+              ],
             ),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+            if (references.isNotEmpty) ...<Widget>[
+              const SizedBox(height: 12),
+              Wrap(
+                spacing: 12,
+                runSpacing: 12,
+                children: references
+                    .map(
+                      (BibleRef ref) => Chip(
+                        label: LinkedVerse(
+                          reference: ref,
+                          style: theme.textTheme.bodySmall,
+                        ),
+                        padding: const EdgeInsets.symmetric(horizontal: 8),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ],
+            if (snippet.isNotEmpty) ...<Widget>[
+              const SizedBox(height: 12),
+              Text(
+                snippet,
+                style: theme.textTheme.bodyMedium,
+              ),
+            ],
+            const SizedBox(height: 16),
+            Align(
+              alignment: Alignment.centerRight,
               child: FilledButton.icon(
-                onPressed: openAllLessons,
-                icon: const Icon(Icons.library_books_outlined),
-                label: const Text('View all lessons'),
-                style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(48)),
+                onPressed: onOpen,
+                icon: const Icon(Icons.menu_book_rounded),
+                label: const Text('Open full lesson'),
               ),
             ),
           ],
@@ -60,7 +208,85 @@ class SundaySchoolScreen extends HookConsumerWidget {
   }
 }
 
-final _currentLessonProvider = FutureProvider<Lesson?>((ref) {
-  final repository = ref.read(lessonRepositoryProvider);
-  return repository.getCurrentSundayLesson(Track.beginners);
-});
+class _TrackChip extends StatelessWidget {
+  const _TrackChip({required this.track});
+
+  final Track track;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primary.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: Text(
+        _trackLabel(track),
+        style: theme.textTheme.labelSmall?.copyWith(color: theme.colorScheme.primary),
+      ),
+    );
+  }
+}
+
+String _lessonPreviewSnippet(Lesson lesson) {
+  final payload = lesson.payload;
+  String? raw;
+  switch (lesson.track) {
+    case Track.beginners:
+      final sections = (payload['sections'] as List<dynamic>? ?? <dynamic>[])
+          .whereType<Map<String, dynamic>>();
+      raw = sections
+          .map((section) => section['sectionContent'] as String? ?? '')
+          .firstWhereOrNull((value) => value.trim().isNotEmpty);
+      break;
+    case Track.primaryPals:
+      final story = (payload['story'] as List<dynamic>? ?? <dynamic>[]).cast<String>();
+      raw = story.firstWhereOrNull((paragraph) => paragraph.trim().isNotEmpty);
+      break;
+    case Track.search:
+      final exposition = (payload['exposition'] as List<dynamic>? ?? <dynamic>[]).cast<String>();
+      raw = exposition.firstWhereOrNull((paragraph) => paragraph.trim().isNotEmpty);
+      break;
+    default:
+      raw = null;
+      break;
+  }
+
+  if (raw == null) {
+    return '';
+  }
+
+  final collapsed = raw.replaceAll(RegExp(r'\s+'), ' ').trim();
+  if (collapsed.length <= 220) {
+    return collapsed;
+  }
+  return '${collapsed.substring(0, 217).trimRight()}…';
+}
+
+String _trackLabel(Track track) {
+  switch (track) {
+    case Track.beginners:
+      return 'Beginners';
+    case Track.primaryPals:
+      return 'Primary Pals';
+    case Track.search:
+      return 'Search';
+    default:
+      return track.name;
+  }
+}
+
+IconData _trackIcon(Track track) {
+  switch (track) {
+    case Track.beginners:
+      return Icons.auto_awesome;
+    case Track.primaryPals:
+      return Icons.palette_outlined;
+    case Track.search:
+      return Icons.travel_explore_outlined;
+    default:
+      return Icons.menu_book_outlined;
+  }
+}

--- a/lib/features/sunday_school/widgets/sunday_school_lesson_view.dart
+++ b/lib/features/sunday_school/widgets/sunday_school_lesson_view.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 
+import '../../../data/models/bible_ref.dart';
 import '../../../data/models/enums.dart';
 import '../../../data/models/lesson.dart';
+import '../../../widgets/linked_verse.dart';
 import '../beginners/beginners_lesson_view.dart';
 import '../primary_pals/primary_pals_lesson_view.dart';
 import '../search/search_lesson_view.dart';
@@ -13,25 +15,132 @@ class SundaySchoolLessonView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    switch (lesson.track) {
-      case Track.beginners:
-        return BeginnersLessonView(lesson: lesson);
-      case Track.primaryPals:
-        return PrimaryPalsLessonView(lesson: lesson);
-      case Track.search:
-        return SearchLessonView(lesson: lesson);
-      default:
-        return Padding(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+    final content = switch (lesson.track) {
+      Track.beginners => BeginnersLessonView(lesson: lesson),
+      Track.primaryPals => PrimaryPalsLessonView(lesson: lesson),
+      Track.search => SearchLessonView(lesson: lesson),
+      _ => _ComingSoonPlaceholder(lesson: lesson),
+    };
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        _LessonHeader(lesson: lesson),
+        const Divider(height: 1),
+        Expanded(child: content),
+      ],
+    );
+  }
+}
+
+class _LessonHeader extends StatelessWidget {
+  const _LessonHeader({required this.lesson});
+
+  final Lesson lesson;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final lessonNumber = (lesson.weekIndex ?? 0) + 1;
+    final references = lesson.bibleReferences;
+
+    return Container(
+      color: theme.colorScheme.surfaceVariant.withOpacity(0.25),
+      padding: const EdgeInsets.fromLTRB(24, 24, 24, 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Wrap(
+            spacing: 12,
+            runSpacing: 12,
             children: <Widget>[
-              Text(lesson.title, style: Theme.of(context).textTheme.headlineSmall),
-              const SizedBox(height: 16),
-              const Text('Lesson format coming soon.'),
+              _TrackPill(track: lesson.track),
+              Chip(label: Text('Lesson $lessonNumber')),
             ],
           ),
-        );
-    }
+          const SizedBox(height: 12),
+          Text(
+            lesson.title,
+            style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w700),
+          ),
+          if (references.isNotEmpty) ...<Widget>[
+            const SizedBox(height: 16),
+            Text('Scripture focus', style: theme.textTheme.titleSmall),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: references
+                  .map(
+                    (BibleRef ref) => LinkedVerse(
+                      reference: ref,
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                  )
+                  .toList(),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _TrackPill extends StatelessWidget {
+  const _TrackPill({required this.track});
+
+  final Track track;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(999),
+        color: theme.colorScheme.primary.withOpacity(0.12),
+      ),
+      child: Text(
+        _trackLabel(track),
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.primary,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class _ComingSoonPlaceholder extends StatelessWidget {
+  const _ComingSoonPlaceholder({required this.lesson});
+
+  final Lesson lesson;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(lesson.title, style: Theme.of(context).textTheme.headlineSmall),
+          const SizedBox(height: 16),
+          const Text('Lesson format coming soon.'),
+        ],
+      ),
+    );
+  }
+}
+
+String _trackLabel(Track track) {
+  switch (track) {
+    case Track.beginners:
+      return 'Beginners';
+    case Track.primaryPals:
+      return 'Primary Pals';
+    case Track.search:
+      return 'Search';
+    default:
+      return track.name;
   }
 }

--- a/lib/widgets/linked_verse.dart
+++ b/lib/widgets/linked_verse.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../data/models/bible_ref.dart';
+import '../data/models/enums.dart';
+import '../data/models/verse.dart';
+import '../data/services/bible_service.dart';
 import '../features/bible/bible_screen.dart';
 
-class LinkedVerse extends StatelessWidget {
+class LinkedVerse extends HookConsumerWidget {
   const LinkedVerse({
     required this.reference,
     this.label,
@@ -17,7 +22,7 @@ class LinkedVerse extends StatelessWidget {
   final TextStyle? style;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final effectiveStyle = (style ?? theme.textTheme.bodyMedium)?.copyWith(
       color: theme.colorScheme.primary,
@@ -35,18 +40,162 @@ class LinkedVerse extends StatelessWidget {
   }
 
   void _handleTap(BuildContext context) {
-    final queryParameters = <String, String>{
-      'book': reference.book,
-      'chapter': reference.chapter.toString(),
-    };
-    final verse = reference.verseStart;
-    if (verse != null) {
-      queryParameters['verse'] = verse.toString();
+    final rootContext = context;
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (BuildContext sheetContext) {
+        return _VersePreviewSheet(
+          reference: reference,
+          onOpenFullText: () {
+            Navigator.of(sheetContext).pop();
+            final queryParameters = <String, String>{
+              'book': reference.book,
+              'chapter': reference.chapter.toString(),
+            };
+            final verse = reference.verseStart;
+            if (verse != null) {
+              queryParameters['verse'] = verse.toString();
+            }
+            rootContext.goNamed(
+              BibleScreen.routeName,
+              queryParameters: queryParameters,
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+class _VersePreviewSheet extends HookConsumerWidget {
+  const _VersePreviewSheet({required this.reference, required this.onOpenFullText});
+
+  final BibleRef reference;
+  final VoidCallback onOpenFullText;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final bibleService = ref.read(bibleServiceProvider);
+    const translation = Translation.kjv;
+
+    final passageFuture = useMemoized(
+      () => bibleService.getPassage(reference, translation),
+      <Object?>[reference, translation],
+    );
+    final passageSnapshot = useFuture(passageFuture);
+
+    Widget content;
+    if (passageSnapshot.hasError) {
+      content = Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 24),
+          child: Text('Unable to preview passage: ${passageSnapshot.error}'),
+        ),
+      );
+    } else if (!passageSnapshot.hasData) {
+      content = const Center(child: Padding(padding: EdgeInsets.all(24), child: CircularProgressIndicator()));
+    } else {
+      final verses = passageSnapshot.data ?? <Verse>[];
+      if (verses.isEmpty) {
+        content = const Center(
+          child: Padding(
+            padding: EdgeInsets.symmetric(vertical: 24),
+            child: Text('Passage not available in this translation.'),
+          ),
+        );
+      } else {
+        content = SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: verses.map((verse) => _VerseLine(verse: verse)).toList(),
+          ),
+        );
+      }
     }
 
-    context.goNamed(
-      BibleScreen.routeName,
-      queryParameters: queryParameters,
+    final mediaQuery = MediaQuery.of(context);
+    final maxHeight = mediaQuery.size.height * 0.5;
+
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 24,
+        right: 24,
+        top: 16,
+        bottom: 24 + mediaQuery.viewPadding.bottom,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Center(
+            child: Container(
+              width: 48,
+              height: 4,
+              decoration: BoxDecoration(
+                color: theme.colorScheme.outlineVariant,
+                borderRadius: BorderRadius.circular(999),
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(reference.displayText, style: theme.textTheme.titleLarge),
+          const SizedBox(height: 4),
+          Text('King James Version', style: theme.textTheme.bodySmall),
+          const SizedBox(height: 16),
+          ConstrainedBox(
+            constraints: BoxConstraints(maxHeight: maxHeight),
+            child: content,
+          ),
+          const SizedBox(height: 20),
+          Align(
+            alignment: Alignment.centerRight,
+            child: FilledButton.icon(
+              onPressed: onOpenFullText,
+              icon: const Icon(Icons.open_in_new),
+              label: const Text('Go to full text'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _VerseLine extends StatelessWidget {
+  const _VerseLine({required this.verse});
+
+  final Verse verse;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textStyle = theme.textTheme.bodyLarge ?? const TextStyle(fontSize: 16);
+    final verseNumberStyle = textStyle.copyWith(
+      fontWeight: FontWeight.w600,
+      color: theme.colorScheme.primary,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: SelectableText.rich(
+        TextSpan(
+          children: <InlineSpan>[
+            WidgetSpan(
+              alignment: PlaceholderAlignment.aboveBaseline,
+              baseline: TextBaseline.alphabetic,
+              child: Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: Text('${verse.verse}', style: verseNumberStyle),
+              ),
+            ),
+            TextSpan(text: verse.text, style: textStyle),
+          ],
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- add a modal preview for linked scripture references with a shortcut to the full Bible screen
- show the current week’s lessons for all Sunday School tracks with lesson numbers and scripture chips
- align lesson scheduling and lesson views around weekly numbering, adding polished headers and navigation for each class type

## Testing
- not run (Flutter CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68ece260b660832088e2612c4a7b3bb8